### PR TITLE
Renew expired invite

### DIFF
--- a/api.html
+++ b/api.html
@@ -264,6 +264,12 @@
   "code": 0,
   "status": 400
 }
+</code></pre></div><h2>HTTP status code <a href="http://httpstatus.es/410" target="_blank">410</a></h2><p>The invite has expired. A new code has been generated and emailed to the user.</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>name</strong>: <em>required (string)</em></li><li><strong>message</strong>: <em>required (string)</em></li><li><strong>code</strong>: <em>required (integer)</em></li><li><strong>status</strong>: <em>required (integer)</em></li></ul><p><strong>Example</strong>:</p><div class="examples"><pre><code>{
+  "name": "Bad Request",
+  "message": "",
+  "code": 0,
+  "status": 400
+}
 </code></pre></div><h2>HTTP status code <a href="http://httpstatus.es/500" target="_blank">500</a></h2><p>A server-side error occurred.</p><h3>Body</h3><p><strong>Media type</strong>: application/json</p><p><strong>Type</strong>: object</p><strong>Properties</strong><ul><li><strong>name</strong>: <em>required (string)</em></li><li><strong>message</strong>: <em>required (string)</em></li><li><strong>code</strong>: <em>required (integer)</em></li><li><strong>status</strong>: <em>required (integer)</em></li></ul><p><strong>Example</strong>:</p><div class="examples"><pre><code>{
   "name": "Bad Request",
   "message": "",

--- a/api.raml
+++ b/api.raml
@@ -314,6 +314,12 @@ types:
           authentication failed).
         body:
           type: Error
+      410:
+        description: >
+          The invite has expired. A new code has been generated and emailed
+          to the user.
+        body:
+          type: Error
       500:
         description: A server-side error occurred.
         body:

--- a/application/common/models/Authentication.php
+++ b/application/common/models/Authentication.php
@@ -67,7 +67,7 @@ class Authentication
      * Attempt an authentication by new user invite.
      *
      * @param string $invite New user invite code. If not blank, username and password are ignored.
-     * @throws \Exception
+     * @throws HttpException
      */
     protected function authenticateByInvite($invite)
     {

--- a/application/common/models/Authentication.php
+++ b/application/common/models/Authentication.php
@@ -78,7 +78,7 @@ class Authentication
             return;
         }
 
-        if ( ! $invite->isValidCode()) {
+        if ($invite->isExpired()) {
             $emailData = ['inviteCode' => $invite->renew()];
 
             /* @var $emailer Emailer */

--- a/application/common/models/Authentication.php
+++ b/application/common/models/Authentication.php
@@ -1,8 +1,10 @@
 <?php
 namespace common\models;
 
+use common\components\Emailer;
 use common\helpers\MySqlDateTime;
 use common\ldap\Ldap;
+use yii\web\HttpException;
 
 /**
  * An immutable class for checking authentication credentials.
@@ -65,6 +67,7 @@ class Authentication
      * Attempt an authentication by new user invite.
      *
      * @param string $invite New user invite code. If not blank, username and password are ignored.
+     * @throws \Exception
      */
     protected function authenticateByInvite($invite)
     {
@@ -74,9 +77,15 @@ class Authentication
             $this->errors['invite'] = ['Invalid code.'];
             return;
         }
+
         if ( ! $invite->isValidCode()) {
-            $this->errors = $invite->getErrors();
-            return;
+            $emailData = ['inviteCode' => $invite->renew()];
+
+            /* @var $emailer Emailer */
+            $emailer = \Yii::$app->emailer;
+            $emailer->sendMessageTo(EmailLog::MESSAGE_TYPE_INVITE, $invite->user, $emailData);
+
+            throw new HttpException(410);
         }
 
         /* @var $user User */

--- a/application/common/models/Invite.php
+++ b/application/common/models/Invite.php
@@ -60,13 +60,13 @@ class Invite extends InviteBase
     }
 
     /**
-     * Checks expiration date. If `expires_on` is today or before, `isValidCode`
-     * returns `false` and adds an error message.
+     * Checks expiration date. If `expires_on` is today or before,
+     * returns `true` and adds an error message.
      *
      * @return bool
      * @throws \Exception
      */
-    public function isValidCode()
+    public function isExpired()
     {
         $expiration = strtotime($this->expires_on);
         if ($expiration === false) {
@@ -76,9 +76,9 @@ class Invite extends InviteBase
         $now = time();
         if ($now > $expiration) {
             $this->addError('expires_on', 'Expired code.');
-            return false;
+            return true;
         }
-        return true;
+        return false;
     }
 
     /**

--- a/application/common/models/Invite.php
+++ b/application/common/models/Invite.php
@@ -25,18 +25,30 @@ class Invite extends InviteBase
         ], parent::rules());
     }
 
-    private static function newExpireDate()
+    /**
+     * Calculate and return a new expire date.
+     * @return string
+     */
+    private static function newExpireDate(): string
     {
         $lifespan = Yii::$app->params['inviteLifespan'];
 
         return MySqlDateTime::relative($lifespan);
     }
 
-    private static function newCode()
+    /**
+     * Generate and return a new code.
+     * @return string
+     * @throws \Exception
+     */
+    private static function newCode():string
     {
         return Uuid::uuid4()->toString();
     }
 
+    /**
+     * @inheritdoc
+     */
     public function attributeLabels(): array
     {
         $labels = parent::attributeLabels();
@@ -69,6 +81,10 @@ class Invite extends InviteBase
         return true;
     }
 
+    /**
+     * Return the invite code.
+     * @return string
+     */
     public function getCode(): string
     {
         return $this->uuid;

--- a/application/features/authentication.feature
+++ b/application/features/authentication.feature
@@ -231,7 +231,7 @@ Feature: Authentication
       | property  | value       |
       | invite    | xyz123      |
     When I request "/authentication" be created
-    Then the response status code should be 400
+    Then the response status code should be 410
 
   Scenario: Incorrect invite code for an account with no password in the db
     Given the user "shep_clark" has no password in the database

--- a/application/features/bootstrap/UnitTestsContext.php
+++ b/application/features/bootstrap/UnitTestsContext.php
@@ -220,7 +220,7 @@ class UnitTestsContext extends YiiContext
     public function iReceiveACodeThatIsNotExpired()
     {
         Assert::notNull($this->inviteCode);
-        Assert::true($this->inviteCode->isValidCode());
+        Assert::false($this->inviteCode->isExpired());
     }
 
     /**


### PR DESCRIPTION
In response to `/authentication` with an `invite` code that has expired, respond with a 410 and renew the invite with a new code. Also send an email to the user with the new code.