### PR TITLE
improve Mfa::deleteOldRecords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.6.3] - 2019-08-06
+### Added
+- Fix defect in Mfa::deleteOldRecords. 
+
 ## [4.6.2] - 2019-08-05
 ### Added
 - Cron deletes old manager "rescue" 2SV (MFA) codes 
@@ -169,7 +173,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of ID Broker.
 
-[Unreleased]: https://github.com/silinternational/idp-id-broker/compare/4.6.2...HEAD
+[Unreleased]: https://github.com/silinternational/idp-id-broker/compare/4.6.3...HEAD
+[4.6.2]: https://github.com/silinternational/idp-id-broker/compare/4.6.1...4.6.3
 [4.6.2]: https://github.com/silinternational/idp-id-broker/compare/4.6.1...4.6.2
 [4.6.1]: https://github.com/silinternational/idp-id-broker/compare/4.6.0...4.6.1
 [4.6.0]: https://github.com/silinternational/idp-id-broker/compare/4.5.2...4.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 ## [4.6.3] - 2019-08-06
-### Added
+### Fixed
 - Fix defect in Mfa::deleteOldRecords. 
 
 ## [4.6.2] - 2019-08-05

--- a/application/common/models/Mfa.php
+++ b/application/common/models/Mfa.php
@@ -462,13 +462,11 @@ class Mfa extends MfaBase
      */
     protected static function deleteOldRecords(string $age, array $criteria): void
     {
-        \Yii::warning([
-            'action' => 'delete old mfa records',
-            'criteria' => $criteria,
-            'status' => 'starting',
-        ]);
-
-        $age = str_replace('+', '-', $age);
+        if (! preg_match('/[\+\-].*/', $age)) {
+            $age = '-' . $age;
+        } else {
+            $age = str_replace('+', '-', $age);
+        }
 
         /**
          * @var string $removeOlderThan  Records created before this date should be deleted
@@ -480,6 +478,15 @@ class Mfa extends MfaBase
             ->where($criteria)
             ->andWhere(['<', 'created_utc', $removeOlderThan])
             ->all();
+
+        \Yii::warning([
+            'action' => 'delete old mfa records',
+            'criteria' => $criteria,
+            'status' => 'starting',
+            'age' => $age,
+            'removeOlderThan' => $removeOlderThan,
+            'count' => count($mfas),
+        ]);
 
         $numDeleted = 0;
         foreach ($mfas as $mfa) {

--- a/application/common/models/Mfa.php
+++ b/application/common/models/Mfa.php
@@ -464,9 +464,9 @@ class Mfa extends MfaBase
     {
         if (! preg_match('/[\+\-].*/', $age)) {
             $age = '-' . $age;
-        } else {
-            $age = str_replace('+', '-', $age);
         }
+
+        $age = str_replace('+', '-', $age);
 
         /**
          * @var string $removeOlderThan  Records created before this date should be deleted


### PR DESCRIPTION
The last edit before the previous release changed what types of relative dates Mfa::deleteOldRecords could handle. Specifically, it didn't correctly deal with '1 week', which caused all manager MFA records to be deleted.