### PR TITLE
extract class NagState

### DIFF
--- a/application/common/models/NagState.php
+++ b/application/common/models/NagState.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace common\models;
+
+use \Exception;
+use common\helpers\MySqlDateTime;
+
+class NagState
+{
+    const NAG_NONE           = 'none';
+    const NAG_ADD_MFA        = 'add_mfa';
+    const NAG_ADD_METHOD     = 'add_method';
+    const NAG_PROFILE_REVIEW = 'profile_review';
+
+    /** @var string */
+    private $state;
+
+    /** @var string */
+    private $nagForMfaAfter;
+
+    /** @var string */
+    private $nagForMethodAfter;
+
+    /** @var string */
+    private $reviewProfileAfter;
+
+    /** @var int */
+    private $numberOfVerifiedMfas;
+
+    /** @var int */
+    private $numberOfVerifiedMethods;
+
+    public function __construct(
+        $nagForMfaAfter,
+        $nagForMethodAfter,
+        $reviewProfileAfter,
+        $numberOfVerifiedMfas,
+        $numberOfVerifiedMethods
+    ) {
+        $state = null;
+        $this->nagForMfaAfter = $nagForMfaAfter;
+        $this->nagForMethodAfter = $nagForMethodAfter;
+        $this->reviewProfileAfter = $reviewProfileAfter;
+        $this->numberOfVerifiedMfas = $numberOfVerifiedMfas;
+        $this->numberOfVerifiedMethods = $numberOfVerifiedMethods;
+    }
+
+    /**
+     * @uses isTimeToNagToAddMfa()
+     * @uses isTimeToNagToAddMethod()
+     * @uses isTimeForReview()
+     * @return int|string
+     */
+    public function getState()
+    {
+        /*
+         * Don't recalculate in case the date has changed since the last calculation.
+         */
+        if ($this->state !== null) {
+            return $this->state;
+        }
+
+        $possibleNags = [
+            self::NAG_ADD_MFA => 'isTimeToNagToAddMfa',
+            self::NAG_ADD_METHOD => 'isTimeToNagToAddMethod',
+            self::NAG_PROFILE_REVIEW => 'isTimeForReview',
+        ];
+
+        $now = time();
+        foreach ($possibleNags as $nagType => $isTime) {
+            if ($this->$isTime($now)) {
+                $this->state = $nagType;
+                return $this->state;
+            }
+        }
+        return self::NAG_NONE;
+    }
+
+    /**
+     * Based on provided time, determine whether to present a reminder to add
+     * an MFA option.
+     * @param int $now
+     * @return bool
+     * @throws Exception
+     * @usedby getState()
+     */
+    private function isTimeToNagToAddMfa(int $now): bool
+    {
+        return $this->numberOfVerifiedMfas === 0 && MySqlDateTime::isBefore($this->nagForMfaAfter, $now);
+    }
+
+    /**
+     * Based on provided time, determine whether to present a reminder to add
+     * a recovery method option.
+     * @param int $now
+     * @return bool
+     * @throws Exception
+     * @usedby getState()
+     */
+    private function isTimeToNagToAddMethod(int $now): bool
+    {
+        return $this->numberOfVerifiedMethods === 0 && MySqlDateTime::isBefore($this->nagForMethodAfter, $now);
+    }
+
+    /**
+     * Based on provided time, determine whether to present a profile review to
+     * the user.
+     * @param int $now
+     * @return bool
+     * @throws Exception
+     * @usedby getState()
+     */
+    private function isTimeForReview(int $now)
+    {
+        return MySqlDateTime::isBefore($this->reviewProfileAfter, $now);
+    }
+}

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -7,7 +7,6 @@ use common\components\Emailer;
 use common\helpers\MySqlDateTime;
 use common\helpers\Utils;
 use common\ldap\Ldap;
-use common\models\Method;
 use Exception;
 use Ramsey\Uuid\Uuid;
 use Yii;
@@ -24,19 +23,14 @@ class User extends UserBase
     const SCENARIO_AUTHENTICATE    = 'authenticate';
     const SCENARIO_INVITE          = 'invite';
 
