### PR TITLE
Move catch for EnvVarNotFoundException

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 start: app
 
-app: db deps tables basemodels
+app: db deps
 	docker-compose up -d app
 
 deps:

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -4,7 +4,6 @@ use common\ldap\Ldap;
 use Sil\JsonSyslog\JsonSyslogTarget;
 use Sil\Log\EmailTarget;
 use Sil\PhpEnv\Env;
-use Sil\PhpEnv\EnvVarNotFoundException;
 use yii\db\Connection;
 use yii\helpers\Json;
 use yii\swiftmailer\Mailer;

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -16,24 +16,11 @@ $mysqlDatabase = null;
 $mysqlUser     = null;
 $mysqlPassword = null;
 
-try {
-    $idpName       = Env::requireEnv('IDP_NAME');
-    $mysqlHost     = Env::requireEnv('MYSQL_HOST');
-    $mysqlDatabase = Env::requireEnv('MYSQL_DATABASE');
-    $mysqlUser     = Env::requireEnv('MYSQL_USER');
-    $mysqlPassword = Env::requireEnv('MYSQL_PASSWORD');
-} catch (EnvVarNotFoundException $e) {
-    header('Content-type: application/json');
-    http_response_code(500);
-
-    $responseContent = json_encode([
-        'name' => 'Internal Server Error',
-        'message' => $e->getMessage(),
-        'status' => 500,
-    ]);
-
-    exit($responseContent);
-}
+$idpName       = Env::requireEnv('IDP_NAME');
+$mysqlHost     = Env::requireEnv('MYSQL_HOST');
+$mysqlDatabase = Env::requireEnv('MYSQL_DATABASE');
+$mysqlUser     = Env::requireEnv('MYSQL_USER');
+$mysqlPassword = Env::requireEnv('MYSQL_PASSWORD');
 
 $mailerUseFiles    = Env::get('MAILER_USEFILES', false);
 $mailerHost        = Env::get('MAILER_HOST');

--- a/application/frontend/web/index.php
+++ b/application/frontend/web/index.php
@@ -5,15 +5,20 @@ try {
      *       this required file.  */
     $config = require('../config/load-configs.php');
 } catch (Sil\PhpEnv\EnvVarNotFoundException $e) {
+    
+    // Log to syslog (Logentries).
+    openlog('id-broker', LOG_NDELAY | LOG_PERROR, LOG_USER);
+    syslog(LOG_CRIT, $e->getMessage());
+    closelog();
+    
+    // Return error response code/message to HTTP request.
     header('Content-Type: application/json');
     http_response_code(500);
-
     $responseContent = json_encode([
         'name' => 'Internal Server Error',
         'message' => $e->getMessage(),
         'status' => 500,
     ], JSON_PRETTY_PRINT);
-
     exit($responseContent);
 }
 

--- a/application/frontend/web/index.php
+++ b/application/frontend/web/index.php
@@ -1,6 +1,19 @@
 <?php
 
-$config = require('../config/load-configs.php');
+try {
+    $config = require('../config/load-configs.php');
+} catch (EnvVarNotFoundException $e) {
+    header('Content-Type: application/json');
+    http_response_code(500);
+
+    $responseContent = json_encode([
+        'name' => 'Internal Server Error',
+        'message' => $e->getMessage(),
+        'status' => 500,
+    ], JSON_PRETTY_PRINT);
+
+    exit($responseContent);
+}
 
 $application = new yii\web\Application($config);
 $application->run();

