### PR TITLE
Include unverified methods in list

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -1,9 +1,10 @@
-#%RAML 0.8
+#%RAML 1.0
 title: ID Broker API
+version: 4
 protocols: [ HTTPS ]
 mediaType: application/json
 securitySchemes:
-  - AuthzBearerToken:
+  AuthzBearerToken:
       type: x-{other}
       describedBy:
         headers:
@@ -12,8 +13,8 @@ securitySchemes:
             example: Bearer abc123
 securedBy: [ AuthzBearerToken ]
 
-schemas:
-  - Authentication: |
+types:
+  Authentication: |
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "properties": {
@@ -28,7 +29,7 @@ schemas:
         },
         "type": "object"
       }
-  - Error: |
+  Error: |
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "properties": {
@@ -51,7 +52,7 @@ schemas:
         },
         "type": "object"
       }
-  - ReturnedUser: |
+  ReturnedUser: |
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "properties": {
@@ -157,7 +158,7 @@ schemas:
         },
         "type": "object"
       }
-  - UserCreation: |
+  UserCreation: |
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "properties": {
@@ -206,7 +207,7 @@ schemas:
         },
         "type": "object"
       }
-  - UserList: |
+  UserList: |
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "items": {
@@ -280,7 +281,7 @@ schemas:
         },
         "type": "array"
       }
-  - UserUpdate: |
+  UserUpdate: |
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "properties": {
@@ -325,7 +326,7 @@ schemas:
         },
         "type": "object"
       }
-  - MfaCreation: |
+  MfaCreation: |
         {
           "$schema": "http://json-schema.org/draft-03/schema",
           "properties": {
@@ -345,7 +346,7 @@ schemas:
           },
           "type": "object"
         }
-  - MfaCreationResponse: |
+  MfaCreationResponse: |
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "properties": {
@@ -355,12 +356,12 @@ schemas:
           },
           "data": {
             "required": true,
-            "type": "object"
+            "type": "array"
           }
         },
         "type": "object"
       }
-  - MethodResponse: |
+  MethodResponse: |
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "properties": {
@@ -375,7 +376,7 @@ schemas:
         },
         "type": "object"
       }
-  - MethodListResponse: |
+  MethodListResponse: |
       {
         "$schema": "http://json-schema.org/draft-03/schema",
         "items": {
@@ -445,8 +446,8 @@ schemas:
                      {
                        "id": 345,
                        "type": "backupcode"
-                     },
-                   ]
+                     }
+                  ]
                 },
                 "password": {
                   "created_utc":"2017-05-24 14:04:51 UTC",

--- a/api.raml
+++ b/api.raml
@@ -387,6 +387,10 @@ schemas:
             "value": {
               "required": true,
               "type": "string"
+            },
+            "verified": {
+              "required": true,
+              "type": "boolean"
             }
           },
           "type": "object"
@@ -759,7 +763,7 @@ schemas:
                   ]
     /method:
       get:
-        description: Get a list of verified recovery methods for user
+        description: Get a list of verified and unverified recovery methods for user
         responses:
           400:
           200:
@@ -770,7 +774,8 @@ schemas:
                   [
                       {
                           "uid": "0YrSiNp2P6sfkleepNNvFYMQWuLfssve",
-                          "value": email@example.org
+                          "value": email@example.org,
+                          "verified": true
                       },
                   ]
     /password:

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -56,6 +56,7 @@ class Method extends MethodBase
         return [
             'id' => function() { return $this->uid; },
             'value',
+            'verified' => function() { return $this->verified == 1; }
         ];
     }
 

--- a/application/features/method.feature
+++ b/application/features/method.feature
@@ -16,12 +16,12 @@ Feature: Recovery Method
     Then the response status code should be 200
     And I should receive 1 record
 
-  Scenario: Retrieve a Method for a User with 1 verified and 1 unverified Method
+  Scenario: Retrieve Method records for a User with 1 verified and 1 unverified Method
     Given user with employee id 123 has a verified Method
     And user with employee id 123 has an unverified Method
     When I request "/user/123/method" be retrieved
     Then the response status code should be 200
-    And I should receive 1 record
+    And I should receive 2 records
 
   Scenario: Retrieve a specific Method record
     Given user with employee id 123 has a verified Method

--- a/application/frontend/controllers/MethodController.php
+++ b/application/frontend/controllers/MethodController.php
@@ -33,7 +33,7 @@ class MethodController extends BaseRestController
             );
         }
 
-        return Method::findAll(['user_id' => $user->id, 'verified' => 1]);
+        return Method::findAll(['user_id' => $user->id]);
     }
 
     /**


### PR DESCRIPTION
In the `/user/{employee_id}/method` endpoint, we want unverified methods as well as verified ones. Removing the `verified` filter and adding a `verified` property to the response json object.