### PR TITLE
Password recovery method verification reminders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- Added recovery method reminder email, replacing daily method verify emails
 
 ## [4.1.1] - 2019-04-18
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - Added recovery method reminder email, replacing daily method verify emails
+- Send an email notice when an unverified recovery email is purged
 
 ## [4.1.1] - 2019-04-18
 ### Fixed

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -350,18 +350,19 @@ class Emailer extends Component
             $this->otherDataForEmails,
             $data
         );
-        
+
         $htmlView = $this->getViewForMessage($messageType, 'html');
+        $htmlBody = \Yii::$app->view->render($htmlView, $dataForEmail);
+
         $textView = $this->getViewForMessage($messageType, 'text');
-        
-        $this->email(
-            $data['toAddress'] ?? $user->getEmailAddress(),
-            $this->getSubjectForMessage($messageType, $dataForEmail),
-            \Yii::$app->view->render($htmlView, $dataForEmail),
-            \Yii::$app->view->render($textView, $dataForEmail),
-            $data['ccAddress'] ?? ''
-        );
-        
+        $textBody = \Yii::$app->view->render($textView, $dataForEmail);
+
+        $toAddress = $data['toAddress'] ?? $user->getEmailAddress();
+        $ccAddress = $data['ccAddress'] ?? '';
+        $subject = $this->getSubjectForMessage($messageType, $dataForEmail);
+
+        $this->email($toAddress, $subject, $htmlBody, $textBody, $ccAddress);
+
         EmailLog::logMessage($messageType, $user->id);
     }
 

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -615,7 +615,7 @@ class Emailer extends Component
     }
 
     /**
-     * Iterates over all unverified methods sends reminder emails to the user as appropriate
+     * Iterates over all unverified methods and sends reminder emails to the user as appropriate
      */
     public function sendMethodReminderEmails()
     {

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -35,6 +35,8 @@ class Emailer extends Component
 
     const SUBJ_METHOD_VERIFY = 'Please verify your new password recovery method';
     const SUBJ_METHOD_REMINDER = 'REMINDER: Please verify your new password recovery method';
+    const SUBJ_METHOD_PURGED = 'An unverified password recovery method has been removed from your {idpDisplayName}'
+        . ' account';
 
     const PROP_SUBJECT = 'subject';
     const PROP_TO_ADDRESS = 'to_address';
@@ -84,6 +86,7 @@ class Emailer extends Component
     public $sendMfaDisabledEmails = true;
 
     public $sendMethodReminderEmails = true;
+    public $sendMethodPurgedEmails = true;
 
     /**
      * The list of subjects, keyed on message type. This is initialized during
@@ -111,6 +114,7 @@ class Emailer extends Component
 
     public $subjectForMethodVerify;
     public $subjectForMethodReminder;
+    public $subjectForMethodPurged;
 
     /* The number of days of not using a security key after which we email the user */
     public $lostSecurityKeyEmailDays;
@@ -287,6 +291,7 @@ class Emailer extends Component
 
         $this->subjectForMethodVerify = $this->subjectForMethodVerify ?? self::SUBJ_METHOD_VERIFY;
         $this->subjectForMethodReminder = $this->subjectForMethodReminder ?? self::SUBJ_METHOD_REMINDER;
+        $this->subjectForMethodPurged = $this->subjectForMethodPurged ?? self::SUBJ_METHOD_PURGED;
 
         $this->subjects = [
             EmailLog::MESSAGE_TYPE_INVITE => $this->subjectForInvite,
@@ -302,6 +307,7 @@ class Emailer extends Component
             EmailLog::MESSAGE_TYPE_MFA_DISABLED => $this->subjectForMfaDisabled,
             EmailLog::MESSAGE_TYPE_METHOD_VERIFY => $this->subjectForMethodVerify,
             EmailLog::MESSAGE_TYPE_METHOD_REMINDER => $this->subjectForMethodReminder,
+            EmailLog::MESSAGE_TYPE_METHOD_PURGED => $this->subjectForMethodPurged,
             EmailLog::MESSAGE_TYPE_MFA_MANAGER => $this->subjectForMfaManager,
             EmailLog::MESSAGE_TYPE_MFA_MANAGER_HELP => $this->subjectForMfaManagerHelp,
         ];

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -91,7 +91,6 @@ return [
             'sendMfaDisabledEmails' => Env::get('SEND_MFA_DISABLED_EMAILS', true),
             'sendMethodReminderEmails' => Env::get('SEND_METHOD_REMINDER_EMAILS', true),
             'sendMethodPurgedEmails' => Env::get('SEND_METHOD_PURGED_EMAILS', true),
-            'sendPasswordExpiryEmails' => Env::get('SEND_PASSWORD_EXPIRY_EMAILS', true),
 
             'subjectForInvite' => Env::get('SUBJECT_FOR_INVITE'),
             'subjectForMfaRateLimit' => Env::get('SUBJECT_FOR_MFA_RATE_LIMIT'),
@@ -109,7 +108,6 @@ return [
             'subjectForMethodVerify' => Env::get('SUBJECT_FOR_METHOD_VERIFY'),
             'subjectForMethodReminder' => Env::get('SUBJECT_FOR_METHOD_REMINDER'),
             'subjectForMethodPurged' => Env::get('SUBJECT_FOR_METHOD_PURGED'),
-            'subjectForPasswordExpiry' => Env::get('SUBJECT_FOR_PASSWORD_EXPIRY'),
 
             'lostSecurityKeyEmailDays' => Env::get('LOST_SECURITY_KEY_EMAIL_DAYS', 62),
             'minimumBackupCodesBeforeNag' => Env::get('MINIMUM_BACKUP_CODES_BEFORE_NAG', 4),

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -91,6 +91,7 @@ return [
             'sendMfaDisabledEmails' => Env::get('SEND_MFA_DISABLED_EMAILS', true),
             'sendMethodReminderEmails' => Env::get('SEND_METHOD_REMINDER_EMAILS', true),
             'sendMethodPurgedEmails' => Env::get('SEND_METHOD_PURGED_EMAILS', true),
+            'sendPasswordExpiryEmails' => Env::get('SEND_PASSWORD_EXPIRY_EMAILS', true),
 
             'subjectForInvite' => Env::get('SUBJECT_FOR_INVITE'),
             'subjectForMfaRateLimit' => Env::get('SUBJECT_FOR_MFA_RATE_LIMIT'),
@@ -108,6 +109,7 @@ return [
             'subjectForMethodVerify' => Env::get('SUBJECT_FOR_METHOD_VERIFY'),
             'subjectForMethodReminder' => Env::get('SUBJECT_FOR_METHOD_REMINDER'),
             'subjectForMethodPurged' => Env::get('SUBJECT_FOR_METHOD_PURGED'),
+            'subjectForPasswordExpiry' => Env::get('SUBJECT_FOR_PASSWORD_EXPIRY'),
 
             'lostSecurityKeyEmailDays' => Env::get('LOST_SECURITY_KEY_EMAIL_DAYS', 62),
             'minimumBackupCodesBeforeNag' => Env::get('MINIMUM_BACKUP_CODES_BEFORE_NAG', 4),
@@ -210,7 +212,7 @@ return [
         ],
         'method' => ArrayHelper::merge(
             [
-                'lifetime' => '+1 day',
+                'lifetime' => '+5 days',
                 'gracePeriod' => '+15 days',
                 'codeLength' => 6,
                 'maxAttempts' => 10,

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -89,6 +89,7 @@ return [
             'sendMfaOptionRemovedEmails' => Env::get('SEND_MFA_OPTION_REMOVED_EMAILS', true),
             'sendMfaEnabledEmails' => Env::get('SEND_MFA_ENABLED_EMAILS', true),
             'sendMfaDisabledEmails' => Env::get('SEND_MFA_DISABLED_EMAILS', true),
+            'sendMethodReminderEmails' => Env::get('SEND_METHOD_REMINDER_EMAILS', true),
 
             'subjectForInvite' => Env::get('SUBJECT_FOR_INVITE'),
             'subjectForMfaRateLimit' => Env::get('SUBJECT_FOR_MFA_RATE_LIMIT'),
@@ -104,6 +105,7 @@ return [
             'subjectForMfaManager' => Env::get('SUBJECT_FOR_MFA_MANAGER'),
             'subjectForMfaManagerHelp' => Env::get('SUBJECT_FOR_MFA_MANAGER_HELP'),
             'subjectForMethodVerify' => Env::get('SUBJECT_FOR_METHOD_VERIFY'),
+            'subjectForMethodReminder' => Env::get('SUBJECT_FOR_METHOD_REMINDER'),
 
             'lostSecurityKeyEmailDays' => Env::get('LOST_SECURITY_KEY_EMAIL_DAYS', 62),
             'minimumBackupCodesBeforeNag' => Env::get('MINIMUM_BACKUP_CODES_BEFORE_NAG', 4),

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -90,6 +90,7 @@ return [
             'sendMfaEnabledEmails' => Env::get('SEND_MFA_ENABLED_EMAILS', true),
             'sendMfaDisabledEmails' => Env::get('SEND_MFA_DISABLED_EMAILS', true),
             'sendMethodReminderEmails' => Env::get('SEND_METHOD_REMINDER_EMAILS', true),
+            'sendMethodPurgedEmails' => Env::get('SEND_METHOD_PURGED_EMAILS', true),
 
             'subjectForInvite' => Env::get('SUBJECT_FOR_INVITE'),
             'subjectForMfaRateLimit' => Env::get('SUBJECT_FOR_MFA_RATE_LIMIT'),
@@ -106,6 +107,7 @@ return [
             'subjectForMfaManagerHelp' => Env::get('SUBJECT_FOR_MFA_MANAGER_HELP'),
             'subjectForMethodVerify' => Env::get('SUBJECT_FOR_METHOD_VERIFY'),
             'subjectForMethodReminder' => Env::get('SUBJECT_FOR_METHOD_REMINDER'),
+            'subjectForMethodPurged' => Env::get('SUBJECT_FOR_METHOD_PURGED'),
 
             'lostSecurityKeyEmailDays' => Env::get('LOST_SECURITY_KEY_EMAIL_DAYS', 62),
             'minimumBackupCodesBeforeNag' => Env::get('MINIMUM_BACKUP_CODES_BEFORE_NAG', 4),

--- a/application/common/mail/method-purged.html.php
+++ b/application/common/mail/method-purged.html.php
@@ -1,0 +1,45 @@
+<?php
+use yii\helpers\Html as yHtml;
+
+/**
+ * @var string $displayName        Email address to be verified. Provided by user profile.
+ * @var string $alternateAddress   Alternate email address removed. Generated at runtime.
+ * @var string $numberVerified     Number of verified recovery options. Generated at runtime.
+ * @var string $idpDisplayName     Display name of IDP instance. Provided by environment variable IDP_DISPLAY_NAME.
+ * @var string $supportName        Help center name.  Provided by environment variable SUPPORT_NAME.
+ * @var string $supportEmail       Help center email address.  Provided by environment variable SUPPORT_EMAIL.
+ * @var string $helpCenterUrl      Help center website URL.  Provided by environment variable HELP_CENTER_URL.
+ * @var string $emailSignature     Email signature. Provided by environment variable EMAIL_SIGNATURE.
+ * @var string $passwordProfileUrl URL of password manager. Provided by environment variable PASSWORD_PROFILE_URL.
+ */
+
+?>
+<p>Dear <?= yHtml::encode($displayName) ?>,</p>
+
+<p>
+    You recently requested to add an email address, <?= yHtml::encode($alternateAddress); ?>,
+    as an alternate method for verifying your identity should you ever need to reset your
+    <?= yHtml::encode($idpDisplayName); ?> account password. Because it was not verified before
+    its expiration time, it has been removed from your <?= yHtml::encode($idpDisplayName); ?>
+    account.
+</p>
+<p>
+<?php if ($numberVerified === 0) : ?>
+    Please go to your profile page at
+    <?= yHtml::a(yHtml::encode($passwordProfileUrl), $passwordProfileUrl) ?>
+    to add an alternate password recovery email.
+<?php else : ?>
+    If you still wish to add this email, please go to your profile page here:
+    <?= yHtml::a(yHtml::encode($passwordProfileUrl), $passwordProfileUrl) ?>
+<?php endif ?>
+</p>
+<p>
+    If you have any questions, you can visit our Help Center at
+    <?= yHtml::a(yHtml::encode($helpCenterUrl), $helpCenterUrl) ?>
+</p>
+<p>
+    Thanks,
+</p>
+<p>
+    <i><?= yHtml::encode($emailSignature); ?></i>
+</p>

--- a/application/common/mail/method-purged.text.php
+++ b/application/common/mail/method-purged.text.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @var string $displayName        Email address to be verified. Provided by user profile.
+ * @var string $alternateAddress   Email address to be verified. Generated at runtime.
+ * @var string $numberVerified     Number of verified recovery options. Generated at runtime.
+ * @var string $idpDisplayName     Display name of IDP instance. Provided by environment variable IDP_DISPLAY_NAME.
+ * @var string $supportName        Help center name.  Provided by environment variable SUPPORT_NAME.
+ * @var string $supportEmail       Help center email address.  Provided by environment variable SUPPORT_EMAIL.
+ * @var string $helpCenterUrl      Help center website URL.  Provided by environment variable HELP_CENTER_URL.
+ * @var string $emailSignature     Email signature. Provided by environment variable EMAIL_SIGNATURE.
+ * @var string $passwordProfileUrl URL of password manager. Provided by environment variable PASSWORD_PROFILE_URL.
+ */
+?>
+Dear <?= $displayName ?>,
+
+You recently requested to add an email address, <?= $alternateAddress ?>,
+as an alternate method for verifying your identity should you ever need to reset your
+<?= $idpDisplayName ?> account password. Because it was not verified before
+its expiration time, it has been removed from your <?= $idpDisplayName ?> account.
+
+<?php if ($numberVerified === 0) : ?>
+Please go to your profile page at
+<?= $passwordProfileUrl . PHP_EOL ?>
+to add an alternate password recovery email.
+<?php else : ?>
+If you still wish to add this email, please go to your profile page here:
+<?= $passwordProfileUrl . PHP_EOL ?>
+<?php endif ?>
+
+If you have any questions, you can visit our Help Center at
+<?= $helpCenterUrl . PHP_EOL ?>
+
+Thanks,
+<?= $emailSignature ?>

--- a/application/common/mail/method-reminder.html.php
+++ b/application/common/mail/method-reminder.html.php
@@ -1,0 +1,35 @@
+<?php
+use yii\helpers\Html as yHtml;
+
+/**
+ * @var string $displayName        Email address to be verified. Provided by user profile.
+ * @var string $alternateAddress   Email address to be verified. Generated at runtime.
+ * @var string $idpDisplayName     Display name of IDP instance. Provided by environment variable IDP_DISPLAY_NAME.
+ * @var string $supportName        Help center name.  Provided by environment variable SUPPORT_NAME.
+ * @var string $supportEmail       Help center email address.  Provided by environment variable SUPPORT_EMAIL.
+ * @var string $helpCenterUrl      Help center website URL.  Provided by environment variable HELP_CENTER_URL.
+ * @var string $emailSignature     Email signature. Provided by environment variable EMAIL_SIGNATURE.
+ * @var string $passwordProfileUrl URL of password manager. Provided by environment variable PASSWORD_PROFILE_URL.
+ */
+
+?>
+<p>Dear <?= yHtml::encode($displayName) ?>,</p>
+
+<p>
+    You recently requested to add an email address, <?= yHtml::encode($alternateAddress); ?>,
+    as an alternate method for verifying your identity should you ever need to reset your
+    <?= yHtml::encode($idpDisplayName); ?> account password. Please open the inbox for
+    that account and click the link in the verification email we sent earlier. If you cannot
+    find that email, you can generate a new one at your profile page here:
+    <?= yHtml::a(yHtml::encode($passwordProfileUrl), $passwordProfileUrl) ?>
+</p>
+<p>
+    If you have any questions, you can visit our Help Center at
+    <?= yHtml::a(yHtml::encode($helpCenterUrl), $helpCenterUrl) ?>
+</p>
+<p>
+    Thanks,
+</p>
+<p>
+    <i><?= yHtml::encode($emailSignature); ?></i>
+</p>

--- a/application/common/mail/method-reminder.text.php
+++ b/application/common/mail/method-reminder.text.php
@@ -18,10 +18,10 @@ as an alternate method for verifying your identity should you ever need to reset
 <?= $idpDisplayName ?> account password. Please open the inbox for
 that account and click the link in the verification email we sent earlier. If you cannot
 find that email, you can generate a new one at your profile page here:
-<?= $passwordProfileUrl ?>
+<?= $passwordProfileUrl . PHP_EOL ?>
 
 If you have any questions, you can visit our Help Center at
-<?= $helpCenterUrl ?>
+<?= $helpCenterUrl . PHP_EOL ?>
 
 Thanks,
 <?= $emailSignature ?>

--- a/application/common/mail/method-reminder.text.php
+++ b/application/common/mail/method-reminder.text.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @var string $displayName        Email address to be verified. Provided by user profile.
+ * @var string $alternateAddress   Email address to be verified. Generated at runtime.
+ * @var string $idpDisplayName     Display name of IDP instance. Provided by environment variable IDP_DISPLAY_NAME.
+ * @var string $supportName        Help center name.  Provided by environment variable SUPPORT_NAME.
+ * @var string $supportEmail       Help center email address.  Provided by environment variable SUPPORT_EMAIL.
+ * @var string $helpCenterUrl      Help center website URL.  Provided by environment variable HELP_CENTER_URL.
+ * @var string $emailSignature     Email signature. Provided by environment variable EMAIL_SIGNATURE.
+ * @var string $passwordProfileUrl URL of password manager. Provided by environment variable PASSWORD_PROFILE_URL.
+ */
+?>
+Dear <?= $displayName ?>,
+
+You recently requested to add an email address, <?= $alternateAddress ?>,
+as an alternate method for verifying your identity should you ever need to reset your
+<?= $idpDisplayName ?> account password. Please open the inbox for
+that account and click the link in the verification email we sent earlier. If you cannot
+find that email, you can generate a new one at your profile page here:
+<?= $passwordProfileUrl ?>
+
+If you have any questions, you can visit our Help Center at
+<?= $helpCenterUrl ?>
+
+Thanks,
+<?= $emailSignature ?>

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -24,6 +24,7 @@ class EmailLog extends EmailLogBase
     const MESSAGE_TYPE_MFA_ENABLED = 'mfa-enabled';
     const MESSAGE_TYPE_MFA_DISABLED = 'mfa-disabled';
     const MESSAGE_TYPE_METHOD_VERIFY = 'method-verify';
+    const MESSAGE_TYPE_METHOD_REMINDER = 'method-reminder';
     const MESSAGE_TYPE_MFA_MANAGER = 'mfa-manager';
     const MESSAGE_TYPE_MFA_MANAGER_HELP = 'mfa-manager-help';
 
@@ -52,6 +53,7 @@ class EmailLog extends EmailLogBase
             self::MESSAGE_TYPE_MFA_ENABLED,
             self::MESSAGE_TYPE_MFA_DISABLED,
             self::MESSAGE_TYPE_METHOD_VERIFY,
+            self::MESSAGE_TYPE_METHOD_REMINDER,
             self::MESSAGE_TYPE_MFA_MANAGER,
             self::MESSAGE_TYPE_MFA_MANAGER_HELP,
         ];

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -25,6 +25,7 @@ class EmailLog extends EmailLogBase
     const MESSAGE_TYPE_MFA_DISABLED = 'mfa-disabled';
     const MESSAGE_TYPE_METHOD_VERIFY = 'method-verify';
     const MESSAGE_TYPE_METHOD_REMINDER = 'method-reminder';
+    const MESSAGE_TYPE_METHOD_PURGED = 'method-purged';
     const MESSAGE_TYPE_MFA_MANAGER = 'mfa-manager';
     const MESSAGE_TYPE_MFA_MANAGER_HELP = 'mfa-manager-help';
 
@@ -54,6 +55,7 @@ class EmailLog extends EmailLogBase
             self::MESSAGE_TYPE_MFA_DISABLED,
             self::MESSAGE_TYPE_METHOD_VERIFY,
             self::MESSAGE_TYPE_METHOD_REMINDER,
+            self::MESSAGE_TYPE_METHOD_PURGED,
             self::MESSAGE_TYPE_MFA_MANAGER,
             self::MESSAGE_TYPE_MFA_MANAGER_HELP,
         ];

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -166,9 +166,11 @@ class Method extends MethodBase
             ->all();
 
         $numDeleted = 0;
+        /** @var Method $method */
         foreach ($methods as $method) {
             try {
                 if ($method->delete() !== false) {
+                    $method->sendPurgedEmail();
                     $numDeleted += 1;
                 }
             } catch (\Exception $e) {
@@ -330,5 +332,23 @@ class Method extends MethodBase
         }
 
         return $method;
+    }
+
+    /**
+     * Send a notification email message informing the user that a recovery message was purged
+     */
+    public function sendPurgedEmail()
+    {
+        /* @var $emailer Emailer */
+        $emailer = \Yii::$app->emailer;
+
+        $emailer->sendMessageTo(
+            EmailLog::MESSAGE_TYPE_METHOD_PURGED,
+            $this->user,
+            [
+                'alternateAddress' => $this->value,
+                'numberVerified' => count($this->user->getVerifiedMethodOptions()),
+            ]
+        );
     }
 }

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -109,6 +109,6 @@ class CronController extends Controller
     {
         /* @var $emailer Emailer */
         $emailer = \Yii::$app->emailer;
-        $emailer->sendMethodVerifyEmails();
+        $emailer->sendMethodReminderEmails();
     }
 }

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -105,7 +105,17 @@ class CronController extends Controller
         $emailer->sendDelayedMfaRelatedEmails();
     }
 
+    /**
+     * @deprecated
+     */
     public function actionSendMethodVerifyEmails()
+    {
+        /* @var $emailer Emailer */
+        $emailer = \Yii::$app->emailer;
+        $emailer->sendMethodReminderEmails();
+    }
+
+    public function actionSendMethodReminderEmails()
     {
         /* @var $emailer Emailer */
         $emailer = \Yii::$app->emailer;

--- a/application/console/migrations/m190423_163011_add_method_reminder_email_type.php
+++ b/application/console/migrations/m190423_163011_add_method_reminder_email_type.php
@@ -18,7 +18,7 @@ class m190423_163011_add_method_reminder_email_type extends Migration
             "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes'," .
             "'refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed'," .
             "'mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help'," .
-            "'method-reminder') NULL"
+            "'method-reminder','method-purged') NULL"
         );
     }
 

--- a/application/console/migrations/m190423_163011_add_method_reminder_email_type.php
+++ b/application/console/migrations/m190423_163011_add_method_reminder_email_type.php
@@ -1,0 +1,38 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m190423_163011_add_method_reminder_email_type
+ */
+class m190423_163011_add_method_reminder_email_type extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->alterColumn(
+            '{{email_log}}',
+            'message_type',
+            "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes'," .
+            "'refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed'," .
+            "'mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help'," .
+            "'method-reminder') NULL"
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->alterColumn(
+            '{{email_log}}',
+            'message_type',
+            "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes'," .
+            "'refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed'," .
+            "'mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help') NULL"
+        );
+    }
+}

--- a/application/console/migrations/m190423_163011_add_method_reminder_email_type.php
+++ b/application/console/migrations/m190423_163011_add_method_reminder_email_type.php
@@ -18,7 +18,7 @@ class m190423_163011_add_method_reminder_email_type extends Migration
             "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes'," .
             "'refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed'," .
             "'mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help'," .
-            "'method-reminder','method-purged') NULL"
+            "'method-reminder','method-purged','password-expiry') NULL"
         );
     }
 

--- a/application/console/migrations/m190423_163011_add_method_reminder_email_type.php
+++ b/application/console/migrations/m190423_163011_add_method_reminder_email_type.php
@@ -18,7 +18,7 @@ class m190423_163011_add_method_reminder_email_type extends Migration
             "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes'," .
             "'refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed'," .
             "'mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help'," .
-            "'method-reminder','method-purged','password-expiry') NULL"
+            "'method-reminder','method-purged','password-expiring','password-expired') NULL"
         );
     }
 

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -317,3 +317,24 @@ Feature: Email
      When that user is created with a personal email address
      Then an "invite" email should have been sent to them
       And that email should have been copied to the personal email address
