### PR TITLE
Not for merging ... delete webauthn credential

### DIFF
--- a/application/common/components/MfaApiClient.php
+++ b/application/common/components/MfaApiClient.php
@@ -169,6 +169,17 @@ class MfaApiClient
     }
 
     /**
+     * @param array $additionalHeaders
+     * @return bool
+     * @throws GuzzleException
+     */
+    public function webauthnDeleteCredential(string $credId, array $additionalHeaders): bool
+    {
+        $this->callApi("webauthn/credential/$credId", 'DELETE', [], $additionalHeaders);
+        return true;
+    }
+
+    /**
      * @param string $path
      * @param string $method
      * @param array $body

--- a/application/common/components/MfaBackendBackupcode.php
+++ b/application/common/components/MfaBackendBackupcode.php
@@ -80,4 +80,17 @@ class MfaBackendBackupcode extends Component implements MfaBackendInterface
     {
         return MfaBackupcode::deleteCodesForMfaId($mfaId);
     }
+
+
+    /**
+     * Delete WebAuthn credential
+     * @param int $mfaId
+     * @param string $credId
+     * @param string $rpOrigin
+     * @return bool
+     */
+    public function deleteCredential(int $mfaId, string $credId, string $rpOrigin): bool
+    {
+       return true;
+    }
 }

--- a/application/common/components/MfaBackendInterface.php
+++ b/application/common/components/MfaBackendInterface.php
@@ -35,4 +35,16 @@ interface MfaBackendInterface
      * @return bool
      */
     public function delete(int $mfaId): bool;
+
+
+
+    /**
+     * Delete WebAuthn credential
+     * @param int $mfaId
+     * @param string $credId
+     * @param string $rpOrigin
+     * @return bool
+     */
+    public function deleteCredential(int $mfaId, string $credId, string $rpOrigin): bool;
+
 }

--- a/application/common/components/MfaBackendManager.php
+++ b/application/common/components/MfaBackendManager.php
@@ -110,4 +110,17 @@ class MfaBackendManager extends Component implements MfaBackendInterface
     {
         return MfaBackupcode::deleteCodesForMfaId($mfaId);
     }
+
+
+    /**
+     * Delete WebAuthn credential
+     * @param int $mfaId
+     * @param string $credId
+     * @param string $rpOrigin
+     * @return bool
+     */
+    public function deleteCredential(int $mfaId, string $credId, string $rpOrigin): bool
+    {
+        return true;
+    }
 }

--- a/application/common/components/MfaBackendTotp.php
+++ b/application/common/components/MfaBackendTotp.php
@@ -117,4 +117,17 @@ class MfaBackendTotp extends Component implements MfaBackendInterface
 
         return true;
     }
+
+
+    /**
+     * Delete WebAuthn credential
+     * @param int $mfaId
+     * @param string $credId
+     * @param string $rpOrigin
+     * @return bool
+     */
+    public function deleteCredential(int $mfaId, string $credId, string $rpOrigin): bool
+    {
+        return true;
+    }
 }

--- a/application/common/components/MfaBackendWebAuthn.php
+++ b/application/common/components/MfaBackendWebAuthn.php
@@ -173,6 +173,37 @@ class MfaBackendWebAuthn extends Component implements MfaBackendInterface
         return true;
     }
 
