### PR TITLE
Fix when to use email service log target

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -16,7 +16,7 @@ $mysqlDatabase = Env::requireEnv('MYSQL_DATABASE');
 $mysqlUser     = Env::requireEnv('MYSQL_USER');
 $mysqlPassword = Env::requireEnv('MYSQL_PASSWORD');
 
-$notificationEmail = Env::get('NOTIFICATION_EMAIL', 'oncall@example.org');
+$alertsEmail = Env::get('ALERTS_EMAIL');
 
 /*
  * If using Email Service, the following ENV vars should be set:
@@ -92,6 +92,7 @@ return [
                 [
                     'class' => EmailServiceTarget::class,
                     'categories' => ['application'], // stick to messages from this app, not all of Yii's built-in messaging.
+                    'enabled' => !empty($alertsEmail),
                     'except' => [
                         'yii\web\HttpException:400',
                         'yii\web\HttpException:401',
@@ -102,7 +103,7 @@ return [
                     'levels' => ['error'],
                     'logVars' => [], // Disable logging of _SERVER, _POST, etc.
                     'message' => [
-                        'to' => $notificationEmail,
+                        'to' => $alertsEmail,
                         'subject' => 'ERROR - ' . $idpName . ' ID Broker [' . YII_ENV .']',
                     ],
                     'baseUrl' => $emailServiceConfig['baseUrl'],

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -16,7 +16,7 @@ $mysqlDatabase = Env::requireEnv('MYSQL_DATABASE');
 $mysqlUser     = Env::requireEnv('MYSQL_USER');
 $mysqlPassword = Env::requireEnv('MYSQL_PASSWORD');
 
-$alertsEmail = Env::get('ALERTS_EMAIL');
+$notificationEmail = Env::get('NOTIFICATION_EMAIL');
 
 /*
  * If using Email Service, the following ENV vars should be set:
@@ -92,7 +92,7 @@ return [
                 [
                     'class' => EmailServiceTarget::class,
                     'categories' => ['application'], // stick to messages from this app, not all of Yii's built-in messaging.
-                    'enabled' => !empty($alertsEmail),
+                    'enabled' => !empty($notificationEmail),
                     'except' => [
                         'yii\web\HttpException:400',
                         'yii\web\HttpException:401',
@@ -103,7 +103,7 @@ return [
                     'levels' => ['error'],
                     'logVars' => [], // Disable logging of _SERVER, _POST, etc.
                     'message' => [
-                        'to' => $alertsEmail,
+                        'to' => $notificationEmail,
                         'subject' => 'ERROR - ' . $idpName . ' ID Broker [' . YII_ENV .']',
                     ],
                     'baseUrl' => $emailServiceConfig['baseUrl'],

--- a/local.env.dist
+++ b/local.env.dist
@@ -21,9 +21,6 @@ API_ACCESS_KEYS=
 
 ### Optional ENV vars ###
 
-# Where to send alert emails when specific errors are logged.
-#ALERTS_EMAIL=
-
 # [prod|dev|test], app defaults to prod
 APP_ENV=
 

--- a/local.env.dist
+++ b/local.env.dist
@@ -21,6 +21,9 @@ API_ACCESS_KEYS=
 
 ### Optional ENV vars ###
 
+# Where to send alert emails when specific errors are logged.
+#ALERTS_EMAIL=
+
 # [prod|dev|test], app defaults to prod
 APP_ENV=
 


### PR DESCRIPTION
This is fixing a bug that (I think) I introduced when shifting ID Broker over to using EmailServiceTarget, rather than EmailTarget.