### PR TITLE
remove previous change that blanked out a missing manager_email

### DIFF
--- a/application/frontend/controllers/UserController.php
+++ b/application/frontend/controllers/UserController.php
@@ -66,12 +66,7 @@ class UserController extends BaseRestController
         }
 
         $user->scenario = User::SCENARIO_UPDATE_USER;
-
-        $bodyParams = Yii::$app->request->getBodyParams();
-        if (!isset($bodyParams['manager_email'])) {
-            $bodyParams['manager_email'] = '';
-        }
-
+        
         $user->attributes = Yii::$app->request->getBodyParams();
 
         $this->save($user);


### PR DESCRIPTION
I'm not even sure if it would have done anything, since I didn't tell it to use `$bodyParams` lower down