### PR TITLE
don't send expiring notice if password has already expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [4.7.1] - 2019-09-26
+## [4.7.1] - 2019-10-02
 ### Fixed
 - Don't send password expiring notices if the password has already expired
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.7.1] - 2019-09-26
+### Fixed
+- Don't send password expiring notices if the password has already expired
+
 ## [4.7.0] - 2019-08-28
 ### Added
 - Added config option to bcc the mfa-manager-help email to another address
@@ -184,7 +188,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Initial version of ID Broker.
 
-[Unreleased]: https://github.com/silinternational/idp-id-broker/compare/4.7.0...HEAD
+[Unreleased]: https://github.com/silinternational/idp-id-broker/compare/4.7.1...HEAD
+[4.7.1]: https://github.com/silinternational/idp-id-broker/compare/4.7.0...4.7.1
 [4.7.0]: https://github.com/silinternational/idp-id-broker/compare/4.6.4...4.7.0
 [4.6.4]: https://github.com/silinternational/idp-id-broker/compare/4.6.3...4.6.4
 [4.6.3]: https://github.com/silinternational/idp-id-broker/compare/4.6.2...4.6.3

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -661,12 +661,15 @@ class Emailer extends Component
         foreach ($users as $user) {
             /** @var Password $userPassword */
             $userPassword = $user->currentPassword;
-            if ($userPassword
-                && strtotime($userPassword->getExpiresOn()) < strtotime('+15 days')
-                && ! $this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRING)
-            ) {
-                $this->sendMessageTo(EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRING, $user);
-                $numEmailsSent++;
+            if ($userPassword) {
+                $passwordExpiry = strtotime($userPassword->getExpiresOn());
+                if ($passwordExpiry < strtotime('+15 days')
+                    && !($passwordExpiry < time())
+                    && !$this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRING)
+                ) {
+                    $this->sendMessageTo(EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRING, $user);
+                    $numEmailsSent++;
+                }
             }
         }
 

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -358,6 +358,8 @@ Feature: Email
 
     Examples:
       | toSendOrNot  | number  | hasOrHasNot  | shouldOrNot    |
+      | to send      | -1      | has NOT      | should NOT     |
+      | to send      | 0       | has NOT      | should         |
       | to send      | 13      | has NOT      | should         |
       | to send      | 14      | has NOT      | should         |
       | to send      | 15      | has NOT      | should NOT     |


### PR DESCRIPTION
Since there's a separate alert for expired password, there is no reason to send an expiring notice as well when the password is past expiration.