### PR TITLE
Change HTTP status code for password reuse error

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -828,7 +828,7 @@ schemas:
                     "name": "Conflict",
                     "message": "May not be reused yet.",
                     "code": 1542395933,
-                    "status": 422
+                    "status": 409
                   }
           422:
             description: |

--- a/api.raml
+++ b/api.raml
@@ -819,6 +819,17 @@ schemas:
                   }
           204:
             description: No user record was found with that `employee_id`.
+          409:
+            description: A recently-used password was given.
+              application/json:
+                schema: Error
+                example: |
+                  {
+                    "name": "Conflict",
+                    "message": "May not be reused yet.",
+                    "code": 1542395933,
+                    "status": 422
+                  }
           422:
             description: |
               The given password does not meet some requirement (such as if an


### PR DESCRIPTION
Need to distinguish a password reuse error from other validation errors. Changing the HTTP status code from 422 to 409 in this situation.