-    const NAG_NONE           = 'none';
-    const NAG_ADD_MFA        = 'add_mfa';
-    const NAG_ADD_METHOD     = 'add_method';
-    const NAG_PROFILE_REVIEW = 'profile_review';
-
     /** @var string */
     public $password;
 
     /** @var Ldap */
     private $ldap;
 
-    /** @var string */
-    protected $nagState;
+    /** @var NagState */
+    protected $nagState = null;
 
     /**
      * {@inheritdoc}
@@ -517,7 +511,7 @@ class User extends UserBase
                 return $model->getMethodFields();
             },
             'profile_review' => function (self $model) {
-                return $model->getNagState() == self::NAG_PROFILE_REVIEW ? 'yes' : 'no';
+                return $model->getNagState() == NagState::NAG_PROFILE_REVIEW ? 'yes' : 'no';
             }
         ];
 
@@ -586,25 +580,17 @@ class User extends UserBase
      */
     public function getNagState()
     {
-        /*
-         * Don't recalculate in case the date has changed since the last calculation.
-         */
-        if ($this->nagState !== null) {
-            return $this->nagState;
+        if ($this->nagState === null) {
+            $this->nagState = new NagState(
+                $this->nag_for_mfa_after,
+                $this->nag_for_method_after,
+                $this->review_profile_after,
+                count($this->getVerifiedMfaOptions()),
+                count($this->getVerifiedMethodOptions())
+            );
         }
-        $possibleNags = [
-            self::NAG_ADD_MFA => 'isTimeToNagToAddMfa',
-            self::NAG_ADD_METHOD => 'isTimeToNagToAddMethod',
-            self::NAG_PROFILE_REVIEW => 'isTimeForReview',
-        ];
-        $now = time();
-        foreach ($possibleNags as $nagType => $isTime) {
-            if ($this->$isTime($now)) {
-                $this->nagState = $nagType;
-                return $this->nagState;
-            }
-        }
-        return self::NAG_NONE;
+
+        return $this->nagState->getState();
     }
 
 
@@ -615,7 +601,7 @@ class User extends UserBase
     {
         return [
             'prompt'  => $this->isPromptForMfa() ? 'yes' : 'no',
-            'add'     => $this->getNagState() == self::NAG_ADD_MFA ? 'yes' : 'no',
+            'add'     => $this->getNagState() == NagState::NAG_ADD_MFA ? 'yes' : 'no',
             'options' => $this->getVerifiedMfaOptions(),
         ];
     }
@@ -665,11 +651,11 @@ class User extends UserBase
      */
     public function getMethodFields()
     {
-        $shouldProvideMethodOptions = $this->getNagState() === self::NAG_PROFILE_REVIEW
+        $shouldProvideMethodOptions = $this->getNagState() === NagState::NAG_PROFILE_REVIEW
             && $this->scenario == self::SCENARIO_AUTHENTICATE;
 
         return [
-            'add' => $this->getNagState() == self::NAG_ADD_METHOD ? 'yes' : 'no',
+            'add' => $this->getNagState() == NagState::NAG_ADD_METHOD ? 'yes' : 'no',
             'options' => $shouldProvideMethodOptions ? $this->methods : [],
         ];
     }
@@ -911,13 +897,13 @@ class User extends UserBase
     public function updateProfileReviewDates()
     {
         switch ($this->getNagState()) {
-            case self::NAG_ADD_MFA:
+            case NagState::NAG_ADD_MFA:
                 $this->nag_for_mfa_after = MySqlDateTime::relative(\Yii::$app->params['mfaAddInterval']);
                 break;
-            case self::NAG_ADD_METHOD:
+            case NagState::NAG_ADD_METHOD:
                 $this->nag_for_method_after = MySqlDateTime::relative(\Yii::$app->params['methodAddInterval']);
                 break;
-            case self::NAG_PROFILE_REVIEW:
+            case NagState::NAG_PROFILE_REVIEW:
                 $this->review_profile_after = MySqlDateTime::relative(\Yii::$app->params['profileReviewInterval']);
                 break;
         }


### PR DESCRIPTION
I pulled out the core logic of the nag processing. To extract lines like this
```
$this->getNagState() == NagState::NAG_ADD_MFA ? 'yes' : 'no',
```
adds complexity in initializing the NagState object. Could be worth it, but probably not. I didn't touch the actual nag dates (making them dependent on the presence/absence of mfa/method data) but may do that separately. 