### PR TITLE
Change how personal_email is handled

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -171,14 +171,10 @@ class User extends UserBase
                 'require_mfa', 'default', 'value' => 'no', 'on' => self::SCENARIO_NEW_USER
             ],
             [
-                'nag_for_mfa_after',
-                'default',
-                'value' => MySqlDateTime::relative(\Yii::$app->params['mfaAddInterval']),
+                'nag_for_mfa_after', 'default', 'value' => MySqlDateTime::today(),
             ],
             [
-                'nag_for_method_after',
-                'default',
-                'value' => MySqlDateTime::relative(\Yii::$app->params['methodAddInterval']),
+                'nag_for_method_after', 'default', 'value' => MySqlDateTime::today(),
             ],
             [
                 ['active', 'locked', 'require_mfa', 'hide'], 'in', 'range' => ['yes', 'no'],

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -872,4 +872,15 @@ class User extends UserBase
 
         Method::findOrCreate($this->id, $this->personal_email, MySqlDateTime::now());
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function beforeSave($insert)
+    {
+        if ($insert == false && $this->personal_email !== $this->getOldAttribute('personal_email')) {
+            $this->nag_for_method_after = MySqlDateTime::relative('-1 day');
+        }
+        return parent::beforeSave($insert);
+    }
 }

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -851,38 +851,15 @@ class User extends UserBase
     }
 
     /**
-     * Update personal email in recovery methods table. On insert ($insert == true) the personal
-     * email address is added to the list of recovery methods. On update ($insert == false) the
-     * old personal email address is removed and the new one is added.
+     * Add personal email to recovery methods table. On insert ($insert == true) the personal
+     * email address is added to the list of recovery methods.
      * @param bool $insert
-     * @param string|null $oldPersonalEmail
+     * @throws \yii\web\ConflictHttpException
+     * @throws \yii\web\ServerErrorHttpException
      */
-    public function updateRecoveryMethods(bool $insert, $oldPersonalEmail)
+    public function updateRecoveryMethods(bool $insert)
     {
-        if ($insert === false && $oldPersonalEmail !== null) {
-            $oldMethod = Method::findOne(['value' => $oldPersonalEmail, 'user_id' => $this->id]);
-            if ($oldMethod === null) {
-                \Yii::warning([
-                    'action' => 'look up old personal email',
-                    'status' => 'notice',
-                    'employee_id' => $this->employee_id,
-                    'email' => $oldPersonalEmail,
-                    'message' => 'failed to locate old personal email in method table',
-                ]);
-            } else {
-                if ($oldMethod->delete() === false) {
-                    \Yii::error([
-                        'action' => 'delete old personal email',
-                        'status' => 'error',
-                        'employee_id' => $this->employee_id,
-                        'email' => $oldPersonalEmail,
-                        'message' => 'failed to delete old personal email from method table'
-                    ]);
-                };
-            }
-        }
-
-        if ($this->personal_email === null) {
+        if ($this->personal_email === null || $insert == false) {
             return;
         }
 

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -171,10 +171,14 @@ class User extends UserBase
                 'require_mfa', 'default', 'value' => 'no', 'on' => self::SCENARIO_NEW_USER
             ],
             [
-                'nag_for_mfa_after', 'default', 'value' => MySqlDateTime::today(),
+                'nag_for_mfa_after',
+                'default',
+                'value' => MySqlDateTime::relative(\Yii::$app->params['mfaAddInterval']),
             ],
             [
-                'nag_for_method_after', 'default', 'value' => MySqlDateTime::today(),
+                'nag_for_method_after',
+                'default',
+                'value' => MySqlDateTime::relative(\Yii::$app->params['methodAddInterval']),
             ],
             [
                 ['active', 'locked', 'require_mfa', 'hide'], 'in', 'range' => ['yes', 'no'],

--- a/application/features/bootstrap/FeatureContext.php
+++ b/application/features/bootstrap/FeatureContext.php
@@ -602,4 +602,13 @@ class FeatureContext extends YiiContext
             'method should have been deleted but still exists'
         );
     }