+
+  Scenario Outline:  When to send recovery method reminder email
+    Given we are configured <toSendOrNot> recovery method reminder emails
+      And I remove records of any emails that have been sent
+      And a user already exists
+      And no methods exist
+      And a recovery method was created <number> days ago
+      And a "method-reminder" email <hasOrHasNot> been sent to that user
+    When I send recovery method reminder emails
+    Then a "method-reminder" email <shouldOrNot> have been sent to them
+
+    Examples:
+      | toSendOrNot  | number | hasOrHasNot  | shouldOrNot    |
+      | to send      | 3      | has NOT      | should NOT     |
+      | to send      | 4      | has NOT      | should         |
+      | to send      | 5      | has NOT      | should         |
+      | to send      | 3      | has          | should NOT     |
+      | to send      | 4      | has          | should NOT     |
+      | to send      | 5      | has          | should NOT     |
+      | NOT to send  | 5      | has NOT      | should NOT     |
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,13 +19,13 @@ services:
         volumes_from:
             - data
         ports:
-            - "8090:80"
+            - "51140:80"
         depends_on:
             - db
         env_file:
             - ./local.env
         environment:
-            EMAILER_CLASS: \Sil\SilIdBroker\Behat\Context\fakes\FakeEmailer
+#            EMAILER_CLASS: \Sil\SilIdBroker\Behat\Context\fakes\FakeEmailer
             EMAIL_SIGNATURE: Dummy Signature for Development
 
     cron:
