### PR TITLE
Create contingent user

### DIFF
--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -339,7 +339,7 @@ class Emailer extends Component
         $textView = $this->getViewForMessage($messageType, 'text');
         
         $this->email(
-            $data['toAddress'] ?? $user->email ?? $user->personal_email,
+            $data['toAddress'] ?? $user->getEmailAddress(),
             $this->getSubjectForMessage($messageType, $dataForEmail),
             \Yii::$app->view->render($htmlView, $dataForEmail),
             \Yii::$app->view->render($textView, $dataForEmail),

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -339,7 +339,7 @@ class Emailer extends Component
         $textView = $this->getViewForMessage($messageType, 'text');
         
         $this->email(
-            $data['toAddress'] ?? $user->email,
+            $data['toAddress'] ?? $user->email ?? $user->personal_email,
             $this->getSubjectForMessage($messageType, $dataForEmail),
             \Yii::$app->view->render($htmlView, $dataForEmail),
             \Yii::$app->view->render($textView, $dataForEmail),

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -219,5 +219,6 @@ return [
             Env::getArrayFromPrefix('METHOD_')
         ),
         'mfaLifetime' => Env::get('MFA_LIFETIME', '+2 hours'),
+        'contingentUserDuration' => Env::get('CONTINGENT_USER_DURATION', '+4 weeks'),
     ],
 ];

--- a/application/common/models/Mfa.php
+++ b/application/common/models/Mfa.php
@@ -126,7 +126,7 @@ class Mfa extends MfaBase
         \Yii::warning([
             'action' => 'delete mfa',
             'type' => $this->type,
-            'user' => $this->user->email,
+            'username' => $this->user->username,
             'status' => 'success',
         ]);
 
@@ -167,7 +167,7 @@ class Mfa extends MfaBase
         \Yii::warning([
             'action' => 'mfa auth init',
             'type' => $this->type,
-            'user' => $this->user->email,
+            'username' => $this->user->username,
             'status' => 'success',
         ]);
 
@@ -190,7 +190,7 @@ class Mfa extends MfaBase
             \Yii::warning([
                 'action' => 'verify mfa',
                 'type' => $this->type,
-                'user' => $this->user->email,
+                'username' => $this->user->username,
                 'status' => 'error',
                 'error' => 'too many recent failures'
             ]);
@@ -206,7 +206,7 @@ class Mfa extends MfaBase
                 \Yii::error([
                     'action' => 'update last_used_utc on mfa after verification',
                     'status' => 'error',
-                    'user' => $this->user->email,
+                    'username' => $this->user->username,
                     'mfa_id' => $this->id,
                     'error' => $this->getFirstErrors(),
                 ]);
@@ -216,7 +216,7 @@ class Mfa extends MfaBase
             \Yii::warning([
                 'action' => 'verify mfa',
                 'type' => $this->type,
-                'user' => $this->user->email,
+                'username' => $this->user->username,
                 'status' => 'success',
             ]);
             return true;
@@ -227,7 +227,7 @@ class Mfa extends MfaBase
         \Yii::warning([
             'action' => 'verify mfa',
             'type' => $this->type,
-            'user' => $this->user->email,
+            'username' => $this->user->username,
             'status' => 'error',
             'error' => 'verify mfa failed'
         ]);
@@ -285,7 +285,7 @@ class Mfa extends MfaBase
                 \Yii::error([
                     'action' => 'create mfa',
                     'type' => $type,
-                    'user' => $user->email,
+                    'username' => $user->username,
                     'status' => 'error',
                     'error' => $mfa->getFirstErrors(),
                 ]);
@@ -303,7 +303,7 @@ class Mfa extends MfaBase
                 \Yii::error([
                     'action' => 'update mfa',
                     'type' => $type,
-                    'user' => $user->email,
+                    'username' => $user->username,
                     'status' => 'error',
                     'error' => $mfa->getFirstErrors(),
                 ]);
@@ -314,7 +314,7 @@ class Mfa extends MfaBase
         \Yii::warning([
             'action' => 'create mfa',
             'type' => $type,
-            'user' => $user->email,
+            'username' => $user->username,
             'status' => 'success',
         ]);
 
@@ -396,7 +396,7 @@ class Mfa extends MfaBase
                 'mfa_id' => $this->id,
                 'mfa_type' => $this->type,
                 'status' => 'warning',
-                'user' => $this->user->email,
+                'username' => $this->user->username,
             ]);
             
             /* @var $emailer Emailer */

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -205,6 +205,11 @@ class User extends UserBase
                 ['last_synced_utc', 'last_changed_utc'],
                 'default', 'value' => MySqlDateTime::now(),
             ],
