### PR TITLE
add deactivated_utc property to User

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- Added created date to user
+- Added created date/time to user
 - Send email alert to HR with all abandoned users, if any
+- Added deactivated date/time to user
 
 ## [5.2.3] - 2020-10-27
 ### Fixed

--- a/api.raml
+++ b/api.raml
@@ -65,6 +65,7 @@ types:
         enum: [ yes, no ]
       last_login_utc?: string
       created_utc?: string
+      deactivated_utc?: string
       manager_email?: string
       personal_email?: string
       hide:
@@ -115,6 +116,7 @@ types:
         "locked": "no",
         "last_login_utc": "2017-05-24T14:04:51Z",
         "created_utc": "2017-05-24T14:04:51Z",
+        "deactivated_utc": null,
         "hide": "no",
         "member": [],
         "mfa": {

--- a/application/common/models/UserBase.php
+++ b/application/common/models/UserBase.php
@@ -31,6 +31,7 @@ use Yii;
  * @property string $nag_for_mfa_after
  * @property string $nag_for_method_after
  * @property string|null $created_utc
+ * @property string|null $deactivated_utc
  *
  * @property Password $currentPassword
  * @property EmailLog[] $emailLogs
@@ -57,7 +58,7 @@ class UserBase extends \yii\db\ActiveRecord
             [['uuid', 'employee_id', 'first_name', 'last_name', 'username', 'active', 'locked', 'last_changed_utc', 'last_synced_utc', 'review_profile_after', 'nag_for_mfa_after', 'nag_for_method_after'], 'required'],
             [['current_password_id'], 'integer'],
             [['active', 'locked', 'require_mfa', 'hide'], 'string'],
-            [['last_changed_utc', 'last_synced_utc', 'review_profile_after', 'last_login_utc', 'expires_on', 'nag_for_mfa_after', 'nag_for_method_after', 'created_utc'], 'safe'],
+            [['last_changed_utc', 'last_synced_utc', 'review_profile_after', 'last_login_utc', 'expires_on', 'nag_for_mfa_after', 'nag_for_method_after', 'created_utc', 'deactivated_utc'], 'safe'],
             [['uuid'], 'string', 'max' => 64],
             [['employee_id', 'first_name', 'last_name', 'display_name', 'username', 'email', 'manager_email', 'groups', 'personal_email'], 'string', 'max' => 255],
             [['employee_id'], 'unique'],
@@ -97,6 +98,7 @@ class UserBase extends \yii\db\ActiveRecord
             'nag_for_mfa_after' => Yii::t('app', 'Nag For Mfa After'),
             'nag_for_method_after' => Yii::t('app', 'Nag For Method After'),
             'created_utc' => Yii::t('app', 'Created Utc'),
+            'deactivated_utc' => Yii::t('app', 'Deactivated Utc'),
         ];
     }
 

--- a/application/console/migrations/m210503_094330_add_deactivated_utc_to_user.php
+++ b/application/console/migrations/m210503_094330_add_deactivated_utc_to_user.php
@@ -1,0 +1,26 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m210503_094330_add_deactivated_utc_to_user
+ */
+class m210503_094330_add_deactivated_utc_to_user extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->addColumn('{{user}}', 'deactivated_utc', 'datetime null');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->dropColumn('{{user}}', 'deactivated_utc');
+    }
+
+}

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -56,6 +56,7 @@ Feature: User
         | personal_email      | NULL                  |
         | hide                | yes                   |
         | groups              | NULL                  |
+        | deactivated_utc     | NULL                  |
       And last_changed_utc should be stored as now UTC
       And last_synced_utc should be stored as now UTC
       And created_utc should be stored as now UTC
@@ -130,6 +131,26 @@ Feature: User
       | hide            | no                 |
       | hide            | yes                |
       | groups          | mensa,hackers      |
+
+  Scenario: Deactivate an existing user
+    Given a record does not exist with an employee_id of "123"
+      And the requester is authorized
+      And I provide the following valid data:
+        | property        | value                 |
+        | employee_id     | 123                   |
+        | first_name      | Shep                  |
+        | last_name       | Clark                 |
+        | display_name    | Shep Clark            |
+        | username        | shep_clark            |
+        | email           | shep_clark@example.org|
+        | hide            | yes                   |
+      And I request "/user" be created
+      And the response status code should be 200
+      And I change the active to no
+    When I request "/user/123" be updated
+    Then the response status code should be 200
+      And a record exists with a active of no
+      And deactivated_utc should be stored as now UTC
 
 #TODO: consider creating a new security.feature file for all these security-related tests.
 #TODO: need to think through tests for API_ACCESS_KEYS config, i.e., need tests for ApiConsumer


### PR DESCRIPTION
`deactivated_utc` is set to the current time when `active` changes from `'yes'` to `'no'`

I opted not to set it to `null` if a user is reactivated in order to retain the date/time for troubleshooting in case there is a future scenario requires that information. If you believe this will prove more confusing (e.g. an active user with a non-null `deactivated_utc`), I will revise this.