### PR TITLE
Ensure required environment variables (as arrays) are present

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -9,6 +9,7 @@ use common\components\MfaBackendWebAuthn;
 use Sil\JsonLog\target\EmailServiceTarget;
 use Sil\JsonLog\target\JsonStreamTarget;
 use Sil\PhpEnv\Env;
+use Sil\PhpEnv\EnvVarNotFoundException;
 use yii\db\Connection;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
@@ -24,10 +25,25 @@ $notificationEmail = Env::get('NOTIFICATION_EMAIL');
 
 $mfaNumBackupCodes = Env::get('MFA_NUM_BACKUPCODES', 10);
 
+$envValidator = function($name, $key, $config) {
+    if (! isset($config[$key])) {
+        $message = "The $name environment variable is required";
+        throw new EnvVarNotFoundException($message);
+    }
+};
+
 $mfaTotpConfig = Env::getArrayFromPrefix('MFA_TOTP_');
 $mfaTotpConfig['issuer'] = $idpDisplayName;
 
+$envValidator('MFA_TOTP_apiBaseUrl', 'apiBaseUrl', $mfaTotpConfig);
+$envValidator('MFA_TOTP_apiKey', 'apiKey', $mfaTotpConfig);
+$envValidator('MFA_TOTP_apiSecret', 'apiSecret', $mfaTotpConfig);
+
 $mfaWebAuthnConfig = Env::getArrayFromPrefix('MFA_WEBAUTHN_');
+
+$envValidator('MFA_WEBAUTHN_apiBaseUrl', 'apiBaseUrl', $mfaTotpConfig);
+$envValidator('MFA_WEBAUTHN_apiKey', 'apiKey', $mfaTotpConfig);
+$envValidator('MFA_WEBAUTHN_apiSecret', 'apiSecret', $mfaTotpConfig);
 
 $emailerClass = Env::get('EMAILER_CLASS', Emailer::class);
 

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -61,11 +61,10 @@ $emailServiceConfig['validIpRanges'] = Env::getArray('EMAIL_SERVICE_validIpRange
 
 $passwordProfileUrl = Env::get('PASSWORD_PROFILE_URL');
 
-$logPrefix = function ($message) {
+$logPrefix = function () {
     $request = Yii::$app->request;
     $prefixData = [
         'env' => YII_ENV,
-        'message' => $message,
     ];
     if ($request instanceof \yii\web\Request) {
         // Assumes format: Bearer consumer-module-name-32randomcharacters

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -45,10 +45,11 @@ $emailServiceConfig['validIpRanges'] = Env::getArray('EMAIL_SERVICE_validIpRange
 
 $passwordProfileUrl = Env::get('PASSWORD_PROFILE_URL');
 
-$logPrefix = function () {
+$logPrefix = function ($message) {
     $request = Yii::$app->request;
     $prefixData = [
         'env' => YII_ENV,
+        'message' => $message,
     ];
     if ($request instanceof \yii\web\Request) {
         // Assumes format: Bearer consumer-module-name-32randomcharacters

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -38,6 +38,9 @@ app:
         HR_NOTIFICATIONS_EMAIL: hr@example.com
         ABANDONED_USER_bestPracticeUrl: http://www.example.com/best-practices.html
         ABANDONED_USER_deactivateInstructionsUrl: http://www.example.com/deactivate-instructions.html
+        MFA_TOTP_apiBaseUrl: notinuse/
+        MFA_TOTP_apiKey: 20345678-1234-1234-1234-123456789012
+        MFA_TOTP_apiSecret: 21345678-1234-1234-1234-12345678
         MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
         MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
         MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,9 @@ services:
             MYSQL_DATABASE: appfortests
             MYSQL_USER: appfortests
             MYSQL_PASSWORD: appfortests
+            MFA_TOTP_apiBaseUrl: notinuse/
+            MFA_TOTP_apiKey: 10345678-1234-1234-1234-123456789012
+            MFA_TOTP_apiSecret: 11345678-1234-1234-1234-12345678
             MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
             MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
             MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678
@@ -165,6 +168,9 @@ services:
             EMAIL_SERVICE_assertValidIp: "false"
             EMAIL_SERVICE_baseUrl: dummy
             EMAIL_SIGNATURE: Dummy Signature for Test
+            MFA_TOTP_apiBaseUrl: notinuse:8080/
+            MFA_TOTP_apiKey: 10345678-1234-1234-1234-123456789012
+            MFA_TOTP_apiSecret: 11345678-1234-1234-1234-12345678
             MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
             MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
             MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678


### PR DESCRIPTION
This keeps  AWS from killing the old task by not allowing the new task to become healthy and it creates the following logs in Cloudwatch.


```
{
    "name": "Internal Server Error",
    "message": "The MFA_TOTP_apiSecret environment variable is required",
    "status": 500
}
```