### PR TITLE
Fix bug in field for last_login_utc to return null when null

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -410,7 +410,7 @@ class User extends UserBase
             'active',
             'locked',
             'last_login_utc' => function (self $model) {
-                return Utils::getIso8601($model->last_login_utc);
+                return $model->last_login_utc === null ? null : Utils::getIso8601($model->last_login_utc);
             },
             'manager_email',
             'personal_email' => function (self $model) {


### PR DESCRIPTION
When `last_login_utc` is null, the call to `Utils::getIso8601` returns the current date/time