### PR TITLE
Add "grace period" for invites and recovery methods

### DIFF
--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -337,6 +337,29 @@ class Emailer extends Component
         }
     }
 
+    /**
+     * Iterates over all users and sends method verify emails as appropriate
+     */
+    public function sendMethodVerifyEmails()
+    {
+        $query = (new Query)->from('user');
+
+        // iterate over one user at a time.
+        foreach ($query->each() as $userData) {
+            $user = User::findOne($userData['id']);
+
+            $methods = $user->getUnverifiedMethods();
+            foreach ($methods as $method) {
+                $data = [
+                    'toAddress' => $method->value,
+                    'code' => $method->verification_code,
+                    'uid' => $method->uid,
+                ];
+
+                $this->sendMessageTo(EmailLog::MESSAGE_TYPE_METHOD_VERIFY, $user, $data);
+            }
+        }
+    }
 
     /**
      *

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -210,6 +210,7 @@ return [
         'method' => ArrayHelper::merge(
             [
                 'lifetime' => '+1 hour',
+                'gracePeriod' => '+15 days',
                 'codeLength' => 6,
                 'maxAttempts' => 10,
             ],

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -44,15 +44,6 @@ $emailServiceConfig = Env::getArrayFromPrefix('EMAIL_SERVICE_');
 // Re-retrieve the validIpRanges as an array.
 $emailServiceConfig['validIpRanges'] = Env::getArray('EMAIL_SERVICE_validIpRanges');
 
-$methodParams = ArrayHelper::merge(
-    [
-        'lifetimeSeconds' => 3600,
-        'codeLength' => 6,
-        'maxAttempts' => 10,
-    ],
-    Env::getArrayFromPrefix('METHOD_')
-);
-
 return [
     'id' => 'app-common',
     'bootstrap' => ['log'],
@@ -216,6 +207,13 @@ return [
             'trackingId' => Env::get('GA_TRACKING_ID'),
             'clientId'   => Env::get('GA_CLIENT_ID'),
         ],
-        'method' => $methodParams,
+        'method' => ArrayHelper::merge(
+            [
+                'lifetime' => '+1 hour',
+                'codeLength' => 6,
+                'maxAttempts' => 10,
+            ],
+            Env::getArrayFromPrefix('METHOD_')
+        ),
     ],
 ];

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -203,6 +203,7 @@ return [
         'passwordMfaLifespanExtension'  => Env::get('PASSWORD_MFA_LIFESPAN_EXTENSION', '+1 year'),
         'passwordExpirationGracePeriod' => Env::get('PASSWORD_EXPIRATION_GRACE_PERIOD', '+30 days'),
         'inviteLifespan'                => Env::get('INVITE_LIFESPAN', '+1 month'),
+        'inviteGracePeriod'             => Env::get('INVITE_GRACE_PERIOD', '+3 months'),
         'googleAnalytics'               => [
             'trackingId' => Env::get('GA_TRACKING_ID'),
             'clientId'   => Env::get('GA_CLIENT_ID'),

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -210,7 +210,7 @@ return [
         ],
         'method' => ArrayHelper::merge(
             [
-                'lifetime' => '+1 hour',
+                'lifetime' => '+1 day',
                 'gracePeriod' => '+15 days',
                 'codeLength' => 6,
                 'maxAttempts' => 10,

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -216,5 +216,6 @@ return [
             ],
             Env::getArrayFromPrefix('METHOD_')
         ),
+        'mfaLifetime' => Env::get('MFA_LIFETIME', '+2 hours'),
     ],
 ];

--- a/application/common/models/Invite.php
+++ b/application/common/models/Invite.php
@@ -152,9 +152,12 @@ class Invite extends InviteBase
         $removeExpireBefore = MySqlDateTime::relative($inviteGracePeriod);
         $invites = self::find()->andWhere(['<', 'expires_on', $removeExpireBefore])->all();
 
+        $numDeleted = 0;
         foreach ($invites as $invite) {
             try {
-                $invite->delete();
+                if ($invite->delete() !== false) {
+                    $numDeleted += 1;
+                }
             } catch (\Exception $e) {
                 \Yii::error([
                     'action' => 'delete old invites',
@@ -164,5 +167,11 @@ class Invite extends InviteBase
                 ]);
             }
         }
+
+        \Yii::warning([
+            'action' => 'delete old invite records',
+            'status' => 'complete',
+            'count' => $numDeleted,
+        ]);
     }
 }

--- a/application/common/models/Invite.php
+++ b/application/common/models/Invite.php
@@ -149,8 +149,8 @@ class Invite extends InviteBase
          * Replace '+' with '-' so all env parameters can be defined consistently as '+n unit'
          */
         $inviteGracePeriod = str_replace('+', '-', \Yii::$app->params['inviteGracePeriod']);