+            [
+                'expires_on',
+                'default',
+                'value' => $this->getExpiresOnInitialValue(),
+            ],
         ], parent::rules());
     }
 
@@ -799,5 +804,17 @@ class User extends UserBase
             $this->review_profile_after = MySqlDateTime::relative('-1 day');
         }
         return parent::beforeSave($insert);
+    }
+
+    /**
+     * @return string
+     */
+    public function getExpiresOnInitialValue(): string
+    {
+        if ($this->email === null) {
+            return MySqlDateTime::relative(\Yii::$app->params['contingentUserDuration']);
+        } else {
+            return null;
+        }
     }
 }

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -210,6 +210,11 @@ class User extends UserBase
                 'default',
                 'value' => $this->getExpiresOnInitialValue(),
             ],
+            [
+                'email', 'required', 'when' => function ($model) {
+                    return $model->personal_email === null;
+                }
+            ],
         ], parent::rules());
     }
 

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -827,4 +827,24 @@ class User extends UserBase
     {
         return $this->email ?? $this->personal_email;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function afterFind()
+    {
+        if ($this->expires_on !== null && MySqlDateTime::isBefore($this->expires_on, time())) {
+            $this->active = 'no';
+
+            Yii::warning([
+                'event' => 'onAfterFind',
+                'status' => 'user is expired',
+                'employeeId' => $this->employee_id,
+                'scenario' => $this->scenario,
+                'expires_on' => $this->expires_on
+            ], 'application');
+        }
+
+        parent::afterFind();
+    }
 }

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -825,7 +825,7 @@ class User extends UserBase
      */
     public function getEmailAddress(): string
     {
-        return $this->email ?? $this->personal_email;
+        return $this->email ?? $this->personal_email ?? '';
     }
 
     /**

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -825,9 +825,9 @@ class User extends UserBase
     {
         if ($this->email === null) {
             return MySqlDateTime::relative(\Yii::$app->params['contingentUserDuration']);
-        } else {
-            return null;
         }
+
+        return null;
     }
 
     /**

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -810,6 +810,11 @@ class User extends UserBase
         if ($insert == false && $this->personal_email !== $this->getOldAttribute('personal_email')) {
             $this->review_profile_after = MySqlDateTime::relative('-1 day');
         }
+
+        if ($this->getOldAttribute('email') !== null && $this->email === null) {
+            $this->addError('email', 'email cannot be updated to null');
+        }
+
         return parent::beforeSave($insert);
     }
 

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -809,9 +809,9 @@ class User extends UserBase
     }
 
     /**
-     * @return string
+     * @return string:null
      */
-    public function getExpiresOnInitialValue(): string
+    public function getExpiresOnInitialValue()
     {
         if ($this->email === null) {
             return MySqlDateTime::relative(\Yii::$app->params['contingentUserDuration']);

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -326,7 +326,7 @@ class User extends UserBase
             'lastName' => $this->last_name,
             'displayName' => $this->getDisplayName(),
             'username' => $this->username,
-            'email' => $this->email,
+            'email' => $this->getEmailAddress(),
             'active' => $this->active,
             'locked' => $this->locked,
             'lastChangedUtc' => MySqlDateTime::formatDateForHumans($this->last_changed_utc),
@@ -420,7 +420,9 @@ class User extends UserBase
                 return $model->getDisplayName();
             },
             'username',
-            'email',
+            'email' => function (self $model) {
+                return $model->getEmailAddress();
+            },
             'active',
             'locked',
             'last_login_utc' => function (self $model) {
@@ -816,5 +818,13 @@ class User extends UserBase
         } else {
             return null;
         }
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmailAddress(): string
+    {
+        return $this->email ?? $this->personal_email;
     }
 }

--- a/application/common/models/UserBase.php
+++ b/application/common/models/UserBase.php
@@ -27,6 +27,7 @@ use Yii;
  * @property string $groups
  * @property string $personal_email
  * @property string $review_profile_after
+ * @property string $expires_on
  *
  * @property EmailLog[] $emailLogs
  * @property Invite[] $invites
@@ -50,10 +51,10 @@ class UserBase extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['uuid', 'employee_id', 'first_name', 'last_name', 'username', 'email', 'active', 'locked', 'last_changed_utc', 'last_synced_utc', 'review_profile_after'], 'required'],
+            [['uuid', 'employee_id', 'first_name', 'last_name', 'username', 'active', 'locked', 'last_changed_utc', 'last_synced_utc', 'review_profile_after'], 'required'],
             [['current_password_id'], 'integer'],
             [['active', 'locked', 'require_mfa', 'hide'], 'string'],
