### PR TITLE
Change pwned expiration to short future time

### DIFF
--- a/application/common/models/Password.php
+++ b/application/common/models/Password.php
@@ -263,7 +263,7 @@ class Password extends PasswordBase
     {
         $this->setScenario(self::SCENARIO_UPDATE_METADATA);
         $this->hibp_is_pwned = 'yes';
-        $this->expires_on = MySqlDateTime::relativeTime('-20 years');
+        $this->expires_on = MySqlDateTime::relativeTime('+5 minutes');
         $this->grace_period_ends_on = MySqlDateTime::relativeTime(\Yii::$app->params['hibpGracePeriod']);
         if (! $this->save()) {
             \Yii::error([


### PR DESCRIPTION
Setting to past time sent user directly to password expired page but we want to allow current login through.