+
+    /**
+     * Delete WebAuthn credential
+     * @param int $mfaId
+     * @param string $credId
+     * @param string $rpOrigin The Replay Party Origin URL (with scheme, without port or path)
+     * @return bool
+     * @throws NotFoundHttpException
+     * @throws GuzzleException
+     */
+    public function deleteCredential(int $mfaId, string $credId, string $rpOrigin): bool
+    {
+        $mfa = Mfa::findOne(['id' => $mfaId]);
+        if ($mfa == null) {
+            throw new NotFoundHttpException("MFA record for given ID not found");
+        }
+
+        $headers = $this->getWebAuthnHeaders(
+            $mfa->user->username,
+            $mfa->user->getDisplayName(),
+            $rpOrigin,
+            $mfa->external_uuid
+        );
+
+        if (!empty($mfa->external_uuid)) {
+            return $this->client->webauthnDeleteCredential($credId, $headers);
+        }
+
+        return true;
+    }
+
     /**
      * The WebAuthn API requires a bunch of headers, this method returns the parameters as an array of
      * headers to be included with API calls.

--- a/application/features/bootstrap/MfaContext.php
+++ b/application/features/bootstrap/MfaContext.php
@@ -139,6 +139,22 @@ class MfaContext extends \FeatureContext
         $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id, 'deleted');
     }
 
+
+    /**
+     * @When I request to delete a credential of the MFA with a credential_id of :credId
+     */
+    public function iRequestToDeleteACredentialOfTheMfaWithACredentialIDOf($credId)
+    {
+        $dataForTableNode = [
+            ['property', 'value'],
+            ['employee_id', '123'],
+        ];
+
+        $this->iProvideTheFollowingValidData(new TableNode($dataForTableNode));
+        $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id . '/credential/' . $credId,
+            'deleted');
+    }
+
     /**
      * @Then the MFA record is not stored
      */

--- a/application/features/mfa.feature
+++ b/application/features/mfa.feature
@@ -120,3 +120,9 @@ Feature: MFA
       And 0 codes should be stored
       And the MFA record is not stored
 
+  Scenario: Delete the credential of a webauthn MFA option
+    Given the user has a verified "webauthn" MFA
+    When I request to delete a credential of the MFA with a credential_id of "123"
+    Then the response status code should be 400
+    And 10 codes should be stored
+

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -60,11 +60,12 @@ return [
                 /*
                  * MFA routes
                  */
-                'GET    user/<employeeId:\w+>/mfa'    => 'mfa/list',
-                'POST   mfa'                          => 'mfa/create',
-                'PUT    mfa/<id:\d+>'                 => 'mfa/update',
-                'POST   mfa/<id:\d+>/verify'          => 'mfa/verify',
-                'DELETE mfa/<id:\d+>'                 => 'mfa/delete',
+                'GET    user/<employeeId:\w+>/mfa'              => 'mfa/list',
+                'POST   mfa'                                    => 'mfa/create',
+                'PUT    mfa/<id:\d+>'                           => 'mfa/update',
+                'POST   mfa/<id:\d+>/verify'                    => 'mfa/verify',
+                'DELETE mfa/<id:\d+>'                           => 'mfa/delete',
+                'DELETE mfa/<mfaId:\d+>/credential/<credId:.+>' => 'mfa/delete-credential',
 
                 /*
                  * Method routes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,12 @@ services:
             EMAIL_SERVICE_assertValidIp: "false"
             EMAIL_SERVICE_baseUrl: dummy
             EMAIL_SIGNATURE: Dummy Signature for Test
+            MFA_WEBAUTHN_apiBaseUrl: https://example-api.com/
+            MFA_WEBAUTHN_apiKey: abc123
+            MFA_WEBAUTHN_apiSecret: abcd1234
+            MFA_WEBAUTHN_appId: ourApp99
+            MFA_WEBAUTHN_rpDisplayName: Our App
+            MFA_WEBAUTHN_rpId: app99
             HELP_CENTER_URL: https://www.example.com/help
             IDP_DISPLAY_NAME: Test
             IDP_NAME: test


### PR DESCRIPTION
Am I headed in the right direction on this?

Do you have any idea why I'm getting this error in my tiny behat test? (I tried adding the webauthn env vars in docker_compose.yml, but that didn't help.)

  When I request to delete a credential of the MFA with a credential_id of "123" # Sil\SilIdBroker\Behat\Context\MfaContext::iRequestToDeleteACredentialOfTheMfaWithACredentialIDOf()
  
  'message' => 'Typed property common\\components\\MfaBackendWebAuthn::$apiBaseUrl must not be accessed before initialization'
  
  