--- a/application/frontend/web/index.php
+++ b/application/frontend/web/index.php
@@ -1,8 +1,10 @@
 <?php
 
 try {
+    /* NOTE: The composer autoloader will be one of the first things loaded by
+     *       this required file.  */
     $config = require('../config/load-configs.php');
-} catch (EnvVarNotFoundException $e) {
+} catch (Sil\PhpEnv\EnvVarNotFoundException $e) {
     header('Content-Type: application/json');
     http_response_code(500);
 

--- a/application/run.sh
+++ b/application/run.sh
@@ -7,6 +7,9 @@ else
     sed -i /etc/rsyslog.conf -e "s/LOGENTRIESKEY/${LOGENTRIES_KEY}/"
     # Start syslog
     rsyslogd
+    
+    # Give syslog time to fully start up.
+    sleep 3
 fi
 
 # Run database migrations

--- a/application/run.sh
+++ b/application/run.sh
@@ -13,7 +13,14 @@ else
 fi
 
 # Run database migrations
-/data/yii migrate --interactive=0
+output=$(/data/yii migrate --interactive=0 2>&1)
+
+# If the migrations failed, exit.
+rc=$?;
+if [[ $rc != 0 ]]; then
+  logger -p 1 -t application.crit "Migrations FAILED. Exit code ${rc}. Message: ${output}"
+  exit $rc;
+fi
 
 # Run apache in foreground
 apache2ctl -D FOREGROUND

--- a/application/yii
+++ b/application/yii
@@ -26,6 +26,11 @@ try {
     );
 } catch (Sil\PhpEnv\EnvVarNotFoundException $e) {
     fwrite(STDERR, $e->getMessage() . PHP_EOL);
+    
+    openlog('id-broker', LOG_NDELAY | LOG_PERROR, LOG_USER);
+    syslog(LOG_CRIT, $e->getMessage());
+    closelog();
+    
     exit(1);
 }
 

--- a/application/yii
+++ b/application/yii
@@ -25,7 +25,7 @@ try {
         require(__DIR__ . '/console/config/main.php')
     );
 } catch (Sil\PhpEnv\EnvVarNotFoundException $e) {
-    fwrite(STDERR, $e->getMessage());
+    fwrite(STDERR, $e->getMessage() . PHP_EOL);
     exit(1);
 }
 

--- a/application/yii
+++ b/application/yii
@@ -24,7 +24,7 @@ try {
         require(__DIR__ . '/common/config/main.php'),
         require(__DIR__ . '/console/config/main.php')
     );
-} catch (EnvVarNotFoundException $e) {
+} catch (Sil\PhpEnv\EnvVarNotFoundException $e) {
     fwrite(STDERR, $e->getMessage());
     exit(1);
 }

--- a/application/yii
+++ b/application/yii
@@ -19,10 +19,15 @@ require(__DIR__ . '/vendor/autoload.php');
 require(__DIR__ . '/vendor/yiisoft/yii2/Yii.php');
 require(__DIR__ . '/common/config/bootstrap.php');
 
-$config = yii\helpers\ArrayHelper::merge(
-    require(__DIR__ . '/common/config/main.php'),
-    require(__DIR__ . '/console/config/main.php')
-);
+try {
+    $config = yii\helpers\ArrayHelper::merge(
+        require(__DIR__ . '/common/config/main.php'),
+        require(__DIR__ . '/console/config/main.php')
+    );
+} catch (EnvVarNotFoundException $e) {
+    fwrite(STDERR, $e->getMessage());
+    exit(1);
+}
 
 $application = new yii\console\Application($config);
 $exitCode = $application->run();

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -19,6 +19,7 @@ app:
     command: /data/run-tests.sh
     environment:
         APP_ENV: test
+        IDP_NAME: Test
         MYSQL_HOST: db
         MYSQL_DATABASE: test
         MYSQL_USER: idbroker

--- a/dockerbuild/rsyslog.conf
+++ b/dockerbuild/rsyslog.conf
@@ -35,7 +35,7 @@ $KLogPermitNonKernelFacility on
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
 # Filter duplicated messages
-$RepeatedMsgReduction on
+$RepeatedMsgReduction off
 
 #
 # Set the default permissions for all log files.


### PR DESCRIPTION
What do you two think about this slight refactor of catching the `EnvVarNotFoundException`s? Since calls from the console won't be HTTP requests, the http_response_code and JSON output formatting didn't quite seem applicable, so I moved the HTTP stuff to frontend/web/index.php, and put something in the console calls to return a non-zero exit code and a simple/clean error message.