### PR TITLE
Update local env docs

### DIFF
--- a/local.env.dist
+++ b/local.env.dist
@@ -1,4 +1,4 @@
-### Required ENV vars
+### Required ENV vars ###
 
 # Format: [idpname]-[component-name]. Example: "insite-id-broker" for calls FROM
 # the ID Broker in the Insite Idp-in-a-Box.
@@ -13,9 +13,12 @@ MYSQL_PASSWORD=
 # format is comma-separated tokens (no-space), e.g., test-cli-abc123,consumer-id-def456,something-unique-ghi789
 API_ACCESS_KEYS=
 
-### Optional ENV vars
+
+### Optional ENV vars ###
+
 # [prod|dev|test], app defaults to prod
 APP_ENV=
+
 LOGENTRIES_KEY=
 COMPOSER_AUTH=
 

--- a/local.env.dist
+++ b/local.env.dist
@@ -1,7 +1,7 @@
 ### Required ENV vars ###
 
-# Format: [idpname]-[component-name]. Example: "insite-id-broker" for calls FROM
-# the ID Broker in the Insite Idp-in-a-Box.
+# The user-friendly version of the name of this IdP.
+# Example: "Your Org"
 IDP_NAME=
 
 MYSQL_ROOT_PASSWORD=


### PR DESCRIPTION
Apparently I had misunderstood the expect value for the IDP_NAME environment variable. This is updating that info about it in `local.env.dist` to stop giving incorrect information.

(Originally I had thought it would be used in assembling the access tokens, but now I'm not sure why I thought that.)