### PR TITLE
New configs to improve 2sv adoption

### DIFF
--- a/application/behat.yml
+++ b/application/behat.yml
@@ -5,6 +5,7 @@ default:
                 - "%paths.base%/features/authentication.feature"
                 - "%paths.base%/features/password.feature"
                 - "%paths.base%/features/user.feature"
+                - "%paths.base%/features/user-unit-tests.feature"
                 - "%paths.base%/features/user-search.feature"
             contexts: [ FeatureContext, Sil\SilIdBroker\Behat\Context\UnitTestsContext ]
         analytics_features:

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -194,6 +194,8 @@ return [
         'idpName'                       => $idpName,
         'idpDisplayName'                => $idpDisplayName,
         'mfaAddInterval'                => Env::get('MFA_ADD_INTERVAL', '+30 days'),
+        'mfaRequiredForNewUsers'        => Env::get('MFA_REQUIRED_FOR_NEW_USERS', false),
+        'mfaAllowDisable'               => Env::get('MFA_ALLOW_DISABLE', true),
         'methodAddInterval'             => Env::get('METHOD_ADD_INTERVAL', '+6 months'),
         'profileReviewInterval'         => Env::get('PROFILE_REVIEW_INTERVAL', '+6 months'),
         'passwordReuseLimit'            => Env::get('PASSWORD_REUSE_LIMIT', 10),

--- a/application/common/models/Mfa.php
+++ b/application/common/models/Mfa.php
@@ -104,6 +104,14 @@ class Mfa extends MfaBase
                 self::EVENT_TYPE_VERIFY,
                 $this
             );
+
+            if (! \Yii::$app->params['mfaAllowDisable']
+                && $this->user->require_mfa === 'no'
+            ) {
+                $this->user->require_mfa = 'yes';
+                $this->user->scenario = User::SCENARIO_UPDATE_USER;
+                $this->user->save();
+            }
         }
     }
 

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -442,7 +442,8 @@ class User extends UserBase
             },
             'profile_review' => function (self $model) {
                 return $model->getNagState() == NagState::NAG_PROFILE_REVIEW ? 'yes' : 'no';
-            }
+            },
+            'require_mfa',
         ];
 
         if ($this->current_password_id !== null) {
@@ -880,6 +881,19 @@ class User extends UserBase
 
         if ($this->isExpired()) {
             $this->deactivateExpiredUser();
+        }
+
+        if ($this->scenario == self::SCENARIO_NEW_USER
+            && \Yii::$app->params['mfaRequiredForNewUsers']
+        ) {
+            $this->require_mfa = 'yes';
+        }
+
+        if (! \Yii::$app->params['mfaAllowDisable']
+            && $this->require_mfa == 'no'
+            && $this->getOldAttribute('require_mfa') == 'yes'
+        ) {
+            $this->require_mfa = 'yes';
         }
 
         return parent::beforeSave($insert);

--- a/application/features/bootstrap/FeatureContext.php
+++ b/application/features/bootstrap/FeatureContext.php
@@ -278,31 +278,42 @@ class FeatureContext extends YiiContext
     }
 
     /**
-     * @Given /^the following data (is|is not) returned:$/
+     * @Then the following data is returned:
      */
-    public function theFollowingDataReturned($isOrIsNot, TableNode $data)
+    public function theFollowingDataIsReturned(TableNode $data)
     {
         foreach ($data as $row) {
             if (strpos($row['property'], '.') !== false) {
                 $name = explode('.', $row['property'], 2);
-                if ($isOrIsNot === 'is') {
-                    Assert::eq(
-                        $this->resBody[$name[0]][$name[1]],
+                Assert::eq(
+                    $this->resBody[$name[0]][$name[1]],
+                    $row['value'],
+                    sprintf(
+                        '"%s" not equal to "%s", "%s" found',
+                        $row['property'],
                         $row['value'],
-                        sprintf(
-                            '"%s" not equal to "%s", "%s" found',
-                            $row['property'],
-                            $row['value'],
-                            $this->resBody[$name[0]][$name[1]]
-                        )
-                    );
-                } else {
-                    Assert::true(false, "invalid test condition");
-                }
+                        $this->resBody[$name[0]][$name[1]]
+                    )
+                );
             } else {
-                $isOrIsNot === 'is' ? Assert::eq($this->resBody[$row['property']], $row['value'])
-                    : Assert::keyNotExists($this->resBody, $row['property']);
+                Assert::keyExists(
+                    $this->resBody,
+                    $row['property'],
+                    'key ' . $row['property'] . ' not found in ' . var_export($this->resBody, true)
+                );
+                Assert::eq($this->resBody[$row['property']], $row['value']);
             }
+        }
+    }
+
+
+    /**
+     * @Given the following data is not returned:
+     */
+    public function theFollowingDataIsNotReturned(TableNode $data)
+    {
+        foreach ($data as $row) {
+            Assert::keyNotExists($this->resBody, $row['property']);
         }
     }
 