@@ -118,7 +118,7 @@ services:
     phpmyadmin:
         image: phpmyadmin/phpmyadmin
         ports:
-            - "8091:80"
+            - "51141:80"
         depends_on:
             - db
         env_file:

--- a/dockerbuild/broker-cron
+++ b/dockerbuild/broker-cron
@@ -4,4 +4,4 @@
 
 0 1 * * * root /data/yii cron/google-analytics 2>&1 | /usr/bin/logger -t id-broker-cron
 0 2 * * * root /data/yii cron/send-delayed-mfa-related-emails 2>&1 | /usr/bin/logger -t id-broker-cron
-0 3 * * * root /data/yii cron/send-method-verify-emails 2>&1 | /usr/bin/logger -t id-broker-cron
+0 3 * * * root /data/yii cron/send-method-reminder-emails 2>&1 | /usr/bin/logger -t id-broker-cron

--- a/local.env.dist
+++ b/local.env.dist
@@ -104,6 +104,8 @@ GA_CLIENT_ID=
 #SEND_MFA_OPTION_REMOVED_EMAILS=true
 #SEND_MFA_ENABLED_EMAILS=true
 #SEND_MFA_DISABLED_EMAILS=true
+#SEND_METHOD_REMINDER=true
+#SEND_METHOD_PURGED=true
 
 # define the following to change the default subject line
 # default subjects are defined in application/common/components/Emailer.php