-            [['last_changed_utc', 'last_synced_utc', 'last_login_utc', 'review_profile_after'], 'safe'],
+            [['last_changed_utc', 'last_synced_utc', 'last_login_utc', 'review_profile_after', 'expires_on'], 'safe'],
             [['uuid'], 'string', 'max' => 64],
             [['employee_id', 'first_name', 'last_name', 'display_name', 'username', 'email', 'manager_email', 'groups', 'personal_email'], 'string', 'max' => 255],
             [['employee_id'], 'unique'],
@@ -89,6 +90,7 @@ class UserBase extends \yii\db\ActiveRecord
             'groups' => Yii::t('app', 'Groups'),
             'personal_email' => Yii::t('app', 'Personal Email'),
             'review_profile_after' => Yii::t('app', 'Review Profile After'),
+            'expires_on' => Yii::t('app', 'Expires On'),
         ];
     }
 

--- a/application/console/migrations/m190314_014900_add_expiration_column_to_user_table.php
+++ b/application/console/migrations/m190314_014900_add_expiration_column_to_user_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Handles adding expiration to table `user`.
+ */
+class m190314_014900_add_expiration_column_to_user_table extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{user}}', 'expires_on', 'date null');
+        $this->alterColumn('{{user}}', 'email', 'varchar(255)');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->alterColumn('{{user}}', 'email', 'varchar(255) not null');
+        $this->dropColumn('{{user}}', 'expires_on');
+    }
+}

--- a/application/features/authentication.feature
+++ b/application/features/authentication.feature
@@ -248,3 +248,39 @@ Feature: Authentication
 # TODO: need test for check that a user's password is good all the way until midnight of the expiration/grace period dates
 # TODO: need test to allow username or email address to be used for authentication
 
+  Scenario: Authenticate a "contingent" user with an invite code
+    Given I provide the following valid data:
+        | property        | value                 |
+        | employee_id     | 456                   |
+        | first_name      | New                   |
+        | last_name       | Guy                   |
+        | username        | new_guy               |
+        | email           | null                  |
+        | personal_email  | personal@example.com  |
+      And I request "/user" be created
+      And the response status code should be 200
+      And the user "new_guy" has a non-expired invite code "xyz123"
+      And I provide the following valid data:
+        | property  | value       |
+        | invite    | xyz123      |
+    When I request "/authentication" be created
+    Then the response status code should be 200
+
+  Scenario: Attempt to authenticate an expired "contingent" user with an invite code
+    Given I provide the following valid data:
+        | property        | value                 |
+        | employee_id     | 456                   |
+        | first_name      | New                   |
+        | last_name       | Guy                   |
+        | username        | new_guy               |
+        | email           | null                  |
+        | personal_email  | personal@example.com  |
+      And I request "/user" be created
+      And the response status code should be 200
+      And the user "new_guy" has a non-expired invite code "xyz123"
+      And the user record for "new_guy" has expired
+      And I provide the following valid data:
+        | property  | value       |
+        | invite    | xyz123      |
+    When I request "/authentication" be created
+    Then the response status code should be 400

--- a/application/features/bootstrap/FeatureContext.php
+++ b/application/features/bootstrap/FeatureContext.php
@@ -270,7 +270,7 @@ class FeatureContext extends YiiContext
     public function iProvideTheFollowingValidData(TableNode $data)
     {
         foreach ($data as $row) {
-            $this->reqBody[$row['property']] = $row['value'];
+            $this->reqBody[$row['property']] = ($row['value'] === 'null' ? null : $row['value']);
         }
     }
 
@@ -628,5 +628,16 @@ class FeatureContext extends YiiContext
     {
         $this->userFromDb->refresh();
         Assert::true(MySqlDateTime::isBefore($this->userFromDb->review_profile_after, time()));
+    }
+
+    /**
+     * @Given the user record for :username has expired
+     */
+    public function theUserRecordForHasExpired($username)
+    {
+        $user = User::findByUsername($username);
+        $user->expires_on = '2000-01-01';
+        $user->scenario = User::SCENARIO_UPDATE_USER;
+        Assert::true($user->save());
     }
 }

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -23,7 +23,7 @@ Feature: User
     When I request "/user" be created
     Then the response status code should be 200
       And the following data is returned:
-        | property      | value                 |
+        | property        | value                 |
 #TODO:need to ensure uuid came back but not sure about value...
         | employee_id     | 123                   |
         | first_name      | Shep                  |
@@ -523,3 +523,42 @@ Feature: User
     When I request "/user/123" be updated
     Then the response status code should be 200
       And the profile review date should be past
+
+  Scenario: Add a user with personal email address and no primary email address
+    Given a record does not exist with an employee_id of "123"
+      And the requester is authorized
+      And I provide the following valid data:
+        | property        | value                 |
+        | employee_id     | 123                   |
+        | first_name      | New                   |
+        | last_name       | Guy                   |
+        | username        | new_guy               |
+        | personal_email  | personal@example.com  |
+    When I request "/user" be created
+    Then the response status code should be 200
+      And a record exists with an employee_id of "123"
+      And the following data is returned:
+        | property        | value                 |
+        | employee_id     | 123                   |
+        | email           | personal@example.com  |
+        | active          | yes                   |
+        | locked          | no                    |
+        | personal_email  | personal@example.com  |
+
+  Scenario: Attempt to update email to null
+    Given the requester is authorized
+      And I provide the following valid data:
+        | property        | value                 |
+        | employee_id     | 123                   |
+        | first_name      | Established           |
+        | last_name       | User                  |
+        | username        | established_user      |
+        | email           | primary@example.com   |
+      And I request "/user" be created
+      And the response status code should be 200
+      And I provide the following valid data:
+        | property       | value                  |
+        | email          | null                   |
+        | personal_email | personal@example.org   |
+    When I request "/user/123" be updated
+    Then the response status code should be 422

--- a/application/frontend/controllers/AuthenticationController.php
+++ b/application/frontend/controllers/AuthenticationController.php
@@ -19,18 +19,36 @@ class AuthenticationController extends BaseRestController
     {
         $migratePasswords = Yii::$app->params['migratePasswordsFromLdap'];
 
+        $username = (string)Yii::$app->request->getBodyParam('username');
+        $password = (string)Yii::$app->request->getBodyParam('password');
+        $inviteCode = (string)Yii::$app->request->getBodyParam('invite');
+
         $authentication = new Authentication(
-            (string)Yii::$app->request->getBodyParam('username'),
-            (string)Yii::$app->request->getBodyParam('password'),
+            $username,
+            $password,
             $migratePasswords ? Yii::$app->ldap : null,
-            (string)Yii::$app->request->getBodyParam('invite')
+            $inviteCode
         );
 
         $authenticatedUser = $authentication->getAuthenticatedUser();
 
+        $log = [
+            'action' => 'authentication/create',
+            'username' => $username,
+            'password' => empty($password) ? 'no' : 'yes',
+            'invite' => empty($inviteCode) ? 'no' : 'yes',
+        ];
+
         if ($authenticatedUser !== null) {
+            $log['status'] = 'created';
+            Yii::info($log, 'application');
+
             return $authenticatedUser;
         }
+
+        $log['status'] = 'failed';
+        $log['errors'] = $authentication->getErrors();
+        Yii::warning($log, 'application');
 
         throw new BadRequestHttpException();
     }

--- a/application/frontend/controllers/UserController.php
+++ b/application/frontend/controllers/UserController.php
@@ -41,6 +41,14 @@ class UserController extends BaseRestController
          */
         $user->refresh();
 
+        Yii::info([
+            'action' => 'user/create',
+            'status' => 'created',
+            'id' => $user->id,
+            'employeeId' => $user->employee_id,
+            'scenario' => $user->scenario,
+        ], 'application');
+
         return $user;
     }
 

--- a/local.env.dist
+++ b/local.env.dist
@@ -220,6 +220,12 @@ LDAP_USE_TLS="true"
 #PROFILE_REVIEW_INTERVAL=
 
 
+# === Creation of new "contingent" user with no primary email address. ===
+
+# time before expiration of a "contingent" user
+#CONTINGENT_USER_DURATION=+4 weeks
+
+
 # === Debug and development ===
 
 # specify one of [prod|dev|test]; defaults to prod


### PR DESCRIPTION
Allows for creation of a "contingent" user -- a user that is in the onboarding process, needs access, but does not yet have a primary email address.
- Adds concept of user record expiration, set to 4 weeks by default, and not defined for normal user creation
- `personal_email` is provided everywhere that `email` is needed if `email` is `null`: outgoing email message "To" header, email template variable, and API responses
- `email` can only be set to `null` on initial creation of a user record, and only if `personal_email` is not `null`