### PR TITLE
Fix bug with delete inactive users and test it

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -94,8 +94,7 @@ class User extends UserBase
         foreach ($this->mfas as $mfa) {
             // first delete the children and then the parent to avoid foreign key constraint error
             if ($mfa->type == MFA::TYPE_WEBAUTHN) {
-                $didDelete = self::deleteWebauthns($mfa);
-                if (!$didDelete) {
+                if (!self::deleteWebauthns($mfa)) {
                     return false;
                 }
             }
@@ -1223,7 +1222,6 @@ class User extends UserBase
                     $numDeleted += 1;
                 }
             } catch (\Exception $e) {
-                print_r(PHP_EOL . "EEEEEEEEEE: " . $e->getMessage() . PHP_EOL);
                 \Yii::error([
                     'action' => 'delete inactive users',
                     'status' => 'failed',

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -92,12 +92,6 @@ class User extends UserBase
         }
 
         foreach ($this->mfas as $mfa) {
-            // first delete the children and then the parent to avoid foreign key constraint error
-            if ($mfa->type == MFA::TYPE_WEBAUTHN) {
-                if (!self::deleteWebauthns($mfa)) {
-                    return false;
-                }
-            }
             if (! $mfa->delete()) {
                 \Yii::error([
                     'action' => 'delete mfa record before deleting user',
@@ -152,26 +146,6 @@ class User extends UserBase
             }
         }
 
-        return true;
-    }
-
-    // The MfaBackend code for deleting a webauthn type MFA
-    // isn't designed to do this so easily.
-    private static function deleteWebauthns(MFA $mfa)
-    {
-        $children = $mfa->mfaWebauthns;
-        foreach ($children as $child) {
-            if (!$child->delete()) {
-                \Yii::error([
-                    'action' => 'delete mfa webauthn child record before deleting mfa',
-                    'status' => 'error',
-                    'error' => $child->getFirstErrors(),
-                    'mfa_id' => $mfa->id,
-                    'child_id' => $child->id,
-                ]);
-                return false;
-            }
-        }
         return true;
     }
 

--- a/application/features/user.feature
+++ b/application/features/user.feature
@@ -741,3 +741,16 @@ Feature: User
       | no     | 7 months  | is NOT    |
       | yes    | 5 months  | is NOT    |
       | yes    | 7 months  | is        |
+
+  Scenario Outline: Delete inactive users even with webauthns
+    Given I create a new user with a "active" property of "<active>"
+      And that user has a verified backup code mfa
+      And that user has a verified webauthn mfa
+    When I delete inactive users
+     And I retrieve the remaining users
+    Then the user <isOrIsNot> included in the data
+
+    Examples:
+      | active | isOrIsNot |
+      | no     | is NOT    |
+      | yes    | is        |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,7 +165,7 @@ services:
             EMAIL_SERVICE_assertValidIp: "false"
             EMAIL_SERVICE_baseUrl: dummy
             EMAIL_SIGNATURE: Dummy Signature for Test
-            MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080
+            MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
             MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
             MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678
             # the corresponding hash: $2a$10$8Bp9PqqfStjLvh1nQJ67JeY3CO/mEXmF1GKfe8Vk0kue1.i7fa2mC


### PR DESCRIPTION
This was the error we were getting  ...
```
"error": "SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`idbroker`.`mfa_webauthn`, CONSTRAINT `fk_mfa_webauthn_mfa_id` FOREIGN KEY (`mfa_id`) REFERENCES `mfa` (`id`) ON DELETE NO ACTION ON UPDATE NO ACTION
```