### PR TITLE
deactivate a user that has had no email address for too long

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -879,7 +879,7 @@ class User extends UserBase
         }
 
         if ($this->isExpired()) {
-            $this->deactivate();
+            $this->deactivateExpiredUser();
         }
 
         return parent::beforeSave($insert);
@@ -907,7 +907,7 @@ class User extends UserBase
     public function afterFind()
     {
         if ($this->isExpired()) {
-            $this->deactivate();
+            $this->deactivateExpiredUser();
         }
 
         parent::afterFind();
@@ -1114,10 +1114,13 @@ class User extends UserBase
 
     protected function isExpired(): bool
     {
-        return $this->expires_on != null && MySqlDateTime::isBefore($this->expires_on, time());
+        return $this->expires_on !== null && MySqlDateTime::isBefore($this->expires_on, time());
     }
 
-    protected function deactivate(): void
+    /**
+     * Attempts to deactivate an expired user. If not successful, an error is logged.
+     */
+    protected function deactivateExpiredUser(): void
     {
         if ($this->active == 'no') {
             return;

--- a/application/features/bootstrap/FeatureContext.php
+++ b/application/features/bootstrap/FeatureContext.php
@@ -719,4 +719,16 @@ class FeatureContext extends YiiContext
             '/[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-[1-4][0-9a-fA-F]{3}\-[0-9a-fA-F]{4}\-[0-9a-fA-F]{12}/'
         );
     }
+
+    /**
+     * @Given I wait until after the user :username expiration date
+     */
+    public function iWaitUntilAfterTheUserExpirationDate($username)
+    {
+        $this->userFromDb = User::findOne(['username' => $username]);
+        $earlier = MySqlDateTime::relative("-1 year");
+        $this->userFromDb->expires_on = MySqlDateTime::relative($earlier);
+        $this->userFromDb->scenario = User::SCENARIO_UPDATE_USER;
+        $this->userFromDb->save();
+    }
 }

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -673,3 +673,32 @@ Feature: User
         |   it                 |
         |   {idpName}          |
       And the uuid property should be a valid UUID
+
+  Scenario: Fetch a user with no primary email address after user's expiration date
+    Given a record does not exist with an employee_id of "123"
+      And the requester is authorized
+      And I provide the following valid data:
+        | property        | value                 |
+        | employee_id     | 123                   |
+        | first_name      | New                   |
+        | last_name       | Guy                   |
+        | username        | new_guy               |
+        | personal_email  | personal@example.com  |
+      And I request "/user" be created
+      And I wait until after the user new_guy expiration date
+    When I request "/user/123" be retrieved
+    Then the response status code should be 200
+      And the following data is returned:
+        | property         | value                     |
+        |   employee_id    |   123                     |
+        |   username       |   new_guy                 |
+        |   email          |   personal@example.com    |
+        |   personal_email |   personal@example.com    |
+        |   active         |   no                      |
+        |   locked         |   no                      |
+      And a record exists with an employee_id of "123"
+      And the following data should be stored:
+        | property            | value              |
+        | username            | new_guy            |
+        | active              | no                 |
+        | locked              | no                 |


### PR DESCRIPTION
Update a user record in the database to set `active` to `no` the first time the record is accessed after the expiration date. Prior to this change, the in-memory value of `active` was set to `no` but no change was made to the database. This resulted in correct API responses, but an internal inconsistency that created potential for confusion.