### PR TITLE
limit password expired emails

### DIFF
--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -718,12 +718,15 @@ class Emailer extends Component
         foreach ($users as $user) {
             /** @var Password $userPassword */
             $userPassword = $user->currentPassword;
-            if ($userPassword
-                && strtotime($userPassword->getExpiresOn()) < time()
-                && ! $this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRED)
-            ) {
-                $this->sendMessageTo(EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRED, $user);
-                $numEmailsSent++;
+            if ($userPassword) {
+                $passwordExpiry = strtotime($userPassword->getExpiresOn());
+                if ($passwordExpiry < time()
+                    && $passwordExpiry > strtotime('-15 days')
+                    && ! $this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRED)
+                ) {
+                    $this->sendMessageTo(EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRED, $user);
+                    $numEmailsSent++;
+                }
             }
         }
 

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -661,16 +661,26 @@ class Emailer extends Component
             return;
         }
 
+        $logData = [
+            'action' => 'send password expiring notices',
+            'status' => 'starting',
+        ];
+
+        $users = User::getActiveUnlockedUsers();
+
+        $this->logger->info(array_merge($logData, [
+            'active_users' => count($users)
+        ]));
+
         $numEmailsSent = 0;
-        $users = User::findAll(['active' => 'yes', 'locked' => 'no', ]);
         foreach ($users as $user) {
             /** @var Password $userPassword */
             $userPassword = $user->currentPassword;
             if ($userPassword) {
                 $passwordExpiry = strtotime($userPassword->getExpiresOn());
                 if ($passwordExpiry < strtotime('+15 days')
-                    && !($passwordExpiry < time())
-                    && !$this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRING)
+                    && ! ($passwordExpiry < time())
+                    && ! $this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRING)
                 ) {
                     $this->sendMessageTo(EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRING, $user);
                     $numEmailsSent++;
@@ -678,11 +688,10 @@ class Emailer extends Component
             }
         }
 
-        $this->logger->info([
-            'action' => 'send password expiring notices',
+        $this->logger->info(array_merge($logData, [
             'status' => 'finished',
             'number_sent' => $numEmailsSent,
-        ]);
+        ]));
     }
 
     /**
@@ -694,8 +703,18 @@ class Emailer extends Component
             return;
         }
 
+        $logData = [
+            'action' => 'send password expired notices',
+            'status' => 'starting',
+        ];
+
+        $users = User::getActiveUnlockedUsers();
+
+        $this->logger->info(array_merge($logData, [
+            'active_users' => count($users)
+        ]));
+
         $numEmailsSent = 0;
-        $users = User::findAll(['active' => 'yes', 'locked' => 'no', ]);
         foreach ($users as $user) {
             /** @var Password $userPassword */
             $userPassword = $user->currentPassword;
@@ -708,10 +727,9 @@ class Emailer extends Component
             }
         }
 
-        $this->logger->info([
-            'action' => 'send password expired notices',
+        $this->logger->info(array_merge($logData, [
             'status' => 'finished',
             'number_sent' => $numEmailsSent,
-        ]);
+        ]));
     }
 }

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -53,6 +53,8 @@ class Emailer extends Component
     const PROP_HTML_BODY = 'html_body';
     const PROP_TEXT_BODY = 'text_body';
     const PROP_DELAY_SECONDS = 'delay_seconds';