+
+    /**
+     * @Then the method review date should be past
+     */
+    public function theMethodReviewDateShouldBePast()
+    {
+        $this->userFromDb->refresh();
+        Assert::true(MySqlDateTime::isBefore($this->userFromDb->nag_for_method_after, time()));
+    }
 }

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -494,45 +494,61 @@ Feature: User
     And a record exists with an employee_id of "123"
     And a method record does not exist with a value of "shep_clark@example.org"
 
-  Scenario: Update a user with a personal email address, expect a recovery method to be added.
+  Scenario: Update a user with a personal email address, expect a recovery method NOT to be added.
     Given a record does not exist with an employee_id of "123"
-    And the requester is authorized
-    And I provide the following valid data:
-      | property        | value                 |
-      | employee_id     | 123                   |
-      | first_name      | Shep                  |
-      | last_name       | Clark                 |
-      | username        | shep_clark            |
-      | email           | shep_clark@example.org|
-    And I request "/user" be created
-    And the response status code should be 200
-    And a record exists with an employee_id of "123"
-    And I change the personal_email to my@example.com
+      And the requester is authorized
+      And I provide the following valid data:
+        | property        | value                 |
+        | employee_id     | 123                   |
+        | first_name      | Shep                  |
+        | last_name       | Clark                 |
+        | username        | shep_clark            |
+        | email           | shep_clark@example.org|
+      And I request "/user" be created
+      And the response status code should be 200
+      And a record exists with an employee_id of "123"
+      And I change the personal_email to my@example.com
     When I request "/user/123" be updated
     Then the response status code should be 200
-    And a record exists with a personal_email of my@example.com
-    And a method record exists with a value of "my@example.com"
-    And the method record is marked as verified
+      And a record exists with a personal_email of my@example.com
+      And a method record does not exist with a value of "my@example.com"
 
-  Scenario: Update a user to change the personal email address, expect a recovery method to be added
-  and the previous method to be deleted.
+  Scenario: Update a user to change the personal email address, expect recovery methods to be unchanged
     Given a record does not exist with an employee_id of "123"
-    And the requester is authorized
-    And I provide the following valid data:
-      | property        | value                 |
-      | employee_id     | 123                   |
-      | first_name      | Shep                  |
-      | last_name       | Clark                 |
-      | username        | shep_clark            |
-      | email           | shep_clark@example.org|
-      | personal_email  | old@example.com       |
-    And I request "/user" be created
-    And the response status code should be 200
-    And a record exists with an employee_id of "123"
-    And I change the personal_email to new@example.com
+      And the requester is authorized
+      And I provide the following valid data:
+        | property        | value                 |
+        | employee_id     | 123                   |
+        | first_name      | Shep                  |
+        | last_name       | Clark                 |
+        | username        | shep_clark            |
+        | email           | shep_clark@example.org|
+        | personal_email  | old@example.com       |
+      And I request "/user" be created
+      And the response status code should be 200
+      And a record exists with an employee_id of "123"
+      And I change the personal_email to new@example.com
     When I request "/user/123" be updated
     Then the response status code should be 200
-    And a record exists with a personal_email of new@example.com
-    And a method record exists with a value of "new@example.com"
-    And the method record is marked as verified
-    And a method record does not exist with a value of "old@example.com"
+      And a record exists with a personal_email of new@example.com
+      And a method record exists with a value of "old@example.com"
+      And a method record does not exist with a value of "new@example.com"
+
+  Scenario: Update a user to change the personal email address, expect review date to be past
+    Given a record does not exist with an employee_id of "123"
+      And the requester is authorized
+      And I provide the following valid data:
+        | property        | value                 |
+        | employee_id     | 123                   |
+        | first_name      | Shep                  |
+        | last_name       | Clark                 |
+        | username        | shep_clark            |
+        | email           | shep_clark@example.org|
+        | personal_email  | old@example.com       |
+      And I request "/user" be created
+      And the response status code should be 200
+      And a record exists with an employee_id of "123"
+      And I change the personal_email to new@example.com
+    When I request "/user/123" be updated
+    Then the response status code should be 200
+      And the method review date should be past


### PR DESCRIPTION
- don't make any changes to recovery methods when `personal_email` is changed
- set the profile review date for recovery methods to yesterday when `personal_email` is changed