### PR TITLE
Fix require_mfa handling

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -120,7 +120,7 @@ class User extends UserBase
                 'nag_for_mfa_after', 'default', 'value' => MySqlDateTime::today(),
             ],
             [
-                ['active', 'locked'], 'in', 'range' => ['yes', 'no'],
+                ['active', 'locked', 'require_mfa'], 'in', 'range' => ['yes', 'no'],
             ],
             [
                 'email', 'email',

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -79,6 +79,7 @@ class User extends UserBase
             'email',
             'active',
             'locked',
+            'require_mfa',
             'nag_for_mfa_after',
         ];
 
@@ -90,6 +91,7 @@ class User extends UserBase
             'email',
             'active',
             'locked',
+            'require_mfa',
         ];
 
         $scenarios[self::SCENARIO_UPDATE_PASSWORD] = ['password'];

--- a/application/features/bootstrap/FeatureContext.php
+++ b/application/features/bootstrap/FeatureContext.php
@@ -207,7 +207,11 @@ class FeatureContext extends YiiContext
     {
         $this->userFromDb = User::findOne([$lookupKey => $lookupValue]);
 
-        Assert::notNull($this->userFromDb);
+        Assert::notNull($this->userFromDb, sprintf(
+            'Failed to find a user with a %s of %s.',
+            $lookupKey,
+            var_export($lookupValue, true)
+        ));
     }
 
     /**

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -65,35 +65,51 @@ Feature: User
 #      And the only property to change should be last_synced_utc
 #      And last_synced_utc should be stored as now UTC
 
-#TODO: related to PUT now.
-#  Scenario Outline: Change the properties of an existing user
-#    Given the requester is authorized
-#      And the user store is empty
-#      And I provide the following valid data:
-#        | property     | value                 |
-#        | employee_id  | 123                   |
-#        | first_name   | Shep                  |
-#        | last_name    | Clark                 |
-#        | display_name | Shep Clark            |
-#        | username     | shep_clark            |
-#        | email        | shep_clark@example.org|
-#      And I request "/user" be created
-#      And a record exists with an employee_id of "123"
-#    When I change the <property> to <value>
-#      And I request "/user" be created again
-#    Then a record exists with a <property> of <value>
-#      And last_changed_utc and last_synced_utc are the same
-#      And last_synced_utc should be stored as now UTC
-#
-#    Examples:
-#      | property    | value           |
-#      | first_name  | FIRST           |
-#      | last_name   | LAST            |
-#      | display_name| DISPLAY         |
-#      | username    | USER            |
-#      | email       | chg@example.org |
-#      | active      | no              |
-#      | locked      | yes             |
+  Scenario Outline: Change the properties of an existing user
+    Given a record does not exist with an employee_id of "123"
+      And the requester is authorized
+      And I provide the following valid data:
+        | property     | value                 |
+        | employee_id  | 123                   |
+        | first_name   | Shep                  |
+        | last_name    | Clark                 |
+        | display_name | Shep Clark            |
+        | username     | shep_clark            |
+        | email        | shep_clark@example.org|
+      And I request "/user" be created
+      And the response status code should be 200
+      And a record exists with an employee_id of "123"
+      And the following data should be stored:
+        | property            | value                 |
+        | first_name          | Shep                  |
+        | last_name           | Clark                 |
+        | display_name        | Shep Clark            |
+        | username            | shep_clark            |
+        | email               | shep_clark@example.org|
+        | current_password_id | NULL                  |
+        | active              | yes                   |
+        | locked              | no                    |
+        | require_mfa         | no                    |
+      And I change the <property> to <value>
+    When I request "/user/123" be updated
+    Then the response status code should be 200
+      And a record exists with a <property> of <value>
+      And last_changed_utc should be stored as now UTC
+      And last_synced_utc should be stored as now UTC
+
+    Examples:
+      | property    | value           |
+      | first_name  | FIRST           |
+      | last_name   | LAST            |
+      | display_name| DISPLAY         |
+      | username    | USER            |
+      | email       | chg@example.org |
+      | active      | no              |
+      | active      | yes             |
+      | locked      | no              |
+      | locked      | yes             |
+      | require_mfa | no              |
+      | require_mfa | yes             |
 
 #TODO: consider creating a new security.feature file for all these security-related tests.
 #TODO: need to think through tests for API_ACCESS_KEYS config, i.e., need tests for ApiConsumer

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -14,6 +14,7 @@ Feature: User
         | display_name | Shep Clark            |
         | username     | shep_clark            |
         | email        | shep_clark@example.org|
+        | require_mfa  | yes                   |
     When I request "/user" be created
     Then the response status code should be 200
       And the following data is returned:
@@ -42,6 +43,7 @@ Feature: User
         | current_password_id | NULL                  |
         | active              | yes                   |
         | locked              | no                    |
+        | require_mfa         | yes                   |
       And last_changed_utc should be stored as now UTC
       And last_synced_utc should be stored as now UTC
 
@@ -230,6 +232,18 @@ Feature: User
       | locked      | 21                 | Locked      |
       | locked      | true               | Locked      |
       | locked      | false              | Locked      |
+      | require_mfa | YES                | Require Mfa |
+      | require_mfa | Yes                | Require Mfa |
+      | require_mfa | yessir             | Require Mfa |
+      | require_mfa | NO                 | Require Mfa |
+      | require_mfa | No                 | Require Mfa |
+      | require_mfa | nosir              | Require Mfa |
+      | require_mfa | x                  | Require Mfa |
+      | require_mfa | 1                  | Require Mfa |
+      | require_mfa | 0                  | Require Mfa |
+      | require_mfa | 21                 | Require Mfa |
+      | require_mfa | true               | Require Mfa |
+      | require_mfa | false              | Require Mfa |
 
   Scenario Outline: Attempt to create a new user while providing an invalid(too long) property
     Given the requester is authorized


### PR DESCRIPTION
Previously, the `require_mfa` field was not included in the lists of fields allowed to be updated to create or update.