### PR TITLE
Better handling of manager 2sv

### DIFF
--- a/application/common/components/MfaBackendManager.php
+++ b/application/common/components/MfaBackendManager.php
@@ -85,10 +85,6 @@ class MfaBackendManager extends Component implements MfaBackendInterface
             throw new \Exception("MFA record not found", 1547074716);
         }
 
-        if (count($mfa->mfaBackupcodes) == 0) {
-            $mfa->delete();
-        }
-
         return true;
     }
 

--- a/application/common/components/MfaBackendManager.php
+++ b/application/common/components/MfaBackendManager.php
@@ -27,8 +27,6 @@ class MfaBackendManager extends Component implements MfaBackendInterface
 
         $mfa->setVerified();
 
-        MfaBackupcode::deleteCodesForMfaId($mfa->id);
-
         $codes = MfaBackupcode::createBackupCodes($mfa->id, 1);
         $this->sendManagerEmail($mfa, $codes[0]);
 

--- a/application/common/models/Mfa.php
+++ b/application/common/models/Mfa.php
@@ -224,6 +224,9 @@ class Mfa extends MfaBase
                 'username' => $this->user->username,
                 'status' => 'success',
             ]);
+
+            $this->user->removeManagerCodes();
+
             return true;
         }
 

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -930,7 +930,7 @@ class User extends UserBase
      */
     public function removeManagerCodes()
     {
-        $mfa = Mfa::findOne(['type' => Mfa::TYPE_MANAGER]);
+        $mfa = Mfa::findOne(['user_id' => $this->id, 'type' => Mfa::TYPE_MANAGER]);
         if ($mfa === null) {
             return;
         }

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -923,4 +923,36 @@ class User extends UserBase
             }
         }
     }
+
+    /**
+     * Remove all manager codes for this user
+     * @throws \Exception
+     */
+    public function removeManagerCodes()
+    {
+        $mfa = Mfa::findOne(['type' => Mfa::TYPE_MANAGER]);
+        if ($mfa === null) {
+            return;
+        }
+
+        foreach ($mfa->mfaBackupcodes as $code) {
+            if ($code->delete() === false) {
+                \Yii::error([
+                    'action' => 'remove all manager codes',
+                    'status' => 'error',
+                    'error' => $code->getFirstErrors(),
+                ]);
+                throw new \Exception("Unable to delete manager code", 1556810506);
+            }
+        }
+
+        if ($mfa->delete() === false) {
+            \Yii::error([
+                'action' => 'remove manager mfa',
+                'status' => 'error',
+                'error' => $mfa->getFirstErrors(),
+            ]);
+            throw new \Exception("Unable to delete manager mfa", 1556810507);
+        }
+    }
 }

--- a/application/features/bootstrap/MfaUnitTestsContext.php
+++ b/application/features/bootstrap/MfaUnitTestsContext.php
@@ -3,12 +3,13 @@ namespace Sil\SilIdBroker\Behat\Context;
 
 use common\models\Mfa;
 use common\models\MfaBackupcode;
-use common\models\User;
 use Webmozart\Assert\Assert;
 
 class MfaUnitTestsContext extends UnitTestsContext
 {
     protected $label;
+
+    protected $inputBackupCode;
 
     /**
      * @Given I have a user with a backup codes mfa option
@@ -194,5 +195,35 @@ class MfaUnitTestsContext extends UnitTestsContext
     public function iSeeThatTheMfaOptionIsNotNewlyVerified()
     {
         Assert::false($this->mfaIsNewlyVerified);
+    }
+
+    /**
+     * @Given that user also has a manager rescue mfa option
+     */
+    public function thatUserAlsoHasAManagerRescueMfaOption()
+    {
+        $code = 'manager';
+        $this->createMfa(Mfa::TYPE_MANAGER);
+        MfaBackupcode::insertBackupCode($this->mfaId, $code);
+    }
+
+    /**
+     * @When I verify a backup code
+     */
+    public function iVerifyABackupCode()
+    {
+        $code = 'backup';
+        $mfa = Mfa::findOne(['user_id' => $this->tempUser->id, 'type' => Mfa::TYPE_BACKUPCODE]);
+        MfaBackupcode::insertBackupCode($mfa->id, $code);
+        Assert::true($mfa->verify($code));
+    }
+
+    /**
+     * @Then I see that the user no longer has a manager rescue mfa option
+     */
+    public function iSeeThatTheUserNoLongerHasAManagerRescueMfaOption()
+    {
+        $mfa = Mfa::findOne(['user_id' => $this->tempUser->id, 'type' => Mfa::TYPE_MANAGER]);
+        Assert::null($mfa);
     }
 }

--- a/application/features/bootstrap/UnitTestsContext.php
+++ b/application/features/bootstrap/UnitTestsContext.php
@@ -2,9 +2,11 @@
 namespace Sil\SilIdBroker\Behat\Context;
 
 use common\helpers\MySqlDateTime;
+use common\models\EmailLog;
 use common\models\Invite;
 use common\models\Method;
 use common\models\Mfa;
+use common\models\MfaBackupcode;
 use common\models\User;
 use Webmozart\Assert\Assert;
 
@@ -38,6 +40,19 @@ class UnitTestsContext extends YiiContext
 
     /** @var Invite */
     protected $inviteCode;
+
+    /**
+     * @afterScenario @database
+     */
+    public function purgeDatabase()
+    {
+        MfaBackupcode::deleteAll();
+        Mfa::deleteAll();
+        Invite::deleteAll();
+        EmailLog::deleteAll();
+        Method::deleteAll();
+        User::deleteAll();
+    }
 
     /**
      * Create a new user in the database with the given username (and other

--- a/application/features/mfa-unit-tests.feature
+++ b/application/features/mfa-unit-tests.feature
@@ -1,3 +1,4 @@
+@database
 Feature: Unit Tests for the Mfa model
 
   Scenario Outline: Validate backup codes that may or may not have leading zeros
@@ -44,3 +45,9 @@ Feature: Unit Tests for the Mfa model
       And the totp mfa option has just been verified
     When I check if the mfa option is newly verified
     Then I see that the mfa option is newly verified
+
+  Scenario: Remove all manager codes for a user when an mfa is verified
+    Given I have a user with a backup codes mfa option
+      And that user also has a manager rescue mfa option
+    When I verify a backup code
+    Then I see that the user no longer has a manager rescue mfa option

--- a/application/frontend/controllers/MfaController.php
+++ b/application/frontend/controllers/MfaController.php
@@ -79,7 +79,7 @@ class MfaController extends BaseRestController
 
         // Strip spaces from $value if string
         if (is_string($value)) {
-            $value = str_replace(' ', '', $value);
+            $value = preg_replace('/\D/', '', $value);
         }
 
         if (! $mfa->verify($value)) {


### PR DESCRIPTION
- Allow creation of multiple manager codes
- Delete all manager codes when any 2sv is used
- Strip all non-numeric characters from user-provided codes (any type of 2sv)