+    const FifteenDaysAgo = '-15 days';
+    const FifteenDaysFromNow = '+15 days';
 
     /**
      * The configuration for the email-service client.
@@ -678,7 +680,7 @@ class Emailer extends Component
             $userPassword = $user->currentPassword;
             if ($userPassword) {
                 $passwordExpiry = strtotime($userPassword->getExpiresOn());
-                if ($passwordExpiry < strtotime('+15 days')
+                if ($passwordExpiry < strtotime(self::FifteenDaysFromNow)
                     && ! ($passwordExpiry < time())
                     && ! $this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRING)
                 ) {
@@ -721,7 +723,7 @@ class Emailer extends Component
             if ($userPassword) {
                 $passwordExpiry = strtotime($userPassword->getExpiresOn());
                 if ($passwordExpiry < time()
-                    && $passwordExpiry > strtotime('-15 days')
+                    && $passwordExpiry > strtotime(self::FifteenDaysAgo)
                     && ! $this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRED)
                 ) {
                     $this->sendMessageTo(EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRED, $user);

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -53,8 +53,9 @@ class Emailer extends Component
     const PROP_HTML_BODY = 'html_body';
     const PROP_TEXT_BODY = 'text_body';
     const PROP_DELAY_SECONDS = 'delay_seconds';
-    const FifteenDaysAgo = '-15 days';
-    const FifteenDaysFromNow = '+15 days';
+
+    const FIFTEEN_DAYS_AGO = '-15 days';
+    const FIFTEEN_DAYS_FROM_NOW = '+15 days';
 
     /**
      * The configuration for the email-service client.
@@ -680,7 +681,7 @@ class Emailer extends Component
             $userPassword = $user->currentPassword;
             if ($userPassword) {
                 $passwordExpiry = strtotime($userPassword->getExpiresOn());
-                if ($passwordExpiry < strtotime(self::FifteenDaysFromNow)
+                if ($passwordExpiry < strtotime(self::FIFTEEN_DAYS_FROM_NOW)
                     && ! ($passwordExpiry < time())
                     && ! $this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRING)
                 ) {
@@ -723,7 +724,7 @@ class Emailer extends Component
             if ($userPassword) {
                 $passwordExpiry = strtotime($userPassword->getExpiresOn());
                 if ($passwordExpiry < time()
-                    && $passwordExpiry > strtotime(self::FifteenDaysAgo)
+                    && $passwordExpiry > strtotime(self::FIFTEEN_DAYS_AGO)
                     && ! $this->hasReceivedMessageRecently($user->id, EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRED)
                 ) {
                     $this->sendMessageTo(EmailLog::MESSAGE_TYPE_PASSWORD_EXPIRED, $user);

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -151,6 +151,7 @@ return [
                     'logVars' => [],
                     'categories' => ['application'],
                     'prefix' => $logPrefix,
+                    'exportInterval' => 1,
                 ],
                 [
                     'class' => JsonStreamTarget::class,
@@ -158,6 +159,7 @@ return [
                     'levels' => ['error', 'warning'],
                     'logVars' => [],
                     'prefix' => $logPrefix,
+                    'exportInterval' => 1,
                 ],
                 [
                     'class' => EmailServiceTarget::class,

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1265,4 +1265,12 @@ class User extends UserBase
         $logAttributes['status'] = 'success';
         Yii::warning($logAttributes);
     }
+
+    /**
+     * @return User[]
+     */
+    public static function getActiveUnlockedUsers()
+    {
+        return User::findAll(['active' => 'yes', 'locked' => 'no']);
+    }
 }

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1123,22 +1123,6 @@ class EmailContext extends YiiContext
     }
 
     /**
-     * @Given /^that user has a password that expires (yesterday|today|tomorrow)/
-     */
-    public function thatUserHasAPasswordThatExpires($day)
-    {
-        if ($day == 'yesterday') {
-            $this->thatUserHasAPasswordThatExpiresInDays(-1);
-        } elseif ($day == 'today') {
-            $this->thatUserHasAPasswordThatExpiresInDays(0);
-        } elseif ($day == 'tomorrow') {
-            $this->thatUserHasAPasswordThatExpiresInDays(1);
-        } else {
-            Assert::false(true, 'Invalid tense provided in scenario.');
-        }
-    }
-
-    /**
      * @Given a mfaManagerBcc email address is configured
      */
     public function aMfamanagerbccEmailAddressIsConfigured()

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -372,17 +372,19 @@ Feature: Email
     Given we are configured <toSendOrNot> password expired emails
       And I remove records of any emails that have been sent
       And a user already exists
-      And that user has a password that expires <day>
+      And that user has a password that expires in <number> days
       And a "password-expired" email <hasOrHasNot> been sent to that user
     When I send password expired emails
     Then a "password-expired" email <shouldOrNot> have been sent to them
 
     Examples:
-      | toSendOrNot  | day        | hasOrHasNot  | shouldOrNot    |
-      | to send      | tomorrow   | has NOT      | should NOT     |
-      | to send      | today      | has NOT      | should NOT     |
-      | to send      | yesterday  | has NOT      | should         |
-      | to send      | tomorrow   | has          | should NOT     |
-      | to send      | today      | has          | should NOT     |
-      | to send      | yesterday  | has          | should NOT     |
-      | NOT to send  | yesterday  | has NOT      | should NOT     |
+      | toSendOrNot  | number | hasOrHasNot  | shouldOrNot    |
+      | to send      | 1      | has NOT      | should NOT     |
+      | to send      | 0      | has NOT      | should NOT     |
+      | to send      | -1     | has NOT      | should         |
+      | to send      | -15    | has NOT      | should         |
+      | to send      | -16    | has NOT      | should NOT     |
+      | to send      | 1      | has          | should NOT     |
+      | to send      | 0      | has          | should NOT     |
+      | to send      | -1     | has          | should NOT     |
+      | NOT to send  | -1     | has NOT      | should NOT     |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
             - data
         ports:
             - "51140:80"
+        mem_limit: 200m
         depends_on:
             - db
         env_file:
@@ -33,6 +34,7 @@ services:
         build: ./
         volumes_from:
             - data
+        mem_limit: 200m
         volumes:
             - ./dockerbuild/broker-cron:/etc/cron.d/broker-cron
         depends_on:
@@ -48,6 +50,7 @@ services:
         build: ./
         volumes_from:
             - data
+        mem_limit: 200m
         ports:
             - "80"
         depends_on:
@@ -84,6 +87,7 @@ services:
             - ${COMPOSER_CACHE_DIR}:/composer
         volumes_from:
             - data
+        mem_limit: 200m
         working_dir: /data
         environment:
             COMPOSER_CACHE_DIR: /composer
@@ -95,6 +99,7 @@ services:
         image: silintl/php7:7.2
         volumes_from:
             - data
+        mem_limit: 200m
         working_dir: /data
         depends_on:
             - appfortests


### PR DESCRIPTION
Since at least one IdP instance was affected by an out-of-memory problem on sending password expiry messages, we realize it is not helpful to send password expired messages long after the fact. This change limits these messages to only those that have a password expired in the past 15 days.