@@ -122,6 +124,7 @@ GA_CLIENT_ID=
 #SUBJECT_FOR_MFA_MANAGER_HELP=
 #SUBJECT_FOR_METHOD_VERIFY=
 #SUBJECT_FOR_METHOD_REMINDER=
+#SUBJECT_FOR_METHOD_PURGED=
 
 # The number of days of not using a security key after which we email
 # the user. Defaults to 62.

--- a/local.env.dist
+++ b/local.env.dist
@@ -121,6 +121,7 @@ GA_CLIENT_ID=
 #SUBJECT_FOR_MFA_MANAGER=
 #SUBJECT_FOR_MFA_MANAGER_HELP=
 #SUBJECT_FOR_METHOD_VERIFY=
+#SUBJECT_FOR_METHOD_REMINDER=
 
 # The number of days of not using a security key after which we email
 # the user. Defaults to 62.
@@ -188,6 +189,9 @@ GA_CLIENT_ID=
 
 # If a recovery method has been expired longer than this amount of time,
 # it will be removed; defaults to "+1 week"
+# Note: if the sum of METHOD_lifetime and METHOD_gracePeriod are longer
+# than EMAIL_REPEAT_DELAY_DAYS, additional reminder(s) may be sent to
+# verify the recovery method.
 #METHOD_gracePeriod=
 
 # number of digits in verification code; defaults to 6


### PR DESCRIPTION
Added two new email templates: `method-reminder` and `method-purged`. The reminder is triggered once, after 3 days have passed since the email address was added. Then, if still not verified, the purge process will run at 7 days (by default) to delete the record and send another email to notify the user. 

(Note: the default expiration time of a method verification is 1 day. Therefore, the reminder email will be received by the user after it has expired.)