-        $removeOlderThan = MySqlDateTime::relative($inviteGracePeriod);
-        $invites = self::find()->andWhere(['<', 'expires_on', $removeOlderThan])->all();
+        $removeExpireBefore = MySqlDateTime::relative($inviteGracePeriod);
+        $invites = self::find()->andWhere(['<', 'expires_on', $removeExpireBefore])->all();
 
         foreach ($invites as $invite) {
             try {

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -156,9 +156,12 @@ class Method extends MethodBase
             ->andWhere(['<', 'verification_expires', $removeExpireBefore])
             ->all();
 
+        $numDeleted = 0;
         foreach ($methods as $method) {
             try {
-                $method->delete();
+                if ($method->delete() !== false) {
+                    $numDeleted += 1;
+                }
             } catch (\Exception $e) {
                 \Yii::error([
                     'action' => 'delete expired unverified methods',
@@ -168,6 +171,12 @@ class Method extends MethodBase
                 ]);
             }
         }
+
+        \Yii::warning([
+            'action' => 'delete old unverified method records',
+            'status' => 'complete',
+            'count' => $numDeleted,
+        ]);
     }
 
     /**

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -197,7 +197,9 @@ class Method extends MethodBase
                 $method->verified = 1;
             }
         } else {
-            $method->restartVerification();
+            if (! $method->isVerified()) {
+                $method->restartVerification();
+            }
             return $method;
         }
 

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -196,6 +196,9 @@ class Method extends MethodBase
                 $method->created = $created;
                 $method->verified = 1;
             }
+        } else {
+            $method->restartVerification();
+            return $method;
         }
 
         if (! $method->save()) {

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -142,12 +142,18 @@ class Method extends MethodBase
 
     /**
      * Delete all method records that are not verified and verification_expires date is in the past
+     * by more than a configured "grace period."
      */
     public static function deleteExpiredUnverifiedMethods()
     {
+        /*
+         * Replace '+' with '-' so all env parameters can be defined consistently as '+n unit'
+         */
+        $methodGracePeriod = str_replace('+', '-', \Yii::$app->params['method']['gracePeriod']);
+        $removeOlderThan = MySqlDateTime::relativeTime($methodGracePeriod);
         $methods = self::find()
             ->where(['verified' => 0])
-            ->andWhere(['<', 'verification_expires', MySqlDateTime::now()])
+            ->andWhere(['<', 'verification_expires', $removeOlderThan])
             ->all();
 
         foreach ($methods as $method) {

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -242,7 +242,7 @@ class Method extends MethodBase
      */
     protected function calculateExpirationDate(): string
     {
-        return MySqlDateTime::formatDateTime(time() + \Yii::$app->params['method']['lifetimeSeconds']);
+        return MySqlDateTime::relativeTime(\Yii::$app->params['method']['lifetime']);
     }
 
     /**

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -150,10 +150,10 @@ class Method extends MethodBase
          * Replace '+' with '-' so all env parameters can be defined consistently as '+n unit'
          */
         $methodGracePeriod = str_replace('+', '-', \Yii::$app->params['method']['gracePeriod']);
-        $removeOlderThan = MySqlDateTime::relativeTime($methodGracePeriod);
+        $removeExpireBefore = MySqlDateTime::relativeTime($methodGracePeriod);
         $methods = self::find()
             ->where(['verified' => 0])
-            ->andWhere(['<', 'verification_expires', $removeOlderThan])
+            ->andWhere(['<', 'verification_expires', $removeExpireBefore])
             ->all();
 
         foreach ($methods as $method) {

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -547,6 +547,16 @@ class User extends UserBase
     }
 
     /**
+     * @return Method[]
+     */
+    public function getUnverifiedMethods()
+    {
+        return array_filter($this->methods, function ($method) {
+            return $method->verified === 0;
+        });
+    }
+
+    /**
      * Return method-related properties to include in /user responses
      *
      * @return array method-related properties

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -2,6 +2,7 @@
 namespace console\controllers;
 
 use common\models\Invite;
+use common\models\Method;
 use common\models\Mfa;
 use common\models\User;
 use common\components\Emailer;
@@ -13,6 +14,12 @@ class CronController extends Controller
 {
     public function actionRemoveOldUnverifiedRecords()
     {
+        \Yii::warning([
+            'action' => 'delete old unverified method records',
+            'status' => 'starting',
+        ]);
+        Method::deleteExpiredUnverifiedMethods();
+
         \Yii::warning([
             'action' => 'delete old invite records',
             'status' => 'starting',

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -98,11 +98,17 @@ class CronController extends Controller
         \Yii::warning($gaEvents);
     }
 
-
     public function actionSendDelayedMfaRelatedEmails()
     {
         /* @var $emailer Emailer */
         $emailer = \Yii::$app->emailer;
         $emailer->sendDelayedMfaRelatedEmails();
+    }
+
+    public function actionSendMethodVerifyEmails()
+    {
+        /* @var $emailer Emailer */
+        $emailer = \Yii::$app->emailer;
+        $emailer->sendMethodVerifyEmails();
     }
 }

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -1,6 +1,7 @@
 <?php
 namespace console\controllers;
 
+use common\models\Invite;
 use common\models\Mfa;
 use common\models\User;
 use common\components\Emailer;
@@ -12,6 +13,12 @@ class CronController extends Controller
 {
     public function actionRemoveOldUnverifiedRecords()
     {
+        \Yii::warning([
+            'action' => 'delete old invite records',
+            'status' => 'starting',
+        ]);
+        Invite::deleteOldInvites();
+
         \Yii::warning([
             'action' => 'delete old unverified mfa records',
             'status' => 'starting',

--- a/application/frontend/controllers/MethodController.php
+++ b/application/frontend/controllers/MethodController.php
@@ -91,9 +91,6 @@ class MethodController extends BaseRestController
      */
     public function actionCreate()
     {
-        // ensure we don't use expired methods
-        Method::deleteExpiredUnverifiedMethods();
-
         $created = (string)\Yii::$app->request->post('created');
 
         $value = \Yii::$app->request->post('value');

--- a/dockerbuild/broker-cron
+++ b/dockerbuild/broker-cron
@@ -4,3 +4,4 @@
 
 0 1 * * * root /data/yii cron/google-analytics 2>&1 | /usr/bin/logger -t id-broker-cron
 0 2 * * * root /data/yii cron/send-delayed-mfa-related-emails 2>&1 | /usr/bin/logger -t id-broker-cron
+0 3 * * * root /data/yii cron/send-method-verify-emails 2>&1 | /usr/bin/logger -t id-broker-cron

--- a/local.env.dist
+++ b/local.env.dist
@@ -155,6 +155,9 @@ GA_CLIENT_ID=
 # time span before the invite code expires; defaults to "+1 month"
 #INVITE_LIFESPAN=
 
+# grace period after the invite lifespan, after which the invite will
+# be deleted; defaults to "+3 months"
+#INVITE_GRACE_PERIOD=
 
 
 # === LDAP parameters ===

--- a/local.env.dist
+++ b/local.env.dist
@@ -173,6 +173,9 @@ LDAP_USE_TLS="true"
 
 # === MFA parameters ===
 
+# MFA_lifetime defines the amount of time in which an MFA must be verified
+# defaults to "+2 hours"
+#MFA_lifetime=
 
 # Required parameters for TOTP service
 #MFA_TOTP_apiBaseUrl=

--- a/local.env.dist
+++ b/local.env.dist
@@ -1,12 +1,57 @@
-### Required ENV vars ###
+### ID Broker configuration parameters ###
+
+# Unless otherwise indicated, date and time periods must be specified in
+# PHP relative date format. Examples: "+30 days", "+15 minutes", "+4 weeks"
+# See http://php.net/manual/en/datetime.formats.relative.php
+# for details on this format.
+
+# Do not enclose values in quotation marks. Spaces are allowed if
+# appropriate for an individual parameter.
+
+# Parameters are required unless a default is shown or specifically
+# described as optional.
+
+
+# === IDP parameters ===
+
+# The code name of this IdP. Example: "org"
+IDP_NAME=
+
+
+# === email template data ===
+
+# The user-friendly version of the name of this IdP. For example:
+#IDP_DISPLAY_NAME=Some Organization
+IDP_DISPLAY_NAME=
+
+# URL of the help center
+HELP_CENTER_URL=
+
+# URL of the forgot password page on the password manager UI
+PASSWORD_FORGOT_URL=https://www.example.com/forgot
+
+# URL of the password manager UI
+PASSWORD_PROFILE_URL=https://www.example.com
+
+# help desk email address
+SUPPORT_EMAIL=
+
+# alternative name for support; defaults to "support"
+SUPPORT_NAME=
+
+# email signature line
+EMAIL_SIGNATURE=
+
+
+# === email service parameters ===
 
 EMAIL_SERVICE_accessToken=
 EMAIL_SERVICE_assertValidIp=
 EMAIL_SERVICE_baseUrl=
 EMAIL_SERVICE_validIpRanges=
 
-# The code name of this IdP. Example: "org"
-IDP_NAME=
+
+# === database parameters ===
 
 MYSQL_ROOT_PASSWORD=
 MYSQL_HOST=
@@ -14,24 +59,16 @@ MYSQL_DATABASE=
 MYSQL_USER=
 MYSQL_PASSWORD=
 
-# format is comma-separated tokens (no-space), e.g., test-cli-abc123,consumer-id-def456,something-unique-ghi789
+
+# === API authentication ===
+
+# access key for authentication with the ID Broker API; format is comma-
+# separated tokens (no-space), for example:
+#API_ACCESS_KEYS=test-cli-abc123,consumer-id-def456,something-unique-ghi789
 API_ACCESS_KEYS=
 
-HELP_CENTER_URL=
-PASSWORD_FORGOT_URL=https://www.example.com/forgot
-PASSWORD_PROFILE_URL=https://www.example.com
 
-SUPPORT_EMAIL=
-EMAIL_SIGNATURE=
-
-### Optional ENV vars ###
-
-# [prod|dev|test], app defaults to prod
-#APP_ENV=
-
-# The user-friendly version of the name of this IdP.
-# Example: "Some Organization"
-IDP_DISPLAY_NAME=Some Organization
+# === Google Analytics ===
 
 # UA-12345678-12 (i.e. the Google Analytics property id)
 GA_TRACKING_ID=
@@ -40,24 +77,39 @@ GA_TRACKING_ID=
 # IDP-<the name of the idp>-ID-BROKER
 GA_CLIENT_ID=
 
+
+# === Logentries ===
+
 # The "Log token" from the "Log Settings" pane on logentries.com  (not the "Log key")
 #LOGENTRIES_KEY=
-#COMPOSER_AUTH=
 
+
+# === email error notification ===
+
+# If this is defined, error messages will be sent to this email address.
 #NOTIFICATION_EMAIL=
 
-#SEND_INVITE_EMAILS=false
+
+# === user email parameters ===
+
+# Set the following to true or false to enable or disable each message type.
+# The default values are as listed here.
+#SEND_INVITE_EMAILS=true
 #SEND_MFA_RATE_LIMIT_EMAILS=true
 #SEND_PASSWORD_CHANGED_EMAILS=true
 #SEND_WELCOME_EMAILS=true
-#SEND_GET_BACKUP_CODES_EMAILS=false
-#SEND_REFRESH_BACKUP_CODES_EMAILS=false
-#SEND_LOST_SECURITY_KEY_EMAILS=false
-#SEND_MFA_OPTION_ADDED_EMAILS=false
-#SEND_MFA_OPTION_REMOVED_EMAILS=false
-#SEND_MFA_ENABLED_EMAILS=false
-#SEND_MFA_DISABLED_EMAILS=false
+# Sent when a user has no backup codes
+#SEND_GET_BACKUP_CODES_EMAILS=true
+# Sent when user is low on backup codes. See MINIMUM_BACKUP_CODES_BEFORE_NAG
+#SEND_REFRESH_BACKUP_CODES_EMAILS=true
+#SEND_LOST_SECURITY_KEY_EMAILS=true
+#SEND_MFA_OPTION_ADDED_EMAILS=true
+#SEND_MFA_OPTION_REMOVED_EMAILS=true
+#SEND_MFA_ENABLED_EMAILS=true
+#SEND_MFA_DISABLED_EMAILS=true
 
+# define the following to change the default subject line
+# default subjects are defined in application/common/components/Emailer.php
 #SUBJECT_FOR_INVITE=
 #SUBJECT_FOR_MFA_RATE_LIMIT=
 #SUBJECT_FOR_PASSWORD_CHANGED=
@@ -71,19 +123,41 @@ GA_CLIENT_ID=
 #SUBJECT_FOR_MFA_DISABLED=
 #SUBJECT_FOR_METHOD_VERIFY=
 
-#LOST_SECURITY_KEY_EMAIL_DAYS=62
-#MINIMUM_BACKUP_CODES_BEFORE_NAG=4
-#EMAIL_REPEAT_DELAY_DAYS=31
+# The number of days of not using a security key after which we email
+# the user. Defaults to 62.
+#LOST_SECURITY_KEY_EMAIL_DAYS=
 
+# Nag the user if they have FEWER than this number of backup codes
+# Defaults to 4
+#MINIMUM_BACKUP_CODES_BEFORE_NAG=
+
+# Don't resend the same type of email to the same user for X days
+# Defaults to 31
+#EMAIL_REPEAT_DELAY_DAYS=
+
+
+# === Password parameters ===
+
+# number of passwords to remember for "recent password" restriction
 # defaults to 10
 #PASSWORD_REUSE_LIMIT=
-# must be in PHP's relative date/time format (http://php.net/manual/en/datetime.formats.relative.php)
+
+# time span before which the user should set a new password
 # defaults to "+1 year"
 #PASSWORD_LIFESPAN=
-# defaults to "+30 days"
+
+# grace period after PASSWORD_LIFESPAN after which the account will
+# be locked; defaults to "+30 days"
 #PASSWORD_EXPIRATION_GRACE_PERIOD=
-# defaults to "+1 month"
+
+
+# === New user invite parameters ===
+# time span before the invite code expires; defaults to "+1 month"
 #INVITE_LIFESPAN=
+
+
+
+# === LDAP parameters ===
 
 # Whether to lazy-load passwords from an LDAP [true|false]. Defaults to false.
 #MIGRATE_PW_FROM_LDAP=
@@ -94,33 +168,60 @@ GA_CLIENT_ID=
 #LDAP_ADMIN_PASSWORD=
 #LDAP_DOMAIN_CONTROLLERS=
 #LDAP_USE_SSL=
-#LDAP_USE_TLS=
+LDAP_USE_TLS="true"
 
 
+# === MFA parameters ===
+
+
+# Required parameters for TOTP service
 #MFA_TOTP_apiBaseUrl=
 #MFA_TOTP_apiKey=
 #MFA_TOTP_apiSecret=
 
+# Required parameters for U2F service
 #MFA_U2F_apiBaseUrl=
 #MFA_U2F_apiKey=
 #MFA_U2F_apiSecret=
 #MFA_U2F_appId=
 
-#IP Address of development machine. Used for Xdebug connection.
-#REMOTE_DEBUG_IP=
+# === Password Recovery Method parameters ===
 
-#METHOD_lifetimeSeconds=3600
-#METHOD_codeLength=6
-#METHOD_maxAttempts=10
+# defines the expiration time -- the amount of time in which a recovery
+# method must be verified; defaults to "+1 hour"
+#METHOD_lifetimeSeconds=
 
-# User nag intervals for MFAs and Password Recovery Methods. Must be in PHP relative date format.
-# (See http://php.net/manual/en/datetime.formats.relative.php for details on this format.)
-# defaults to "+30 days"
+# number of digits in verification code; defaults to 6
+#METHOD_codeLength=
+
+# maximum number of verification attempts allowed; defaults to 10
+#METHOD_maxAttempts=
+
+
+# === User nag intervals for MFAs and Password Recovery Methods. ===
+
+# interval between reminders to add MFAs; defaults to "+30 days"
 #MFA_ADD_INTERVAL=
-# defaults to "+6 months"
+
+# interval between reminders to review existing MFAs; defaults to "+6 months"
 #MFA_REVIEW_INTERVAL=
-# defaults to "+6 months"
+
+# interval between reminders to add recovery methods; defaults to "+6 months"
 #METHOD_ADD_INTERVAL=
-# defaults to "+12 months"
+
+# interval between reminders to review existing recovery methods; defaults to "+12 months"
 #METHOD_REVIEW_INTERVAL=
 
+
+# === Debug and development ===
+
+# specify one of [prod|dev|test]; defaults to prod
+#APP_ENV=
+
+# === Composer ===
+# (optional) auth key for Composer to bypass GitHub rate limiting, example:
+#COMPOSER_AUTH={"github-oauth":{"github.com":"12341142b12441234c12414124d124e1234124f2"}}
+#COMPOSER_AUTH=
+
+# (optional) IP Address of development machine. Used for Xdebug connection.
+#REMOTE_DEBUG_IP=

--- a/local.env.dist
+++ b/local.env.dist
@@ -191,6 +191,10 @@ LDAP_USE_TLS="true"
 # method must be verified; defaults to "+1 hour"
 #METHOD_lifetime=
 
+# If a recovery method has been expired longer than this amount of time,
+# it will be removed; defaults to "+15 days"
+#METHOD_gracePeriod=
+
 # number of digits in verification code; defaults to 6
 #METHOD_codeLength=
 

--- a/local.env.dist
+++ b/local.env.dist
@@ -194,7 +194,7 @@ LDAP_USE_TLS="true"
 # === Password Recovery Method parameters ===
 
 # defines the expiration time -- the amount of time in which a recovery
-# method must be verified; defaults to "+1 week"
+# method must be verified; defaults to "+1 day"
 #METHOD_lifetime=
 
 # If a recovery method has been expired longer than this amount of time,

--- a/local.env.dist
+++ b/local.env.dist
@@ -194,11 +194,11 @@ LDAP_USE_TLS="true"
 # === Password Recovery Method parameters ===
 
 # defines the expiration time -- the amount of time in which a recovery
-# method must be verified; defaults to "+1 hour"
+# method must be verified; defaults to "+1 week"
 #METHOD_lifetime=
 
 # If a recovery method has been expired longer than this amount of time,
-# it will be removed; defaults to "+15 days"
+# it will be removed; defaults to "+1 week"
 #METHOD_gracePeriod=
 
 # number of digits in verification code; defaults to 6

--- a/local.env.dist
+++ b/local.env.dist
@@ -189,7 +189,7 @@ LDAP_USE_TLS="true"
 
 # defines the expiration time -- the amount of time in which a recovery
 # method must be verified; defaults to "+1 hour"
-#METHOD_lifetimeSeconds=
+#METHOD_lifetime=
 
 # number of digits in verification code; defaults to 6
 #METHOD_codeLength=


### PR DESCRIPTION
Defined a time following the expiration, but prior to removal of the `invite` and `method` records.
- method expiration now defaults to 1 week, with a 1-week grace period
- invite expiration defaults to 1 month, with a 3-month grace period

Also:
- recovery method verification emails are sent daily until verified or purged
- refactored `mfa` expiration and purge
- `invite` and `method` purge are now done daily by cron job