### PR TITLE
add user created date

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -171,6 +171,7 @@ class User extends UserBase
             'hide',
             'groups',
             'expires_on',
+            'created_utc',
         ];
 
         $scenarios[self::SCENARIO_UPDATE_USER] = [
@@ -264,7 +265,7 @@ class User extends UserBase
                 ['manager_email', 'personal_email'], 'email',
             ],
             [
-                ['last_synced_utc', 'last_changed_utc'],
+                ['last_synced_utc', 'last_changed_utc', 'created_utc'],
                 'default', 'value' => MySqlDateTime::now(),
             ],
             [
@@ -525,6 +526,9 @@ class User extends UserBase
             'locked',
             'last_login_utc' => function (self $model) {
                 return $model->last_login_utc === null ? null : Utils::getIso8601($model->last_login_utc);
+            },
+            'created_utc' => function (self $model) {
+                return $model->created_utc === null ? null : Utils::getIso8601($model->created_utc);
             },
             'manager_email',
             'personal_email' => function (self $model) {
@@ -909,6 +913,8 @@ class User extends UserBase
 
         $labels['last_changed_utc'] = Yii::t('app', 'Last Changed (UTC)');
         $labels['last_synced_utc'] = Yii::t('app', 'Last Synced (UTC)');
+        $labels['created_utc'] = Yii::t('app', 'Created (UTC)');
+        
 
         return $labels;
     }

--- a/application/common/models/UserBase.php
+++ b/application/common/models/UserBase.php
@@ -30,6 +30,7 @@ use Yii;
  * @property string|null $expires_on
  * @property string $nag_for_mfa_after
  * @property string $nag_for_method_after
+ * @property string|null $created_utc
  *
  * @property Password $currentPassword
  * @property EmailLog[] $emailLogs
@@ -56,7 +57,7 @@ class UserBase extends \yii\db\ActiveRecord
             [['uuid', 'employee_id', 'first_name', 'last_name', 'username', 'active', 'locked', 'last_changed_utc', 'last_synced_utc', 'review_profile_after', 'nag_for_mfa_after', 'nag_for_method_after'], 'required'],
             [['current_password_id'], 'integer'],
             [['active', 'locked', 'require_mfa', 'hide'], 'string'],
-            [['last_changed_utc', 'last_synced_utc', 'review_profile_after', 'last_login_utc', 'expires_on', 'nag_for_mfa_after', 'nag_for_method_after'], 'safe'],
+            [['last_changed_utc', 'last_synced_utc', 'review_profile_after', 'last_login_utc', 'expires_on', 'nag_for_mfa_after', 'nag_for_method_after', 'created_utc'], 'safe'],
             [['uuid'], 'string', 'max' => 64],
             [['employee_id', 'first_name', 'last_name', 'display_name', 'username', 'email', 'manager_email', 'groups', 'personal_email'], 'string', 'max' => 255],
             [['employee_id'], 'unique'],
@@ -95,6 +96,7 @@ class UserBase extends \yii\db\ActiveRecord
             'expires_on' => Yii::t('app', 'Expires On'),
             'nag_for_mfa_after' => Yii::t('app', 'Nag For Mfa After'),
             'nag_for_method_after' => Yii::t('app', 'Nag For Method After'),
+            'created_utc' => Yii::t('app', 'Created Utc'),
         ];
     }
 

--- a/application/console/migrations/m210112_185351_add_created_utc_to_user.php
+++ b/application/console/migrations/m210112_185351_add_created_utc_to_user.php
@@ -1,0 +1,26 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m210112_185351_add_created_utc_to_user
+ */
+class m210112_185351_add_created_utc_to_user extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{user}}', 'created_utc', 'datetime null');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropColumn('{{user}}', 'created_utc'); 
+    }
+
+}

--- a/application/features/bootstrap/FeatureContext.php
+++ b/application/features/bootstrap/FeatureContext.php
@@ -322,6 +322,8 @@ class FeatureContext extends YiiContext
      */
     public function aRecordExistsForThisKey($lookupKey, $lookupValue)
     {
+        $this->userFromDbBefore = $this->userFromDb;
+
         $this->userFromDb = User::findOne([$lookupKey => $lookupValue]);
 
         Assert::notNull($this->userFromDb, sprintf(
@@ -367,6 +369,18 @@ class FeatureContext extends YiiContext
         $storedNow = strtotime($this->userFromDb->$property);
 
         Assert::range($storedNow, $minAcceptable, $maxAcceptable);
+    }
+
+    /**
+     * @Then :property should not change
+     *
+     */
+    public function shouldNotChange($property)
+    {
+        $valueBefore = $this->userFromDbBefore->$property;
+        $valueNow = $this->userFromDb->$property;
+
+        Assert::eq($valueBefore, $valueNow);
     }
 
     /**

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -58,6 +58,7 @@ Feature: User
         | groups              | NULL                  |
       And last_changed_utc should be stored as now UTC
       And last_synced_utc should be stored as now UTC
+      And created_utc should be stored as now UTC
 
 #TODO: related to PUT now.
 #  Scenario: "Touch" an existing user without making any changes
@@ -110,6 +111,7 @@ Feature: User
       And a record exists with a <property> of <value>
       And last_changed_utc should be stored as now UTC
       And last_synced_utc should be stored as now UTC
+      And created_utc should not change
 
     Examples:
       | property        | value              |


### PR DESCRIPTION
The created_utc field is set to the current time when a user is created, and doesn't change when a user is updated. It does not, however, prevent an API consumer setting created_utc to any value they want when creating a user. We wrestled with it but settled on the "don't care" side of the issue since (1) we won't do that, and (2) it may not be altogether bad to allow it.