### PR TITLE
Feature/user spec changes

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -102,40 +102,40 @@ schemas:
         "items": {
           "properties": {
                "id": {
-                 "required": true,
+                 "required": false,
                  "type": "integer"
                },
               "employee_id": {
-                "required": true,
+                "required": false,
                 "type": "string"
               },
               "first_name": {
-                "required": true,
+                "required": false,
                 "type": "string"
               },
               "last_name": {
-                "required": true,
+                "required": false,
                 "type": "string"
               },
               "display_name": {
-                "required": true,
+                "required": false,
                 "type": "string"
               },
               "username": {
-                "required": true,
+                "required": false,
                 "type": "string"
               },
               "email": {
-                "required": true,
+                "required": false,
                 "type": "string"
               },
               "active": {
-                "required": true,
+                "required": false,
                 "type": "string",
                 "enum": ["yes", "no"]
               },
               "locked": {
-                "required": true,
+                "required": false,
                 "type": "string",
                 "enum": ["yes", "no"]
               }

--- a/api.raml
+++ b/api.raml
@@ -55,6 +55,10 @@ schemas:
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "properties": {
+            "id": {
+              "required": true,
+              "type": "integer"
+            },
             "employee_id": {
               "required": true,
               "type": "string"
@@ -97,6 +101,10 @@ schemas:
         "$schema": "http://json-schema.org/draft-03/schema",
         "items": {
           "properties": {
+               "id": {
+                 "required": true,
+                 "type": "integer"
+               },
               "employee_id": {
                 "required": true,
                 "type": "string"
@@ -195,6 +203,7 @@ schemas:
             schema: User
             example: |
               {
+                "id": "1",
                 "employee_id": "12345",
                 "first_name": "John",
                 "last_name": "Smith",
@@ -242,6 +251,7 @@ schemas:
               example: |
                 [
                     {
+                      "id": "1",
                       "employee_id": "12345",
                       "first_name": "John",
                       "last_name": "Smith",
@@ -252,6 +262,7 @@ schemas:
                       "locked": "no"
                     },
                     {
+                      "id": "2",
                       "employee_id": "54321",
                       "first_name": "Jane",
                       "last_name": "Smith",
@@ -303,19 +314,19 @@ schemas:
                 "status": 500
               }
 
-  /{employee_id}:
+  /{id}:
     get:
       description: Get information about a specific user.
       responses:
         200:
           description:
-            The corresponding user record (matching on the `employee_id` URL
-            parameter).
+            The corresponding user record (matching on the `id` URL parameter).
           body:
             application/json:
               schema: User
               example: |
                 {
+                  "id": "1",
                   "employee_id": "12345",
                   "first_name": "John",
                   "last_name": "Smith",
@@ -326,7 +337,7 @@ schemas:
                   "locked": "no"
                 }
         204:
-          description: No user record was found with that `employee_id`.
+          description: No user record was found with that `id`.
     put:
       description: Update a user record.
       body:
@@ -389,8 +400,20 @@ schemas:
         responses:
           200:
             description: |
-              The password for the user with that `employee_id` was
-              successfully updated.
+              The password for the user with that `id` was successfully updated.
+          404:
+            description: |
+              No record was found for the given `id`.
+            body:
+              application/json:
+                schema: Error
+                example: |
+                  {
+                    "name": "Not found",
+                    "message": "",
+                    "code": 0,
+                    "status": 404
+                  }
           422:
             description: |
               The given password does not meet some requirement (such as if an

--- a/api.raml
+++ b/api.raml
@@ -231,7 +231,7 @@ schemas:
                 "status": 500
               }
 
-/user:
+/users:
   get:
     description: Get a list of the existing users.
     responses:

--- a/api.raml
+++ b/api.raml
@@ -243,6 +243,13 @@ schemas:
 /users:
   get:
     description: Get a list of the existing users.
+    queryParameters:
+      fields:
+        description: A comma-delimited list of fields to include for each user.
+        required: false
+        type: string
+        default: "fields=employee_id,first_name,last_name,display_name,username,email,active,locked"
+        example: "fields=employee_id,active"
     responses:
       200:
           body:

--- a/api.raml
+++ b/api.raml
@@ -98,36 +98,36 @@ schemas:
         "items": {
           "properties": {
               "employee_id": {
-                "required": false,
+                "required": true,
                 "type": "string"
               },
               "first_name": {
-                "required": false,
+                "required": true,
                 "type": "string"
               },
               "last_name": {
-                "required": false,
+                "required": true,
                 "type": "string"
               },
               "display_name": {
-                "required": false,
+                "required": true,
                 "type": "string"
               },
               "username": {
-                "required": false,
+                "required": true,
                 "type": "string"
               },
               "email": {
-                "required": false,
+                "required": true,
                 "type": "string"
               },
               "active": {
-                "required": false,
+                "required": true,
                 "type": "string",
                 "enum": ["yes", "no"]
               },
               "locked": {
-                "required": false,
+                "required": true,
                 "type": "string",
                 "enum": ["yes", "no"]
               }
@@ -234,29 +234,34 @@ schemas:
 /user:
   get:
     description: Get a list of the existing users.
-    queryParameters:
-      fields:
-        description: A comma-delimited list of fields to include for each user.
-        required: false
-        type: string
-        default: "fields=employee_id,active"
-        example: "fields=employee_id"
-      expand:
-        description: |
-          A comma-delimited list of extra fields to include for each user.
-        required: false
-        type: string
-        example: "fields=first_name,last_name,display_name,username,email,locked"
     responses:
       200:
-        body:
-          application/json:
-            schema: UserList
-            example: |
-              [
-                {"employee_id": "11111", "active": "yes"},
-                {"employee_id": "22222", "active": "no"}
-              ]
+          body:
+            application/json:
+              schema: UserList
+              example: |
+                [
+                    {
+                      "employee_id": "12345",
+                      "first_name": "John",
+                      "last_name": "Smith",
+                      "display_name": "John Smith",
+                      "username": "john_smith",
+                      "email": "john_smith@example.com",
+                      "active": "yes",
+                      "locked": "no"
+                    },
+                    {
+                      "employee_id": "54321",
+                      "first_name": "Jane",
+                      "last_name": "Smith",
+                      "display_name": "Jane Smith",
+                      "username": "jane_smith",
+                      "email": "jane_smith@example.com",
+                      "active": "yes",
+                      "locked": "no"
+                    }
+                ]
   post:
     description: Create a new user record.
     body:

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -10,6 +10,8 @@ use yii\helpers\ArrayHelper;
 
 class User extends UserBase
 {
+    const SCENARIO_NEW_USER        = 'new_user';
+    const SCENARIO_UPDATE_USER     = 'update_user';
     const SCENARIO_UPDATE_PASSWORD = 'update_password';
     const SCENARIO_AUTHENTICATE    = 'authenticate';
 
@@ -19,8 +21,18 @@ class User extends UserBase
     {
         $scenarios = parent::scenarios();
 
-        $scenarios[self::SCENARIO_DEFAULT] = [
+        $scenarios[self::SCENARIO_NEW_USER] = [
             'employee_id',
+            'first_name',
+            'last_name',
+            'display_name',
+            'username',
+            'email',
+            'active',
+            'locked',
+        ];
+
+        $scenarios[self::SCENARIO_UPDATE_USER] = [
             'first_name',
             'last_name',
             'display_name',
@@ -33,6 +45,8 @@ class User extends UserBase
         $scenarios[self::SCENARIO_UPDATE_PASSWORD] = ['password'];
 
         $scenarios[self::SCENARIO_AUTHENTICATE] = ['username', 'password', '!active', '!locked'];
+
+        $scenarios[self::SCENARIO_DEFAULT] = $scenarios[self::SCENARIO_NEW_USER];
 
         return $scenarios;
     }
@@ -118,6 +132,7 @@ class User extends UserBase
     private function updateOnSync(): \Closure
     {
         return function () {
+            //TODO: make explicit for NEW and UPDATE_USER only.
             return $this->scenario === self::SCENARIO_DEFAULT ? MySqlDateTime::now()
                                                               : $this->last_synced_utc;
         };

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -129,6 +129,7 @@ class User extends UserBase
     public function fields(): array
     {
         return [
+            'id',
             'employee_id',
             'first_name',
             'last_name',

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -21,6 +21,8 @@ class User extends UserBase
     {
         $scenarios = parent::scenarios();
 
+        $scenarios[self::SCENARIO_DEFAULT] = null;
+
         $scenarios[self::SCENARIO_NEW_USER] = [
             'employee_id',
             'first_name',
@@ -45,8 +47,6 @@ class User extends UserBase
         $scenarios[self::SCENARIO_UPDATE_PASSWORD] = ['password'];
 
         $scenarios[self::SCENARIO_AUTHENTICATE] = ['username', 'password', '!active', '!locked'];
-
-        $scenarios[self::SCENARIO_DEFAULT] = $scenarios[self::SCENARIO_NEW_USER];
 
         return $scenarios;
     }
@@ -132,10 +132,14 @@ class User extends UserBase
     private function updateOnSync(): \Closure
     {
         return function () {
-            //TODO: make explicit for NEW and UPDATE_USER only.
-            return $this->scenario === self::SCENARIO_DEFAULT ? MySqlDateTime::now()
-                                                              : $this->last_synced_utc;
+            return $this->isSync($this->scenario) ? MySqlDateTime::now()
+                                                  : $this->last_synced_utc;
         };
+    }
+
+    private function isSync($scenario): bool
+    {
+        return in_array($scenario, [self::SCENARIO_NEW_USER, self::SCENARIO_UPDATE_USER]);
     }
 
     /**

--- a/application/features/authentication.feature
+++ b/application/features/authentication.feature
@@ -14,7 +14,7 @@ Feature: Authentication
         | display_name | Shep Clark            |
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
-      And I request "/user" be created
+      And I request "/users" be created
       And a record exists with an employee_id of "123"
       And the user has a password of "govols!!!"
 

--- a/application/features/bootstrap/FeatureContext.php
+++ b/application/features/bootstrap/FeatureContext.php
@@ -56,6 +56,7 @@ class FeatureContext extends YiiContext
         $this->now = MySqlDateTime::now();
 
         $this->resBody = $this->extractBody($this->response);
+
     }
 
     private function buildClient(): Client
@@ -348,5 +349,13 @@ class FeatureContext extends YiiContext
         $this->userFromDb->$property = $value;
 
         Assert::true($this->userFromDb->save());
+    }
+
+    /**
+     * @Given /^I should receive (\d+) users$/
+     */
+    public function iShouldReceiveUsers($numOfUsers)
+    {
+        Assert::count($this->resBody, $numOfUsers);
     }
 }

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -327,3 +327,10 @@ Feature: User
     When I request "/user" be retrieved
     Then the response status code should be 200
       And I should receive 2 users
+
+    #TODO: get a user with/without a match
+    #TODO: get a user with both an alphanumeric and numeric employee_id
+    #TODO: get a user with invalid employee_id
+    #TODO: act upon a user/{id} in an undefined authz and !authz
+    #TODO: review previous test for additional ideas
+

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -18,6 +18,7 @@ Feature: User
     Then the response status code should be 200
       And the following data is returned:
         | property     | value                 |
+#TODO: need to figure this check out.        | id           | ???                   |
         | employee_id  | 123                   |
         | first_name   | Shep                  |
         | last_name    | Clark                 |
@@ -28,7 +29,6 @@ Feature: User
         | locked       | no                    |
       And the following data is not returned:
         | property      |
-        | id            |
         | password_hash |
       And a record exists with an employee_id of "123"
       And the following data should be stored:

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -116,7 +116,6 @@ Feature: User
 
     Examples:
       | action    |
-      | retrieved |
       | updated   |
       | deleted   |
       | patched   |
@@ -303,3 +302,28 @@ Feature: User
       And I request "/user" be created
     Then the response status code should be 422
       And the property message should contain "Email"
+
+  Scenario: Retrieve all users
+    Given the requester is authorized
+      And the user store is empty
+      And I provide the following valid data:
+        | property     | value                 |
+        | employee_id  | 123                   |
+        | first_name   | Shep                  |
+        | last_name    | Clark                 |
+        | display_name | Shep Clark            |
+        | username     | shep_clark            |
+        | email        | shep_clark@example.org|
+      And I request "/user" be created
+      And I provide the following valid data:
+        | property     | value                  |
+        | employee_id  | 234                    |
+        | first_name   | Shepp                  |
+        | last_name    | Clark                  |
+        | display_name | Shepp Clark            |
+        | username     | shepp_clark            |
+        | email        | shepp_clark@example.org|
+      And I request "/user" be created
+    When I request "/user" be retrieved
+    Then the response status code should be 200
+      And I should receive 2 users

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -330,9 +330,16 @@ Feature: User
     Then the response status code should be 200
       And I should receive 2 users
 
-    #TODO: get a user with/without a match
-    #TODO: get a user with invalid id
-    #TODO: act upon a user/{id} in an undefined authz and !authz
-    #TODO: review previous tests for additional ideas
-    #TODO: get a user utilizing fields param
+#TODO: get a user with/without a match
+#TODO: get a user with invalid id
+#TODO: act upon a user/{id} in an undefined authz and !authz
+#TODO: review previous tests for additional ideas
+#TODO: get a user utilizing fields param
+
+#TODO: ensure an employee_id cannot be changed in PUT
+#TODO: PUT without any changes should still update last_synced, right?
+#TODO: PUT with a change to an existing value on one of the unique fields should generate an error.
+#TODO: PUT with a change should update the last_changed data properly...as well as the field to be updated :-)
+
+
 

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -14,7 +14,7 @@ Feature: User
         | display_name | Shep Clark            |
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
-    When I request "/user" be created
+    When I request "/users" be created
     Then the response status code should be 200
       And the following data is returned:
         | property     | value                 |
@@ -54,9 +54,9 @@ Feature: User
         | display_name | Shep Clark            |
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
-      And I request "/user" be created
+      And I request "/users" be created
       And a record exists with an employee_id of "123"
-    When I request "/user" be created again
+    When I request "/users" be created again
     Then a record exists with an employee_id of "123"
       And the only property to change should be last_synced_utc
       And last_synced_utc should be stored as now UTC
@@ -72,10 +72,10 @@ Feature: User
         | display_name | Shep Clark            |
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
-      And I request "/user" be created
+      And I request "/users" be created
       And a record exists with an employee_id of "123"
     When I change the <property> to <value>
-      And I request "/user" be created again
+      And I request "/users" be created again
     Then a record exists with a <property> of <value>
       And last_changed_utc and last_synced_utc are the same
       And last_synced_utc should be stored as now UTC
@@ -93,7 +93,7 @@ Feature: User
   Scenario Outline: Attempt to act upon a user as an unauthorized user
     Given the requester is not authorized
       And the user store is empty
-    When I request "/user" be <action>
+    When I request "/users" be <action>
     Then the response status code should be 401
       And the property message should contain "invalid credentials"
       And the user store is still empty
@@ -109,7 +109,7 @@ Feature: User
   Scenario Outline: Attempt to act upon a user in an undefined way as an authorized user
     Given the requester is authorized
       And the user store is empty
-    When I request "/user" be <action>
+    When I request "/users" be <action>
     Then the response status code should be 405
       And the property message should contain "not allowed"
       And the user store is still empty
@@ -132,7 +132,7 @@ Feature: User
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
       But then I remove the <property>
-    When I request "/user" be created
+    When I request "/users" be created
     Then the response status code should be 422
       And the property message should contain "<contents>"
       And the user store is still empty
@@ -157,7 +157,7 @@ Feature: User
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
       But I provide an invalid <property> of <value>
-    When I request "/user" be created
+    When I request "/users" be created
     Then the response status code should be 422
       And the property message should contain "<contents>"
       And the user store is still empty
@@ -238,7 +238,7 @@ Feature: User
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
       But I provide a <property> that is too long
-    When I request "/user" be created
+    When I request "/users" be created
     Then the response status code should be 422
       And the property message should contain "<contents>"
       And the user store is still empty
@@ -264,7 +264,7 @@ Feature: User
         | display_name | Shep Clark            |
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
-      And I request "/user" be created
+      And I request "/users" be created
       And a record exists with an employee_id of "123"
     When I provide the following valid data:
         | property     | value            |
@@ -274,7 +274,7 @@ Feature: User
         | display_name | Shep Clark       |
         | username     | shep_clark       |
         | email        | chg@example.org  |
-      And I request "/user" be created
+      And I request "/users" be created
     Then the response status code should be 422
       And the property message should contain "Username"
 
@@ -289,7 +289,7 @@ Feature: User
         | display_name | Shep Clark            |
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
-      And I request "/user" be created
+      And I request "/users" be created
       And a record exists with an employee_id of "123"
     When I provide the following valid data:
         | property     | value                 |
@@ -299,7 +299,7 @@ Feature: User
         | display_name | Shep Clark            |
         | username     | chg                   |
         | email        | shep_clark@example.org|
-      And I request "/user" be created
+      And I request "/users" be created
     Then the response status code should be 422
       And the property message should contain "Email"
 
@@ -314,7 +314,7 @@ Feature: User
         | display_name | Shep Clark            |
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
-      And I request "/user" be created
+      And I request "/users" be created
       And I provide the following valid data:
         | property     | value                  |
         | employee_id  | 234                    |
@@ -323,8 +323,8 @@ Feature: User
         | display_name | Shepp Clark            |
         | username     | shepp_clark            |
         | email        | shepp_clark@example.org|
-      And I request "/user" be created
-    When I request "/user" be retrieved
+      And I request "/users" be created
+    When I request "/users" be retrieved
     Then the response status code should be 200
       And I should receive 2 users
 

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -44,51 +44,53 @@ Feature: User
       And last_changed_utc should be stored as now UTC
       And last_synced_utc should be stored as now UTC
 
-  Scenario: "Touch" an existing user without making any changes
-    Given the requester is authorized
-      And I provide the following valid data:
-        | property     | value                 |
-        | employee_id  | 123                   |
-        | first_name   | Shep                  |
-        | last_name    | Clark                 |
-        | display_name | Shep Clark            |
-        | username     | shep_clark            |
-        | email        | shep_clark@example.org|
-      And I request "/users" be created
-      And a record exists with an employee_id of "123"
-    When I request "/users" be created again
-    Then a record exists with an employee_id of "123"
-      And the only property to change should be last_synced_utc
-      And last_synced_utc should be stored as now UTC
+#TODO: related to PUT now.
+#  Scenario: "Touch" an existing user without making any changes
+#    Given the requester is authorized
+#      And I provide the following valid data:
+#        | property     | value                 |
+#        | employee_id  | 123                   |
+#        | first_name   | Shep                  |
+#        | last_name    | Clark                 |
+#        | display_name | Shep Clark            |
+#        | username     | shep_clark            |
+#        | email        | shep_clark@example.org|
+#      And I request "/users" be created
+#      And a record exists with an employee_id of "123"
+#    When I request "/users" be created again
+#    Then a record exists with an employee_id of "123"
+#      And the only property to change should be last_synced_utc
+#      And last_synced_utc should be stored as now UTC
 
-  Scenario Outline: Change the properties of an existing user
-    Given the requester is authorized
-      And the user store is empty
-      And I provide the following valid data:
-        | property     | value                 |
-        | employee_id  | 123                   |
-        | first_name   | Shep                  |
-        | last_name    | Clark                 |
-        | display_name | Shep Clark            |
-        | username     | shep_clark            |
-        | email        | shep_clark@example.org|
-      And I request "/users" be created
-      And a record exists with an employee_id of "123"
-    When I change the <property> to <value>
-      And I request "/users" be created again
-    Then a record exists with a <property> of <value>
-      And last_changed_utc and last_synced_utc are the same
-      And last_synced_utc should be stored as now UTC
-
-    Examples:
-      | property    | value           |
-      | first_name  | FIRST           |
-      | last_name   | LAST            |
-      | display_name| DISPLAY         |
-      | username    | USER            |
-      | email       | chg@example.org |
-      | active      | no              |
-      | locked      | yes             |
+#TODO: related to PUT now.
+#  Scenario Outline: Change the properties of an existing user
+#    Given the requester is authorized
+#      And the user store is empty
+#      And I provide the following valid data:
+#        | property     | value                 |
+#        | employee_id  | 123                   |
+#        | first_name   | Shep                  |
+#        | last_name    | Clark                 |
+#        | display_name | Shep Clark            |
+#        | username     | shep_clark            |
+#        | email        | shep_clark@example.org|
+#      And I request "/users" be created
+#      And a record exists with an employee_id of "123"
+#    When I change the <property> to <value>
+#      And I request "/users" be created again
+#    Then a record exists with a <property> of <value>
+#      And last_changed_utc and last_synced_utc are the same
+#      And last_synced_utc should be stored as now UTC
+#
+#    Examples:
+#      | property    | value           |
+#      | first_name  | FIRST           |
+#      | last_name   | LAST            |
+#      | display_name| DISPLAY         |
+#      | username    | USER            |
+#      | email       | chg@example.org |
+#      | active      | no              |
+#      | locked      | yes             |
 
   Scenario Outline: Attempt to act upon a user as an unauthorized user
     Given the requester is not authorized
@@ -252,7 +254,6 @@ Feature: User
       | username     | Username     |
       | email        | Email        |
 
-
   Scenario: Attempt to create a new user with a username that already exists
     Given the requester is authorized
       And the user store is empty
@@ -302,6 +303,7 @@ Feature: User
       And I request "/users" be created
     Then the response status code should be 422
       And the property message should contain "Email"
+#TODO: need one of these for employee id now too.
 
   Scenario: Retrieve all users
     Given the requester is authorized
@@ -329,8 +331,8 @@ Feature: User
       And I should receive 2 users
 
     #TODO: get a user with/without a match
-    #TODO: get a user with both an alphanumeric and numeric employee_id
-    #TODO: get a user with invalid employee_id
+    #TODO: get a user with invalid id
     #TODO: act upon a user/{id} in an undefined authz and !authz
-    #TODO: review previous test for additional ideas
+    #TODO: review previous tests for additional ideas
+    #TODO: get a user utilizing fields param
 

--- a/application/frontend/components/BaseRestController.php
+++ b/application/frontend/components/BaseRestController.php
@@ -46,7 +46,7 @@ class BaseRestController extends Controller
         $this->throwNotAllowed();
     }
 
-    public function actionView()
+    public function actionView($id)
     {
         $this->throwNotAllowed();
     }

--- a/application/frontend/components/BaseRestController.php
+++ b/application/frontend/components/BaseRestController.php
@@ -36,7 +36,7 @@ class BaseRestController extends Controller
         $this->throwNotAllowed();
     }
 
-    public function actionUpdate()
+    public function actionUpdate($id)
     {
         $this->throwNotAllowed();
     }

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -30,17 +30,16 @@ return [
             // http://www.yiiframework.com/doc-2.0/guide-rest-routing.html
             'rules' => [
                 [
+                    // http://www.yiiframework.com/doc-2.0/yii-rest-urlrule.html
                     'class' => 'yii\rest\UrlRule',
-                    'controller' => ['user', 'authentication'],
+                    'controller' => ['user', 'authentication', 'site'],
                     'extraPatterns' => [
                         'GET,HEAD <employeeId:\w+>' => 'view',
+                        'PUT <employeeId:\w+>/password' => 'update-password',
+                        'system-status' => 'system-status',
                     ],
                     'pluralize' => false,
                 ],
-
-                'PUT /user/<employeeId:\w+>/password' => 'user/update-password',
-
-                'GET /site/system-status' => 'site/system-status',
 
                 '<undefinedRequest>' => 'site/undefined-request',
             ]

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -32,10 +32,17 @@ return [
                 [
                     // http://www.yiiframework.com/doc-2.0/yii-rest-urlrule.html
                     'class' => 'yii\rest\UrlRule',
-                    'controller' => ['user', 'authentication', 'site'],
+                    'controller' => 'user',
                     'extraPatterns' => [
                         'GET,HEAD <employeeId:\w+>' => 'view',
                         'PUT <employeeId:\w+>/password' => 'update-password',
+                    ],
+                ],
+                [
+                    // http://www.yiiframework.com/doc-2.0/yii-rest-urlrule.html
+                    'class' => 'yii\rest\UrlRule',
+                    'controller' => ['authentication', 'site'],
+                    'extraPatterns' => [
                         'system-status' => 'system-status',
                     ],
                     'pluralize' => false,

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -1,6 +1,7 @@
 <?php
 
 use common\models\ApiConsumer;
+use yii\web\JsonParser;
 
 return [
     'id' => 'app-frontend',
@@ -17,7 +18,7 @@ return [
         'request' => [
             // restrict input to JSON only http://www.yiiframework.com/doc-2.0/guide-rest-quick-start.html#enabling-json-input
             'parsers' => [
-                'application/json' => 'yii\web\JsonParser',
+                'application/json' => JsonParser::class,
             ]
         ],
         // http://www.yiiframework.com/doc-2.0/guide-runtime-responses.html

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -32,6 +32,9 @@ return [
                 [
                     'class' => 'yii\rest\UrlRule',
                     'controller' => ['user', 'authentication'],
+                    'extraPatterns' => [
+                        'GET,HEAD <employeeId:\w+>' => 'view',
+                    ],
                     'pluralize' => false,
                 ],
 

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -34,8 +34,7 @@ return [
                     'class' => 'yii\rest\UrlRule',
                     'controller' => 'user',
                     'extraPatterns' => [
-                        'GET,HEAD <employeeId:\w+>' => 'view',
-                        'PUT <employeeId:\w+>/password' => 'update-password',
+                        'PUT <id>/password' => 'update-password',
                     ],
                 ],
                 [

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -1,5 +1,7 @@
 <?php
 
+use common\models\ApiConsumer;
+
 return [
     'id' => 'app-frontend',
     'basePath' => dirname(__DIR__),
@@ -8,7 +10,7 @@ return [
     'components' => [
         // http://www.yiiframework.com/doc-2.0/guide-security-authentication.html
         'user' => [
-            'identityClass' => 'common\models\ApiConsumer', // custom Bearer <token> implementation
+            'identityClass' => ApiConsumer::class, // custom Bearer <token> implementation
             'enableSession' => false, // ensure statelessness
         ],
         // http://www.yiiframework.com/doc-2.0/guide-runtime-requests.html

--- a/application/frontend/controllers/UserController.php
+++ b/application/frontend/controllers/UserController.php
@@ -8,14 +8,14 @@ use yii\web\NotFoundHttpException;
 
 class UserController extends BaseRestController
 {
-    public function actionIndex() // GET /user
+    public function actionIndex() // GET /users
     {
         return User::find()->all();
     }
 
-    public function actionView($employeeId) // GET /user/abc123
+    public function actionView($id) // GET /users/1
     {
-        return User::findOne(['employee_id' => $employeeId]);
+        return User::findOne($id);
     }
 
     public function actionCreate(): User
@@ -33,11 +33,9 @@ class UserController extends BaseRestController
         return $user;
     }
 
-    public function actionUpdatePassword(string $employeeId): User
+    public function actionUpdatePassword($id): User
     {
-        $user = User::findOne([
-            'employee_id' => $employeeId
-        ]);
+        $user = User::findOne($id);
 
         if ($user === null) {
             throw new NotFoundHttpException();

--- a/application/frontend/controllers/UserController.php
+++ b/application/frontend/controllers/UserController.php
@@ -20,11 +20,7 @@ class UserController extends BaseRestController
 
     public function actionCreate(): User
     {
-        $existingUser = User::findOne([
-            'employee_id' => Yii::$app->request->getBodyParam('employee_id')
-        ]);
-
-        $user = $existingUser ?? new User();
+        $user = new User();
 
         $user->attributes = Yii::$app->request->getBodyParams();
 

--- a/application/frontend/controllers/UserController.php
+++ b/application/frontend/controllers/UserController.php
@@ -22,6 +22,8 @@ class UserController extends BaseRestController
     {
         $user = new User();
 
+        $user->scenario = User::SCENARIO_NEW_USER;
+
         $user->attributes = Yii::$app->request->getBodyParams();
 
         parent::save($user);

--- a/application/frontend/controllers/UserController.php
+++ b/application/frontend/controllers/UserController.php
@@ -8,9 +8,14 @@ use yii\web\NotFoundHttpException;
 
 class UserController extends BaseRestController
 {
-    public function actionIndex()
+    public function actionIndex() // GET /user
     {
         return User::find()->all();
+    }
+
+    public function actionView($employeeId) // GET /user/abc123
+    {
+        return User::findOne(['employee_id' => $employeeId]);
     }
 
     public function actionCreate(): User

--- a/application/frontend/controllers/UserController.php
+++ b/application/frontend/controllers/UserController.php
@@ -8,6 +8,11 @@ use yii\web\NotFoundHttpException;
 
 class UserController extends BaseRestController
 {
+    public function actionIndex()
+    {
+        return User::find()->all();
+    }
+
     public function actionCreate(): User
     {
         $existingUser = User::findOne([

--- a/application/frontend/controllers/UserController.php
+++ b/application/frontend/controllers/UserController.php
@@ -29,6 +29,23 @@ class UserController extends BaseRestController
         return $user;
     }
 
+    public function actionUpdate($id)
+    {
+        $user = User::findOne($id);
+
+        if ($user === null) {
+            throw new NotFoundHttpException();
+        }
+
+        $user->scenario = User::SCENARIO_UPDATE_USER;
+
+        $user->attributes = Yii::$app->request->getBodyParams();
+
+        parent::save($user);
+
+        return $user;
+    }
+
     public function actionUpdatePassword($id): User
     {
         $user = User::findOne($id);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,9 @@ services:
             TEST_SERVER_HOSTNAME: app
             APP_ENV: test
         command: vendor/bin/behat
+        # running isolated tests
+        # docker-compose run --rm test vendor/bin/behat features/user.feature
+        # docker-compose run --rm test vendor/bin/behat features/user.feature:306
 
 networks:
     default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,10 +46,10 @@ services:
         environment:
             TEST_SERVER_HOSTNAME: app
             APP_ENV: test
-        command: vendor/bin/behat
+        command: vendor/bin/behat --stop-on-failure
         # running isolated tests
-        # docker-compose run --rm test vendor/bin/behat features/user.feature
-        # docker-compose run --rm test vendor/bin/behat features/user.feature:306
+        # docker-compose run --rm test vendor/bin/behat --stop-on-failure features/user.feature
+        # docker-compose run --rm test vendor/bin/behat --stop-on-failure features/user.feature:306
 
 networks:
     default:


### PR DESCRIPTION
wanted to go ahead and get this functionality in place, tests still still to come.

of note: 

1.  pluralizes user endpoint, e.g., `GET /user` is now `GET /users`
2.  moves to traditional `id` usage instead of `employee_id`, e.g., `PUT /user/{employee_id}` is now `PUT /user/{id}`.  With the additional of the `GET /users` in this spec change, there's always a way to get the generated key for a given resource now.

resolves #31 core-functionality