### PR TITLE
cron deletes old manager mfa records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.6.1]
+### Added
+- Cron deletes old manager "rescue" 2SV (MFA) codes 
+
 ## [4.6.0]
 ### Added
 - Optionally include an email address on the bcc line of manager mfa emails 
@@ -161,7 +165,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of ID Broker.
 
-[Unreleased]: https://github.com/silinternational/idp-id-broker/compare/4.6.0...HEAD
+[Unreleased]: https://github.com/silinternational/idp-id-broker/compare/4.6.1...HEAD
+[4.6.1]: https://github.com/silinternational/idp-id-broker/compare/4.6.0...4.6.1
 [4.6.0]: https://github.com/silinternational/idp-id-broker/compare/4.5.2...4.6.0
 [4.5.2]: https://github.com/silinternational/idp-id-broker/compare/4.5.1...4.5.2
 [4.5.1]: https://github.com/silinternational/idp-id-broker/compare/4.5.0...4.5.1

--- a/application/common/models/Invite.php
+++ b/application/common/models/Invite.php
@@ -145,6 +145,11 @@ class Invite extends InviteBase
      */
     public static function deleteOldInvites()
     {
+        \Yii::warning([
+            'action' => 'delete old invite records',
+            'status' => 'starting',
+        ]);
+
         /*
          * Replace '+' with '-' so all env parameters can be defined consistently as '+n unit'
          */

--- a/application/common/models/Method.php
+++ b/application/common/models/Method.php
@@ -150,6 +150,11 @@ class Method extends MethodBase
      */
     public static function deleteExpiredUnverifiedMethods()
     {
+        \Yii::warning([
+            'action' => 'delete old unverified method records',
+            'status' => 'starting',
+        ]);
+
         /*
          * Replace '+' with '-' so all env parameters can be defined consistently as '+n unit'
          */

--- a/application/common/models/Mfa.php
+++ b/application/common/models/Mfa.php
@@ -462,7 +462,7 @@ class Mfa extends MfaBase
      */
     protected static function deleteOldRecords(string $age, array $criteria): void
     {
-        $age = '-' . ltrim($age, '+');
+        $age = str_replace('+', '-', $age);
 
         /**
          * @var string $removeOlderThan  Records created before this date should be deleted

--- a/application/common/models/Mfa.php
+++ b/application/common/models/Mfa.php
@@ -462,6 +462,12 @@ class Mfa extends MfaBase
      */
     protected static function deleteOldRecords(string $age, array $criteria): void
     {
+        \Yii::warning([
+            'action' => 'delete old mfa records',
+            'criteria' => $criteria,
+            'status' => 'starting',
+        ]);
+
         $age = str_replace('+', '-', $age);
 
         /**

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -31,6 +31,12 @@ class CronController extends Controller
             'status' => 'starting',
         ]);
         Mfa::removeOldUnverifiedRecords();
+
+        \Yii::warning([
+            'action' => 'delete old manager mfa records',
+            'status' => 'starting',
+        ]);
+        Mfa::removeOldManagerMfaRecords();
     }
 
     /**

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -14,28 +14,12 @@ class CronController extends Controller
 {
     public function actionRemoveOldUnverifiedRecords()
     {
-        \Yii::warning([
-            'action' => 'delete old unverified method records',
-            'status' => 'starting',
-        ]);
         Method::deleteExpiredUnverifiedMethods();
 
-        \Yii::warning([
-            'action' => 'delete old invite records',
-            'status' => 'starting',
-        ]);
         Invite::deleteOldInvites();
 
-        \Yii::warning([
-            'action' => 'delete old unverified mfa records',
-            'status' => 'starting',
-        ]);
         Mfa::removeOldUnverifiedRecords();
 
-        \Yii::warning([
-            'action' => 'delete old manager mfa records',
-            'status' => 'starting',
-        ]);
         Mfa::removeOldManagerMfaRecords();
     }
 


### PR DESCRIPTION
I originally thought `Mfa::removeOldUnverifiedRecords()` would take care of this, but it did not because manager codes are marked as verified when created.