--- a/application/features/bootstrap/FeatureContext.php
+++ b/application/features/bootstrap/FeatureContext.php
@@ -396,7 +396,7 @@ class FeatureContext extends YiiContext
     }
 
     /**
-     * @Given /^I change the (.*) to (.*)$/
+     * @Given /^I change the (\w*) to (.*)$/
      */
     public function iChangeThe($property, $value)
     {

--- a/application/features/bootstrap/UnitTestsContext.php
+++ b/application/features/bootstrap/UnitTestsContext.php
@@ -295,9 +295,7 @@ class UnitTestsContext extends YiiContext
      */
     public function thatUserHasAPropertyValueOf($property, $value)
     {
-        $this->tempUser->$property = $value;
-        $this->tempUser->save();
-        Assert::eq($this->tempUser->$property, $value);
+        $this->iChangeTheUsersPropertyTo($property, $value);
     }
 
     /**

--- a/application/features/user-unit-tests.feature
+++ b/application/features/user-unit-tests.feature
@@ -1,0 +1,51 @@
+Feature: User Unit Tests
+
+  Unit tests for the User model
+
+  Background:
+    Given the user store is empty
+
+  Scenario: Create a user with require_mfa = no when mfaRequiredForNewUsers is false
+    Given the mfaRequiredForNewUsers config parameter is false
+    When I create a new user with a require_mfa property of no
+    Then I see the user's require_mfa property is no
+
+  Scenario: Create a user with require_mfa = no when mfaRequiredForNewUsers is true
+    Given the mfaRequiredForNewUsers config parameter is true
+    When I create a new user with a require_mfa property of no
+    Then I see the user's require_mfa property is yes
+
+  Scenario: Ensure require_mfa remains "no" for existing users
+    Given the database contains a user
+      And that user has a require_mfa property value of no
+      And the mfaRequiredForNewUsers config parameter is true
+    When I change the user's hide property to yes
+    Then I see the user's require_mfa property is no
+
+  Scenario: Set require_mfa to 'no' when mfaAllowDisable is true
+    Given the database contains a user
+      And that user has a require_mfa property value of yes
+      And the mfaAllowDisable config parameter is true
+    When I change the user's require_mfa property to no
+    Then I see the user's require_mfa property is no
+
+  Scenario: Attempt to set require_mfa to 'no' when mfaAllowDisable is false
+    Given the database contains a user
+      And that user has a require_mfa property value of yes
+      And the mfaAllowDisable config parameter is false
+    When I change the user's require_mfa property to no
+    Then I see the user's require_mfa property is yes
+
+  Scenario: Ensure require_mfa is remains "no" when mfaAllowDisable is true
+    Given the database contains a user with no MFA options
+      And that user has a require_mfa property value of no
+      And the mfaAllowDisable config parameter is true
+    When I add backup codes for that user
+    Then I see the user's require_mfa property is no
+
+  Scenario: Ensure require_mfa is set to "yes" when a first option is added
+    Given the database contains a user with no MFA options
+      And that user has a require_mfa property value of no
+      And the mfaAllowDisable config parameter is false
+    When I add backup codes for that user
+    Then I see the user's require_mfa property is yes

--- a/local.env.dist
+++ b/local.env.dist
@@ -177,9 +177,15 @@ GA_CLIENT_ID=
 
 # === MFA parameters ===
 
-# MFA_lifetime defines the amount of time in which an MFA must be verified
+# Require MFA for all new users, default is disabled
+#MFA_REQUIRED_FOR_NEW_USERS=false
+
+# If false, 'require_mfa' cannot be set to 'no' for any user, default=true
+#MFA_ALLOW_DISABLE=true
+
+# MFA_LIFETIME defines the amount of time in which an MFA must be verified
 # defaults to "+2 hours"
-#MFA_lifetime=
+#MFA_LIFETIME=
 
 # Email address to include in bcc for manager mfa emails
 # By default does not include a bcc address.


### PR DESCRIPTION
- `mfaAllowDisable` makes `require_mfa` a one-way switch
- `mfaRequiredForNewUsers` sets `require_mfa` to "yes" for all new users

Also added `require_mfa` property to User API responses, e.g. for https://github.com/silinternational/idp-id-broker-search.