### PR TITLE
require MFA config variables on status check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ depsfortests:
 	docker-compose run --rm dynamorestart composer install
 
 depsshow:
-	docker-compose run --rm cli bash -c "composer show -D > versions.txt"
+	docker-compose run --rm cli bash -c 'composer show --format=json --no-dev --no-ansi --locked | jq ".locked[] | { \"name\": .name, \"version\": .version }" > dependencies.json'
 
 depsupdate:
 	docker-compose run --rm cli composer update

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ depsfortests:
 	docker-compose run --rm dynamorestart composer install
 
 depsshow:
-	docker-compose run --rm cli bash -c 'composer show --format=json --no-dev --no-ansi --locked | jq ".locked[] | { \"name\": .name, \"version\": .version }" > dependencies.json'
+	docker-compose run --rm cli bash -c 'composer show --format=json --no-dev --no-ansi --locked | jq "[.locked[] | { \"name\": .name, \"version\": .version }]" > dependencies.json'
 
 depsupdate:
 	docker-compose run --rm cli composer update

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -65,13 +65,13 @@ class Emailer extends Component
      * @var array
      */
     public $emailServiceConfig = [];
-    
+
     /** @var EmailServiceClient */
     protected $emailServiceClient = null;
-    
+
     /** @var LoggerInterface */
     public $logger = null;
-    
+
     /**
      * Other values that should be made available to be inserted into emails.
      * The keys should be camelCase and will be made available as variables
@@ -113,7 +113,7 @@ class Emailer extends Component
      * @var array
      */
     protected $subjects;
-    
+
     public $subjectForInvite;
     public $subjectForMfaRateLimit;
     public $subjectForPasswordChanged;
@@ -165,7 +165,7 @@ class Emailer extends Component
             'baseUrl',
             'validIpRanges',
         ];
-        
+
         foreach ($requiredParams as $param) {
             if (! isset($this->emailServiceConfig[$param])) {
                 throw new InvalidArgumentException(
@@ -174,7 +174,7 @@ class Emailer extends Component
                 );
             }
         }
-        
+
         foreach ($this->subjects as $messageType => $subject) {
             if (empty($subject)) {
                 throw new InvalidArgumentException(sprintf(
@@ -225,7 +225,7 @@ class Emailer extends Component
 
         $this->getEmailServiceClient()->email($properties);
     }
-    
+
     /**
      * @return EmailServiceClient
      */
@@ -241,19 +241,8 @@ class Emailer extends Component
                 ]
             );
         }
-        
-        return $this->emailServiceClient;
-    }
 
-    /**
-     * Ping the /site/status URL, and throw an exception if there's a problem.
-     *
-     * @return string "OK".
-     * @throws Exception
-     */
-    public function getSiteStatus()
-    {
-        return $this->getEmailServiceClient()->getSiteStatus();
+        return $this->emailServiceClient;
     }
 
     /**
@@ -337,9 +326,9 @@ class Emailer extends Component
         $this->hrNotificationsEmail = $this->hrNotificationsEmail ?? '';
 
         $this->assertConfigIsValid();
-        
+
         $this->verifyOtherDataForEmailIsValid();
-        
+
         parent::init();
     }
 
@@ -423,7 +412,7 @@ class Emailer extends Component
 
         return MySqlDateTime::dateIsRecent($latestEmail->sent_utc, $this->emailRepeatDelayDays);
     }
-    
+
     /**
      * Whether we should send an invite message to the given User.
      *
@@ -438,7 +427,7 @@ class Emailer extends Component
             && $isNewUser
             && !$user->hasReceivedMessage(EmailLog::MESSAGE_TYPE_INVITE);
     }
-    
+
     /**
      * Whether we should send a password-changed message to the given User.
      *
@@ -455,7 +444,7 @@ class Emailer extends Component
             && array_key_exists('current_password_id', $changedAttributes)
             && !is_null($changedAttributes['current_password_id']);
     }
-    
+
     /**
      * Whether we should send a welcome message to the given User.
      *
@@ -608,7 +597,7 @@ class Emailer extends Component
             && $mfa->verified
             && $user->getVerifiedMfaOptionsCount() < 1;
     }
-    
+
     /**
      * Verify that the other data provided for use in emails is acceptable. If
      * any data is missing, log that error but let the email be sent anyway.

--- a/application/common/components/MfaApiClient.php
+++ b/application/common/components/MfaApiClient.php
@@ -40,6 +40,14 @@ class MfaApiClient
 
     public function __construct(string $apiBaseUrl, $apiKey, $apiSecret)
     {
+        if (empty($apiKey)) {
+            throw new \InvalidArgumentException('Missing MFA configuration for api key');
+        }
+
+        if (empty($apiSecret)) {
+            throw new \InvalidArgumentException('Missing MFA configuration for api secret');
+        }
+
         if (substr($apiBaseUrl, -1) !== '/') {
             throw new \InvalidArgumentException('The MFA apiBaseUrl must end with a slash (/).');
         }

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -9,7 +9,6 @@ use common\components\MfaBackendWebAuthn;
 use Sil\JsonLog\target\EmailServiceTarget;
 use Sil\JsonLog\target\JsonStreamTarget;
 use Sil\PhpEnv\Env;
-use Sil\PhpEnv\EnvVarNotFoundException;
 use yii\db\Connection;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Json;
@@ -25,25 +24,10 @@ $notificationEmail = Env::get('NOTIFICATION_EMAIL');
 
 $mfaNumBackupCodes = Env::get('MFA_NUM_BACKUPCODES', 10);
 
-$envValidator = function($name, $key, $config) {
-    if (! isset($config[$key])) {
-        $message = "The $name environment variable is required";
-        throw new EnvVarNotFoundException($message);
-    }
-};
-
 $mfaTotpConfig = Env::getArrayFromPrefix('MFA_TOTP_');
 $mfaTotpConfig['issuer'] = $idpDisplayName;
 
-$envValidator('MFA_TOTP_apiBaseUrl', 'apiBaseUrl', $mfaTotpConfig);
-$envValidator('MFA_TOTP_apiKey', 'apiKey', $mfaTotpConfig);
-$envValidator('MFA_TOTP_apiSecret', 'apiSecret', $mfaTotpConfig);
-
 $mfaWebAuthnConfig = Env::getArrayFromPrefix('MFA_WEBAUTHN_');
-
-$envValidator('MFA_WEBAUTHN_apiBaseUrl', 'apiBaseUrl', $mfaWebAuthnConfig);
-$envValidator('MFA_WEBAUTHN_apiKey', 'apiKey', $mfaWebAuthnConfig);
-$envValidator('MFA_WEBAUTHN_apiSecret', 'apiSecret', $mfaWebAuthnConfig);
 
 $emailerClass = Env::get('EMAILER_CLASS', Emailer::class);
 

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -11,7 +11,7 @@
             "version": "3.3.11",
             "source": {
                 "type": "git",
-                "url": "git@github.com:RobinHerbots/Inputmask.git",
+                "url": "https://github.com/RobinHerbots/Inputmask.git",
                 "reference": "5e670ad62f50c738388d4dcec78d2888505ad77b"
             },
             "dist": {
@@ -183,25 +183,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "v1.0.0",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de"
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
-                "reference": "0e2a4f1f8cdfc7a92ec3b01c9334898c806b30de",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
+                "reference": "612a3ee5ab0d5dd97b7cf3874a6efe24325efac3",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1|^8.0"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^9",
-                "phpunit/phpunit": "^7.5|^8.5|^9.5",
-                "psr/log": "^1|^2|^3"
+                "phpstan/phpstan": "1.4.10 || 1.10.15",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "psalm/plugin-phpunit": "0.18.4",
+                "psr/log": "^1 || ^2 || ^3",
+                "vimeo/psalm": "4.30.0 || 5.12.0"
             },
             "suggest": {
                 "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
@@ -220,9 +224,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/v1.0.0"
+                "source": "https://github.com/doctrine/deprecations/tree/v1.1.1"
             },
-            "time": "2022-05-02T15:47:09+00:00"
+            "time": "2023-06-03T09:27:29+00:00"
         },
         {
             "name": "doctrine/lexer",
@@ -304,16 +308,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "3.2.5",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "b531a2311709443320c786feb4519cfaf94af796"
+                "reference": "e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/b531a2311709443320c786feb4519cfaf94af796",
-                "reference": "b531a2311709443320c786feb4519cfaf94af796",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7",
+                "reference": "e5997fa97e8790cdae03a9cbd5e78e45e3c7bda7",
                 "shasum": ""
             },
             "require": {
@@ -359,7 +363,7 @@
             ],
             "support": {
                 "issues": "https://github.com/egulias/EmailValidator/issues",
-                "source": "https://github.com/egulias/EmailValidator/tree/3.2.5"
+                "source": "https://github.com/egulias/EmailValidator/tree/3.2.6"
             },
             "funding": [
                 {
@@ -367,7 +371,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T17:26:14+00:00"
+            "time": "2023-06-01T07:04:22+00:00"
         },
         {
             "name": "ezyang/htmlpurifier",
@@ -473,25 +477,25 @@
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.4.0",
+            "version": "v6.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "4dd1e007f22a927ac77da5a3fbb067b42d3bc224"
+                "reference": "48b0210c51718d682e53210c24d25c5a10a2299b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/4dd1e007f22a927ac77da5a3fbb067b42d3bc224",
-                "reference": "4dd1e007f22a927ac77da5a3fbb067b42d3bc224",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/48b0210c51718d682e53210c24d25c5a10a2299b",
+                "reference": "48b0210c51718d682e53210c24d25c5a10a2299b",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1||^8.0"
+                "php": "^7.4||^8.0"
             },
             "require-dev": {
                 "guzzlehttp/guzzle": "^6.5||^7.4",
-                "phpspec/prophecy-phpunit": "^1.1",
-                "phpunit/phpunit": "^7.5||^9.5",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
                 "psr/cache": "^1.0||^2.0",
                 "psr/http-client": "^1.0",
                 "psr/http-factory": "^1.0"
@@ -530,22 +534,22 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.4.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.8.0"
             },
-            "time": "2023-02-09T21:01:23+00:00"
+            "time": "2023-06-20T16:45:35+00:00"
         },
         {
             "name": "google/apiclient",
-            "version": "v2.13.2",
+            "version": "v2.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client.git",
-                "reference": "53c3168fd1836ec21d28a768f78a8c0e44046ec4"
+                "reference": "789c8b07cad97f420ac0467c782036f955a2ad89"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/53c3168fd1836ec21d28a768f78a8c0e44046ec4",
-                "reference": "53c3168fd1836ec21d28a768f78a8c0e44046ec4",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client/zipball/789c8b07cad97f420ac0467c782036f955a2ad89",
+                "reference": "789c8b07cad97f420ac0467c782036f955a2ad89",
                 "shasum": ""
             },
             "require": {
@@ -600,26 +604,26 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client/issues",
-                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.13.2"
+                "source": "https://github.com/googleapis/google-api-php-client/tree/v2.14.0"
             },
-            "time": "2023-04-06T14:59:47+00:00"
+            "time": "2023-05-11T21:54:55+00:00"
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.296.0",
+            "version": "v0.306.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "30cf08b4f0a064f1c1271b5d8576fe9a6aa47c0c"
+                "reference": "eb778b9e1f7a9020d258f4dde7af776fc81ef8d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/30cf08b4f0a064f1c1271b5d8576fe9a6aa47c0c",
-                "reference": "30cf08b4f0a064f1c1271b5d8576fe9a6aa47c0c",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/eb778b9e1f7a9020d258f4dde7af776fc81ef8d9",
+                "reference": "eb778b9e1f7a9020d258f4dde7af776fc81ef8d9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6"
+                "php": "^7.4||^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7||^8.5.13"
@@ -644,9 +648,9 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.296.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.306.0"
             },
-            "time": "2023-04-16T00:56:11+00:00"
+            "time": "2023-06-26T00:52:13+00:00"
         },
         {
             "name": "google/auth",
@@ -944,16 +948,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598"
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/b94b2807d85443f9719887892882d0329d1e2598",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/67ab6e18aaa14d753cc148911d273f6e6cb6721e",
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e",
                 "shasum": ""
             },
             "require": {
@@ -963,11 +967,6 @@
                 "symfony/phpunit-bridge": "^4.4 || ^5.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "src/functions_include.php"
@@ -1008,7 +1007,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.2"
+                "source": "https://github.com/guzzle/promises/tree/1.5.3"
             },
             "funding": [
                 {
@@ -1024,7 +1023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:55:35+00:00"
+            "time": "2023-05-21T12:31:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -1423,16 +1422,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.19",
+            "version": "3.0.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "cc181005cf548bfd8a4896383bb825d859259f95"
+                "reference": "543a1da81111a0bfd6ae7bbc2865c5e89ed3fc67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/cc181005cf548bfd8a4896383bb825d859259f95",
-                "reference": "cc181005cf548bfd8a4896383bb825d859259f95",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/543a1da81111a0bfd6ae7bbc2865c5e89ed3fc67",
+                "reference": "543a1da81111a0bfd6ae7bbc2865c5e89ed3fc67",
                 "shasum": ""
             },
             "require": {
@@ -1513,7 +1512,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.19"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.20"
             },
             "funding": [
                 {
@@ -1529,7 +1528,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-05T17:13:09+00:00"
+            "time": "2023-06-13T06:30:34+00:00"
         },
         {
             "name": "phpspec/php-diff",
@@ -1874,17 +1873,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "20f03d27a8ee2e23a29aa65c117f20cf31d2e531"
+                "reference": "9920192eab87b9ae105696b0b86326c8fac91677"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/20f03d27a8ee2e23a29aa65c117f20cf31d2e531",
-                "reference": "20f03d27a8ee2e23a29aa65c117f20cf31d2e531",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/9920192eab87b9ae105696b0b86326c8fac91677",
+                "reference": "9920192eab87b9ae105696b0b86326c8fac91677",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
-                "admidio/admidio": "<4.1.9",
+                "admidio/admidio": "<4.2.9",
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
                 "aheinze/cockpit": "<=2.2.1",
                 "akaunting/akaunting": "<2.1.13",
@@ -1897,7 +1896,7 @@
                 "amphp/http-client": ">=4,<4.4",
                 "anchorcms/anchor-cms": "<=0.12.7",
                 "andreapollastri/cipi": "<=3.1.15",
-                "andrewhaine/silverstripe-form-capture": ">=0.2,<=0.2.3|>=1,<=1.0.1|>=2,<=2.2.4",
+                "andrewhaine/silverstripe-form-capture": ">=0.2,<=0.2.3|>=1,<1.0.2|>=2,<2.2.5",
                 "apereo/phpcas": "<1.6",
                 "api-platform/core": ">=2.2,<2.2.10|>=2.3,<2.3.6|>=2.6,<2.7.10|>=3,<3.0.12|>=3.1,<3.1.3",
                 "appwrite/server-ce": "<=1.2.1",
@@ -1907,8 +1906,8 @@
                 "automad/automad": "<1.8",
                 "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
-                "azuracast/azuracast": "<0.18",
-                "backdrop/backdrop": "<=1.23",
+                "azuracast/azuracast": "<0.18.3",
+                "backdrop/backdrop": "<1.24.2",
                 "badaso/core": "<2.7",
                 "bagisto/bagisto": "<0.1.5",
                 "barrelstrength/sprout-base-email": "<1.2.7",
@@ -1917,8 +1916,8 @@
                 "barzahlen/barzahlen-php": "<2.0.1",
                 "baserproject/basercms": "<4.7.5",
                 "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
-                "bigfork/silverstripe-form-capture": ">=3,<=3.1",
-                "billz/raspap-webgui": "<=2.6.6",
+                "bigfork/silverstripe-form-capture": ">=3,<3.1.1",
+                "billz/raspap-webgui": "<2.8.9",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
                 "bmarshall511/wordpress_zero_spam": "<5.2.13",
                 "bolt/bolt": "<3.7.2",
@@ -1943,19 +1942,19 @@
                 "cockpit-hq/cockpit": "<2.4.1",
                 "codeception/codeception": "<3.1.3|>=4,<4.1.22",
                 "codeigniter/framework": "<=3.0.6",
-                "codeigniter4/framework": "<4.2.11",
+                "codeigniter4/framework": "<4.3.5",
                 "codeigniter4/shield": "<1-beta.4|= 1.0.0-beta",
                 "codiad/codiad": "<=2.8.4",
                 "composer/composer": "<1.10.26|>=2-alpha.1,<2.2.12|>=2.3,<2.3.5",
-                "concrete5/concrete5": "<=9.1.3|>= 9.0.0RC1, < 9.1.3",
+                "concrete5/concrete5": "<9.2|>= 9.0.0RC1, < 9.1.3",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
-                "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3",
+                "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.40|>=4.10,<4.11.7|>=4.13,<4.13.21|>=5.1,<5.1.4",
                 "contao/core": ">=2,<3.5.39",
-                "contao/core-bundle": "<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3|= 4.10.0",
+                "contao/core-bundle": "<4.9.40|>=4.10,<4.11.7|>=4.13,<4.13.21|>=5.1,<5.1.4|= 4.10.0",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
-                "craftcms/cms": "<3.7.64|>= 4.0.0-RC1, < 4.3.7|>= 4.0.0-RC1, < 4.2.1",
+                "craftcms/cms": "<=4.4.9|>= 4.0.0-RC1, < 4.4.12|>= 4.0.0-RC1, <= 4.4.5|>= 4.0.0-RC1, <= 4.4.6|>= 4.0.0-RC1, < 4.4.6|>= 4.0.0-RC1, < 4.3.7|>= 4.0.0-RC1, < 4.2.1",
                 "croogo/croogo": "<3.0.7",
                 "cuyz/valinor": "<0.12",
                 "czproject/git-php": "<4.0.3",
@@ -1963,6 +1962,7 @@
                 "datadog/dd-trace": ">=0.30,<0.30.2",
                 "david-garcia/phpwhois": "<=4.3.1",
                 "dbrisinajumi/d2files": "<1",
+                "dcat/laravel-admin": "<=2.1.3-beta",
                 "derhansen/fe_change_pwd": "<2.0.5|>=3,<3.0.3",
                 "derhansen/sf_event_mgt": "<4.3.1|>=5,<5.1.1",
                 "directmailteam/direct-mail": "<5.2.4",
@@ -1975,9 +1975,9 @@
                 "doctrine/mongodb-odm": ">=1,<1.0.2",
                 "doctrine/mongodb-odm-bundle": ">=2,<3.0.1",
                 "doctrine/orm": ">=2,<2.4.8|>=2.5,<2.5.1|>=2.8.3,<2.8.4",
-                "dolibarr/dolibarr": "<16|>=16.0.1,<16.0.3|= 12.0.5|>= 3.3.beta1, < 13.0.2",
+                "dolibarr/dolibarr": "<17.0.1|= 12.0.5|>= 3.3.beta1, < 13.0.2",
                 "dompdf/dompdf": "<2.0.2|= 2.0.2",
-                "drupal/core": ">=7,<7.91|>=8,<9.3.19|>=9.4,<9.4.3",
+                "drupal/core": ">=7,<7.96|>=8,<9.4.14|>=9.5,<9.5.8|>=10,<10.0.8",
                 "drupal/drupal": ">=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4",
                 "dweeves/magmi": "<=0.7.24",
                 "ecodev/newsletter": "<=4",
@@ -2027,19 +2027,19 @@
                 "fooman/tcpdf": "<6.2.22",
                 "forkcms/forkcms": "<5.11.1",
                 "fossar/tcpdf-parser": "<6.2.22",
-                "francoisjacquet/rosariosis": "<10.8.2",
+                "francoisjacquet/rosariosis": "<11",
                 "frappant/frp-form-answers": "<3.1.2|>=4,<4.0.2",
                 "friendsofsymfony/oauth2-php": "<1.3",
                 "friendsofsymfony/rest-bundle": ">=1.2,<1.2.2",
                 "friendsofsymfony/user-bundle": ">=1.2,<1.3.5",
                 "friendsoftypo3/mediace": ">=7.6.2,<7.6.5",
                 "froala/wysiwyg-editor": "<3.2.7",
-                "froxlor/froxlor": "<2.0.14",
+                "froxlor/froxlor": "<2.1",
                 "fuel/core": "<1.8.1",
-                "funadmin/funadmin": "<=3.2",
+                "funadmin/funadmin": "<=3.2|>=3.3.2,<=3.3.3",
                 "gaoming13/wechat-php-sdk": "<=1.10.2",
                 "genix/cms": "<=1.1.11",
-                "getgrav/grav": "<1.7.34",
+                "getgrav/grav": "<1.7.42",
                 "getkirby/cms": "= 3.8.0|<3.5.8.2|>=3.6,<3.6.6.2|>=3.7,<3.7.5.1",
                 "getkirby/panel": "<2.5.14",
                 "getkirby/starterkit": "<=3.7.0.2",
@@ -2054,15 +2054,18 @@
                 "guzzlehttp/psr7": "<1.9.1|>=2,<2.4.5",
                 "harvesthq/chosen": "<1.8.7",
                 "helloxz/imgurl": "= 2.31|<=2.31",
+                "hhxsv5/laravel-s": "<3.7.36",
                 "hillelcoren/invoice-ninja": "<5.3.35",
                 "himiklab/yii2-jqgrid-widget": "<1.0.8",
                 "hjue/justwriting": "<=1",
                 "hov/jobfair": "<1.0.13|>=2,<2.0.2",
+                "httpsoft/http-message": "<1.0.12",
                 "hyn/multi-tenant": ">=5.6,<5.7.2",
                 "ibexa/admin-ui": ">=4.2,<4.2.3",
                 "ibexa/core": ">=4,<4.0.7|>=4.1,<4.1.4|>=4.2,<4.2.3",
                 "ibexa/graphql": ">=2.5,<2.5.31|>=3.3,<3.3.28|>=4.2,<4.2.3",
                 "ibexa/post-install": "<=1.0.4",
+                "ibexa/user": ">=4,<4.4.3",
                 "icecoder/icecoder": "<=8.1",
                 "idno/known": "<=1.3.1",
                 "illuminate/auth": ">=4,<4.0.99|>=4.1,<=4.1.31|>=4.2,<=4.2.22|>=5,<=5.0.35|>=5.1,<=5.1.46|>=5.2,<=5.2.45|>=5.3,<=5.3.31|>=5.4,<=5.4.36|>=5.5,<5.5.10",
@@ -2072,6 +2075,7 @@
                 "illuminate/view": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
                 "impresscms/impresscms": "<=1.4.3",
                 "in2code/femanager": "<5.5.3|>=6,<6.3.4|>=7,<7.1",
+                "in2code/ipandlanguageredirect": "<5.1.2",
                 "in2code/lux": "<17.6.1|>=18,<24.0.2",
                 "innologi/typo3-appointments": "<2.0.6",
                 "intelliants/subrion": "<=4.2.1",
@@ -2091,6 +2095,7 @@
                 "kazist/phpwhois": "<=4.2.6",
                 "kelvinmo/simplexrd": "<3.1.1",
                 "kevinpapst/kimai2": "<1.16.7",
+                "khodakhah/nodcms": "<=3",
                 "kimai/kimai": "<1.1",
                 "kitodo/presentation": "<3.1.2",
                 "klaviyo/magento2-extension": ">=1,<3",
@@ -2098,14 +2103,14 @@
                 "krayin/laravel-crm": "<1.2.2",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
                 "la-haute-societe/tcpdf": "<6.2.22",
-                "laminas/laminas-diactoros": "<2.11.1",
+                "laminas/laminas-diactoros": "<2.18.1|>=2.24,<2.24.2|>=2.25,<2.25.2|= 2.23.0|= 2.22.0|= 2.21.0|= 2.20.0|= 2.19.0",
                 "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
                 "laminas/laminas-http": "<2.14.2",
                 "laravel/fortify": "<1.11.1",
                 "laravel/framework": "<6.20.42|>=7,<7.30.6|>=8,<8.75",
                 "laravel/socialite": ">=1,<1.0.99|>=2,<2.0.10",
                 "latte/latte": "<2.10.8",
-                "lavalite/cms": "<=5.8",
+                "lavalite/cms": "<=9",
                 "lcobucci/jwt": ">=3.4,<3.4.6|>=4,<4.0.4|>=4.1,<4.1.5",
                 "league/commonmark": "<0.18.3",
                 "league/flysystem": "<1.1.4|>=2,<2.1.1",
@@ -2134,14 +2139,14 @@
                 "melisplatform/melis-front": "<5.0.1",
                 "mezzio/mezzio-swoole": "<3.7|>=4,<4.3",
                 "mgallegos/laravel-jqgrid": "<=1.3",
-                "microweber/microweber": "<1.3.3",
+                "microweber/microweber": "<=1.3.4",
                 "miniorange/miniorange-saml": "<1.4.3",
                 "mittwald/typo3_forum": "<1.2.1",
                 "mobiledetect/mobiledetectlib": "<2.8.32",
                 "modx/revolution": "<= 2.8.3-pl|<2.8",
                 "mojo42/jirafeau": "<4.4",
                 "monolog/monolog": ">=1.8,<1.12",
-                "moodle/moodle": "<4.0.7|>=4.1-beta,<4.1.2|= 3.11",
+                "moodle/moodle": "<4.2-rc.2|= 4.2.0|= 3.11",
                 "mustache/mustache": ">=2,<2.14.1",
                 "namshi/jose": "<2.2",
                 "neoan3-apps/template": "<1.1.1",
@@ -2153,10 +2158,11 @@
                 "netgen/tagsbundle": ">=3.4,<3.4.11|>=4,<4.0.15",
                 "nette/application": ">=2,<2.0.19|>=2.1,<2.1.13|>=2.2,<2.2.10|>=2.3,<2.3.14|>=2.4,<2.4.16|>=3,<3.0.6",
                 "nette/nette": ">=2,<2.0.19|>=2.1,<2.1.13",
-                "nilsteampassnet/teampass": "<3.0.3",
+                "nilsteampassnet/teampass": "<3.0.9",
                 "notrinos/notrinos-erp": "<=0.7",
                 "noumo/easyii": "<=0.9",
                 "nukeviet/nukeviet": "<4.5.2",
+                "nyholm/psr7": "<1.6.1",
                 "nystudio107/craft-seomatic": "<3.4.12",
                 "nzo/url-encryptor-bundle": ">=4,<4.3.2|>=5,<5.0.1",
                 "october/backend": "<1.1.2",
@@ -2187,6 +2193,7 @@
                 "personnummer/personnummer": "<3.0.2",
                 "phanan/koel": "<5.1.4",
                 "php-mod/curl": "<2.3.2",
+                "phpbb/phpbb": ">=3.2,<3.2.10|>=3.3,<3.3.1",
                 "phpfastcache/phpfastcache": "<6.1.5|>=7,<7.1.2|>=8,<8.0.7",
                 "phpmailer/phpmailer": "<6.5",
                 "phpmussel/phpmussel": ">=1,<1.6",
@@ -2201,18 +2208,19 @@
                 "phpwhois/phpwhois": "<=4.2.5",
                 "phpxmlrpc/extras": "<0.6.1",
                 "phpxmlrpc/phpxmlrpc": "<4.9.2",
+                "pimcore/customer-management-framework-bundle": "<3.3.10",
                 "pimcore/data-hub": "<1.2.4",
                 "pimcore/perspective-editor": "<1.5.1",
-                "pimcore/pimcore": "<10.5.20",
+                "pimcore/pimcore": "<10.5.23",
                 "pixelfed/pixelfed": "<=0.11.4",
                 "pocketmine/bedrock-protocol": "<8.0.2",
-                "pocketmine/pocketmine-mp": "<4.12.5|>= 4.0.0-BETA5, < 4.4.2",
+                "pocketmine/pocketmine-mp": "<4.20.5|>=4.21,<4.21.1|< 4.18.0-ALPHA2|>= 4.0.0-BETA5, < 4.4.2",
                 "pressbooks/pressbooks": "<5.18",
                 "prestashop/autoupgrade": ">=4,<4.10.1",
                 "prestashop/blockwishlist": ">=2,<2.1.1",
                 "prestashop/contactform": ">=1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
-                "prestashop/prestashop": "<8.0.1",
+                "prestashop/prestashop": "<8.0.4",
                 "prestashop/productcomments": "<5.0.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
                 "prestashop/ps_facetedsearch": "<3.4.1",
@@ -2228,7 +2236,7 @@
                 "pyrocms/pyrocms": "<=3.9.1",
                 "rainlab/debugbar-plugin": "<3.1",
                 "rankmath/seo-by-rank-math": "<=1.0.95",
-                "react/http": ">=0.7,<1.7",
+                "react/http": ">=0.7,<1.9",
                 "really-simple-plugins/complianz-gdpr": "<6.4.2",
                 "remdex/livehelperchat": "<3.99",
                 "rmccue/requests": ">=1.6,<1.8",
@@ -2242,19 +2250,20 @@
                 "scheb/two-factor-bundle": ">=0,<3.26|>=4,<4.11",
                 "sensiolabs/connect": "<4.2.3",
                 "serluck/phpwhois": "<=4.2.6",
+                "sheng/yiicms": "<=1.2",
                 "shopware/core": "<=6.4.20",
                 "shopware/platform": "<=6.4.20",
                 "shopware/production": "<=6.3.5.2",
-                "shopware/shopware": "<=5.7.14",
+                "shopware/shopware": "<=5.7.17",
                 "shopware/storefront": "<=6.4.8.1",
                 "shopxo/shopxo": "<2.2.6",
                 "showdoc/showdoc": "<2.10.4",
-                "silverstripe/admin": ">=1,<1.11.3",
+                "silverstripe/admin": "<1.12.7",
                 "silverstripe/assets": ">=1,<1.11.1",
                 "silverstripe/cms": "<4.11.3",
                 "silverstripe/comments": ">=1.3,<1.9.99|>=2,<2.9.99|>=3,<3.1.1",
                 "silverstripe/forum": "<=0.6.1|>=0.7,<=0.7.3",
-                "silverstripe/framework": "<4.11.14",
+                "silverstripe/framework": "<4.12.5",
                 "silverstripe/graphql": "<3.5.2|>=4-alpha.1,<4-alpha.2|>=4.1.1,<4.1.2|>=4.2.2,<4.2.3|= 4.0.0-alpha1",
                 "silverstripe/hybridsessions": ">=1,<2.4.1|>=2.5,<2.5.1",
                 "silverstripe/registry": ">=2.1,<2.1.2|>=2.2,<2.2.1",
@@ -2272,7 +2281,7 @@
                 "simplesamlphp/simplesamlphp-module-openidprovider": "<0.9",
                 "simplito/elliptic-php": "<1.0.6",
                 "sitegeist/fluid-components": "<3.5",
-                "slim/psr7": "<1.6.1",
+                "slim/psr7": "<1.4.1|>=1.5,<1.5.1|>=1.6,<1.6.1",
                 "slim/slim": "<2.6",
                 "smarty/smarty": "<3.1.48|>=4,<4.3.1",
                 "snipe/snipe-it": "<=6.0.14|>= 6.0.0-RC-1, <= 6.0.0-RC-5",
@@ -2285,7 +2294,7 @@
                 "ssddanbrown/bookstack": "<22.2.3",
                 "statamic/cms": "<3.2.39|>=3.3,<3.3.2",
                 "stormpath/sdk": ">=0,<9.9.99",
-                "studio-42/elfinder": "<2.1.59",
+                "studio-42/elfinder": "<2.1.62",
                 "subrion/cms": "<=4.2.1",
                 "sukohi/surpass": "<1",
                 "sulu/sulu": "= 2.4.0-RC1|<1.6.44|>=2,<2.2.18|>=2.3,<2.3.8",
@@ -2334,13 +2343,14 @@
                 "t3/dce": ">=2.2,<2.6.2",
                 "t3g/svg-sanitizer": "<1.0.3",
                 "tastyigniter/tastyigniter": "<3.3",
+                "tcg/voyager": "<=1.4",
                 "tecnickcom/tcpdf": "<6.2.22",
                 "terminal42/contao-tablelookupwizard": "<3.3.5",
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
                 "thelia/thelia": ">=2.1-beta.1,<2.1.3",
                 "theonedemon/phpwhois": "<=4.2.5",
                 "thinkcmf/thinkcmf": "<=5.1.7",
-                "thorsten/phpmyfaq": "<3.1.12",
+                "thorsten/phpmyfaq": "<3.2-beta",
                 "tinymce/tinymce": "<5.10.7|>=6,<6.3.1",
                 "tinymighty/wiki-seo": "<1.2.2",
                 "titon/framework": ">=0,<9.9.99",
@@ -2348,6 +2358,7 @@
                 "topthink/framework": "<6.0.14",
                 "topthink/think": "<=6.1.1",
                 "topthink/thinkphp": "<=3.2.3",
+                "tpwd/ke_search": "<4.0.3|>=4.1,<4.6.6|>=5,<5.0.2",
                 "tribalsystems/zenario": "<=9.3.57595",
                 "truckersmp/phpwhois": "<=4.3.1",
                 "ttskch/pagination-service-provider": "<1",
@@ -2377,6 +2388,8 @@
                 "web-auth/webauthn-framework": ">=3.3,<3.3.4",
                 "webbuilders-group/silverstripe-kapost-bridge": "<0.4",
                 "webcoast/deferred-image-processing": "<1.0.2",
+                "webklex/laravel-imap": "<5.3",
+                "webklex/php-imap": "<5.3",
                 "webpa/webpa": "<3.1.2",
                 "wikimedia/parsoid": "<0.12.2",
                 "willdurand/js-translation-bundle": "<2.1.1",
@@ -2386,7 +2399,7 @@
                 "wp-graphql/wp-graphql": "<0.3.5",
                 "wpanel/wpanel4-cms": "<=4.3.1",
                 "wpcloud/wp-stateless": "<3.2",
-                "wwbn/avideo": "<12.4",
+                "wwbn/avideo": "<=12.4",
                 "xataface/xataface": "<3",
                 "xpressengine/xpressengine": "<3.0.15",
                 "yeswiki/yeswiki": "<4.1",
@@ -2467,20 +2480,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-20T21:04:06+00:00"
+            "time": "2023-06-28T23:04:41+00:00"
         },
         {
             "name": "silinternational/email-service-php-client",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silinternational/email-service-php-client.git",
-                "reference": "d166332575a7381b7d044659187525ad8feda44c"
+                "reference": "94fdd2c4e6656965d7b96ee8c512294a5eb67edf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silinternational/email-service-php-client/zipball/d166332575a7381b7d044659187525ad8feda44c",
-                "reference": "d166332575a7381b7d044659187525ad8feda44c",
+                "url": "https://api.github.com/repos/silinternational/email-service-php-client/zipball/94fdd2c4e6656965d7b96ee8c512294a5eb67edf",
+                "reference": "94fdd2c4e6656965d7b96ee8c512294a5eb67edf",
                 "shasum": ""
             },
             "require": {
@@ -2524,9 +2537,9 @@
             ],
             "support": {
                 "issues": "https://github.com/silinternational/email-service-php-client/issues",
-                "source": "https://github.com/silinternational/email-service-php-client/tree/2.4.0"
+                "source": "https://github.com/silinternational/email-service-php-client/tree/2.4.1"
             },
-            "time": "2022-08-29T20:46:26+00:00"
+            "time": "2023-06-20T05:37:35+00:00"
         },
         {
             "name": "silinternational/php-array-dot-notation",
@@ -3370,16 +3383,16 @@
         },
         {
             "name": "yiisoft/yii2",
-            "version": "2.0.47",
+            "version": "2.0.48.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii2-framework.git",
-                "reference": "8ecf57895d9c4b29cf9658ffe57af5f3d0e25254"
+                "reference": "de92f154eefe322fc1b1b2a52cce46677441ced4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-framework/zipball/8ecf57895d9c4b29cf9658ffe57af5f3d0e25254",
-                "reference": "8ecf57895d9c4b29cf9658ffe57af5f3d0e25254",
+                "url": "https://api.github.com/repos/yiisoft/yii2-framework/zipball/de92f154eefe322fc1b1b2a52cce46677441ced4",
+                "reference": "de92f154eefe322fc1b1b2a52cce46677441ced4",
                 "shasum": ""
             },
             "require": {
@@ -3390,7 +3403,7 @@
                 "cebe/markdown": "~1.0.0 | ~1.1.0 | ~1.2.0",
                 "ext-ctype": "*",
                 "ext-mbstring": "*",
-                "ezyang/htmlpurifier": "~4.6",
+                "ezyang/htmlpurifier": "^4.6",
                 "lib-pcre": "*",
                 "paragonie/random_compat": ">=1",
                 "php": ">=5.4.0",
@@ -3488,7 +3501,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-11-18T16:21:58+00:00"
+            "time": "2023-05-24T19:04:02+00:00"
         },
         {
             "name": "yiisoft/yii2-composer",
@@ -3568,21 +3581,21 @@
         },
         {
             "name": "yiisoft/yii2-gii",
-            "version": "2.2.5",
+            "version": "2.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii2-gii.git",
-                "reference": "e2f2dcf0f16713e678df6ba70362c99a215a8f72"
+                "reference": "ac574e7e2c29fd865145c8688719f252d19aae23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-gii/zipball/e2f2dcf0f16713e678df6ba70362c99a215a8f72",
-                "reference": "e2f2dcf0f16713e678df6ba70362c99a215a8f72",
+                "url": "https://api.github.com/repos/yiisoft/yii2-gii/zipball/ac574e7e2c29fd865145c8688719f252d19aae23",
+                "reference": "ac574e7e2c29fd865145c8688719f252d19aae23",
                 "shasum": ""
             },
             "require": {
                 "phpspec/php-diff": "^1.1.0",
-                "yiisoft/yii2": "~2.0.14"
+                "yiisoft/yii2": "~2.0.46"
             },
             "require-dev": {
                 "cweagans/composer-patches": "^1.7",
@@ -3599,9 +3612,13 @@
                     "phpunit/phpunit-mock-objects": {
                         "Fix PHP 7 and 8 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_mock_objects.patch"
                     },
+                    "phpunit/php-file-iterator": {
+                        "Fix PHP 8.1 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_path_file_iterator.patch"
+                    },
                     "phpunit/phpunit": {
                         "Fix PHP 7 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_php7.patch",
-                        "Fix PHP 8 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_php8.patch"
+                        "Fix PHP 8 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_php8.patch",
+                        "Fix PHP 8.1 compatibility": "https://yiisoft.github.io/phpunit-patches/phpunit_php81.patch"
                     }
                 }
             },
@@ -3627,11 +3644,11 @@
                 "yii2"
             ],
             "support": {
-                "forum": "http://www.yiiframework.com/forum/",
+                "forum": "https://www.yiiframework.com/forum/",
                 "irc": "irc://irc.freenode.net/yii",
                 "issues": "https://github.com/yiisoft/yii2-gii/issues",
                 "source": "https://github.com/yiisoft/yii2-gii",
-                "wiki": "http://www.yiiframework.com/wiki/"
+                "wiki": "https://www.yiiframework.com/wiki/"
             },
             "funding": [
                 {
@@ -3647,7 +3664,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-04T10:00:25+00:00"
+            "time": "2023-05-22T20:55:37+00:00"
         },
         {
             "name": "yiisoft/yii2-swiftmailer",
@@ -4499,36 +4516,34 @@
         },
         {
             "name": "symfony/config",
-            "version": "v6.2.7",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "249271da6f545d6579e0663374f8249a80be2893"
+                "reference": "a5e00dec161b08c946a2c16eed02adbeedf827ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/249271da6f545d6579e0663374f8249a80be2893",
-                "reference": "249271da6f545d6579e0663374f8249a80be2893",
+                "url": "https://api.github.com/repos/symfony/config/zipball/a5e00dec161b08c946a2c16eed02adbeedf827ae",
+                "reference": "a5e00dec161b08c946a2c16eed02adbeedf827ae",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/filesystem": "^5.4|^6.0",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "symfony/finder": "<5.4"
+                "symfony/finder": "<5.4",
+                "symfony/service-contracts": "<2.5"
             },
             "require-dev": {
                 "symfony/event-dispatcher": "^5.4|^6.0",
                 "symfony/finder": "^5.4|^6.0",
                 "symfony/messenger": "^5.4|^6.0",
-                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/service-contracts": "^2.5|^3",
                 "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/yaml": "To use the yaml reference dumper"
             },
             "type": "library",
             "autoload": {
@@ -4556,7 +4571,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.2.7"
+                "source": "https://github.com/symfony/config/tree/v6.3.0"
             },
             "funding": [
                 {
@@ -4572,20 +4587,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:44:56+00:00"
+            "time": "2023-04-25T10:46:17+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.22",
+            "version": "v5.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "3cd51fd2e6c461ca678f84d419461281bd87a0a8"
+                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3cd51fd2e6c461ca678f84d419461281bd87a0a8",
-                "reference": "3cd51fd2e6c461ca678f84d419461281bd87a0a8",
+                "url": "https://api.github.com/repos/symfony/console/zipball/560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
+                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
                 "shasum": ""
             },
             "require": {
@@ -4655,7 +4670,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.22"
+                "source": "https://github.com/symfony/console/tree/v5.4.24"
             },
             "funding": [
                 {
@@ -4671,34 +4686,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-25T09:27:28+00:00"
+            "time": "2023-05-26T05:13:16+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.2.8",
+            "version": "v6.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "b6195feacceb88fc58a02b69522b569e4c6188ac"
+                "reference": "7abf242af21f196b65f20ab00ff251fdf3889b8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b6195feacceb88fc58a02b69522b569e4c6188ac",
-                "reference": "b6195feacceb88fc58a02b69522b569e4c6188ac",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/7abf242af21f196b65f20ab00ff251fdf3889b8d",
+                "reference": "7abf242af21f196b65f20ab00ff251fdf3889b8d",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.1|^3",
-                "symfony/service-contracts": "^1.1.6|^2.0|^3.0",
-                "symfony/var-exporter": "^6.2.7"
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.2.10"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
                 "symfony/config": "<6.1",
                 "symfony/finder": "<5.4",
-                "symfony/proxy-manager-bridge": "<6.2",
+                "symfony/proxy-manager-bridge": "<6.3",
                 "symfony/yaml": "<5.4"
             },
             "provide": {
@@ -4709,12 +4724,6 @@
                 "symfony/config": "^6.1",
                 "symfony/expression-language": "^5.4|^6.0",
                 "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/config": "",
-                "symfony/expression-language": "For using expressions in service container configuration",
-                "symfony/finder": "For using double-star glob patterns or when GLOB_BRACE portability is required",
-                "symfony/yaml": ""
             },
             "type": "library",
             "autoload": {
@@ -4742,7 +4751,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.2.8"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.3.1"
             },
             "funding": [
                 {
@@ -4758,20 +4767,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-30T13:35:57+00:00"
+            "time": "2023-06-24T11:51:27+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.2.1",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
-                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/7c3aff79d10325257a001fcf92d991f24fc967cf",
+                "reference": "7c3aff79d10325257a001fcf92d991f24fc967cf",
                 "shasum": ""
             },
             "require": {
@@ -4780,7 +4789,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4809,7 +4818,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -4825,7 +4834,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:25:55+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -4914,29 +4923,26 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.2.1",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "0ad3b6f1e4e2da5690fefe075cd53a238646d8dd"
+                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ad3b6f1e4e2da5690fefe075cd53a238646d8dd",
-                "reference": "0ad3b6f1e4e2da5690fefe075cd53a238646d8dd",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/a76aed96a42d2b521153fb382d418e30d18b59df",
+                "reference": "a76aed96a42d2b521153fb382d418e30d18b59df",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "psr/event-dispatcher": "^1"
             },
-            "suggest": {
-                "symfony/event-dispatcher-implementation": ""
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4973,7 +4979,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -4989,20 +4995,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:32:47+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.21",
+            "version": "v5.4.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f"
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
-                "reference": "e75960b1bbfd2b8c9e483e0d74811d555ca3de9f",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
+                "reference": "0ce3a62c9579a53358d3a7eb6b3dfb79789a6364",
                 "shasum": ""
             },
             "require": {
@@ -5037,7 +5043,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.21"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.25"
             },
             "funding": [
                 {
@@ -5053,7 +5059,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-14T08:03:56+00:00"
+            "time": "2023-05-31T13:04:02+00:00"
         },
         {
             "name": "symfony/finder",
@@ -5500,16 +5506,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.22",
+            "version": "v5.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "4b850da0cc3a2a9181c1ed407adbca4733dc839b"
+                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4b850da0cc3a2a9181c1ed407adbca4733dc839b",
-                "reference": "4b850da0cc3a2a9181c1ed407adbca4733dc839b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e3c46cc5689c8782944274bb30702106ecbe3b64",
+                "reference": "e3c46cc5689c8782944274bb30702106ecbe3b64",
                 "shasum": ""
             },
             "require": {
@@ -5542,7 +5548,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.22"
+                "source": "https://github.com/symfony/process/tree/v5.4.24"
             },
             "funding": [
                 {
@@ -5558,20 +5564,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-06T21:29:33+00:00"
+            "time": "2023-05-17T11:26:05+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.2.1",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "a8c9cedf55f314f3a186041d19537303766df09a"
+                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/a8c9cedf55f314f3a186041d19537303766df09a",
-                "reference": "a8c9cedf55f314f3a186041d19537303766df09a",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
+                "reference": "40da9cc13ec349d9e4966ce18b5fbcd724ab10a4",
                 "shasum": ""
             },
             "require": {
@@ -5581,13 +5587,10 @@
             "conflict": {
                 "ext-psr": "<1.1|>=2"
             },
-            "suggest": {
-                "symfony/service-implementation": ""
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -5627,7 +5630,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -5643,7 +5646,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:32:47+00:00"
+            "time": "2023-05-23T14:45:45+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -5709,16 +5712,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.2.8",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef"
+                "reference": "f2e190ee75ff0f5eced645ec0be5c66fac81f51f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef",
-                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f2e190ee75ff0f5eced645ec0be5c66fac81f51f",
+                "reference": "f2e190ee75ff0f5eced645ec0be5c66fac81f51f",
                 "shasum": ""
             },
             "require": {
@@ -5729,13 +5732,13 @@
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
-                "symfony/translation-contracts": "<2.0"
+                "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
                 "symfony/intl": "^6.2",
-                "symfony/translation-contracts": "^2.0|^3.0",
+                "symfony/translation-contracts": "^2.5|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
             "type": "library",
@@ -5775,7 +5778,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.2.8"
+                "source": "https://github.com/symfony/string/tree/v6.3.0"
             },
             "funding": [
                 {
@@ -5791,32 +5794,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-20T16:06:02+00:00"
+            "time": "2023-03-21T21:06:29+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.2.8",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "817535dbb1721df8b3a8f2489dc7e50bcd6209b5"
+                "reference": "f72b2cba8f79dd9d536f534f76874b58ad37876f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/817535dbb1721df8b3a8f2489dc7e50bcd6209b5",
-                "reference": "817535dbb1721df8b3a8f2489dc7e50bcd6209b5",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/f72b2cba8f79dd9d536f534f76874b58ad37876f",
+                "reference": "f72b2cba8f79dd9d536f534f76874b58ad37876f",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1",
                 "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^2.3|^3.0"
+                "symfony/translation-contracts": "^2.5|^3.0"
             },
             "conflict": {
                 "symfony/config": "<5.4",
                 "symfony/console": "<5.4",
                 "symfony/dependency-injection": "<5.4",
+                "symfony/http-client-contracts": "<2.5",
                 "symfony/http-kernel": "<5.4",
+                "symfony/service-contracts": "<2.5",
                 "symfony/twig-bundle": "<5.4",
                 "symfony/yaml": "<5.4"
             },
@@ -5830,19 +5835,13 @@
                 "symfony/console": "^5.4|^6.0",
                 "symfony/dependency-injection": "^5.4|^6.0",
                 "symfony/finder": "^5.4|^6.0",
-                "symfony/http-client-contracts": "^1.1|^2.0|^3.0",
+                "symfony/http-client-contracts": "^2.5|^3.0",
                 "symfony/http-kernel": "^5.4|^6.0",
                 "symfony/intl": "^5.4|^6.0",
                 "symfony/polyfill-intl-icu": "^1.21",
                 "symfony/routing": "^5.4|^6.0",
-                "symfony/service-contracts": "^1.1.2|^2|^3",
+                "symfony/service-contracts": "^2.5|^3",
                 "symfony/yaml": "^5.4|^6.0"
-            },
-            "suggest": {
-                "nikic/php-parser": "To use PhpAstExtractor",
-                "psr/log-implementation": "To use logging capability in translator",
-                "symfony/config": "",
-                "symfony/yaml": ""
             },
             "type": "library",
             "autoload": {
@@ -5873,7 +5872,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.2.8"
+                "source": "https://github.com/symfony/translation/tree/v6.3.0"
             },
             "funding": [
                 {
@@ -5889,32 +5888,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-31T09:14:44+00:00"
+            "time": "2023-05-19T12:46:45+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.2.1",
+            "version": "v3.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "dfec258b9dd17a6b24420d464c43bffe347441c8"
+                "reference": "02c24deb352fb0d79db5486c0c79905a85e37e86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/dfec258b9dd17a6b24420d464c43bffe347441c8",
-                "reference": "dfec258b9dd17a6b24420d464c43bffe347441c8",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/02c24deb352fb0d79db5486c0c79905a85e37e86",
+                "reference": "02c24deb352fb0d79db5486c0c79905a85e37e86",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
-            "suggest": {
-                "symfony/translation-implementation": ""
-            },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "3.4-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -5954,7 +5950,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.3.0"
             },
             "funding": [
                 {
@@ -5970,20 +5966,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:32:47+00:00"
+            "time": "2023-05-30T17:17:10+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v6.2.8",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "8302bb670204500d492c6b8c595ee9a27da62cd6"
+                "reference": "db5416d04269f2827d8c54331ba4cfa42620d350"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/8302bb670204500d492c6b8c595ee9a27da62cd6",
-                "reference": "8302bb670204500d492c6b8c595ee9a27da62cd6",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/db5416d04269f2827d8c54331ba4cfa42620d350",
+                "reference": "db5416d04269f2827d8c54331ba4cfa42620d350",
                 "shasum": ""
             },
             "require": {
@@ -6028,7 +6024,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v6.2.8"
+                "source": "https://github.com/symfony/var-exporter/tree/v6.3.0"
             },
             "funding": [
                 {
@@ -6044,20 +6040,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-14T15:48:45+00:00"
+            "time": "2023-04-21T08:48:44+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.2.7",
+            "version": "v6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "e8e6a1d59e050525f27a1f530aa9703423cb7f57"
+                "reference": "a9a8337aa641ef2aa39c3e028f9107ec391e5927"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/e8e6a1d59e050525f27a1f530aa9703423cb7f57",
-                "reference": "e8e6a1d59e050525f27a1f530aa9703423cb7f57",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a9a8337aa641ef2aa39c3e028f9107ec391e5927",
+                "reference": "a9a8337aa641ef2aa39c3e028f9107ec391e5927",
                 "shasum": ""
             },
             "require": {
@@ -6069,9 +6065,6 @@
             },
             "require-dev": {
                 "symfony/console": "^5.4|^6.0"
-            },
-            "suggest": {
-                "symfony/console": "For validating YAML files using the lint command"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -6102,7 +6095,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.2.7"
+                "source": "https://github.com/symfony/yaml/tree/v6.3.0"
             },
             "funding": [
                 {
@@ -6118,7 +6111,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-02-16T09:57:23+00:00"
+            "time": "2023-04-28T13:28:14+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/application/dependencies.json
+++ b/application/dependencies.json
@@ -1,0 +1,192 @@
+{
+  "name": "bower-asset/inputmask",
+  "version": "3.3.11"
+}
+{
+  "name": "br33f/php-ga4-mp",
+  "version": "v0.1.3"
+}
+{
+  "name": "cebe/markdown",
+  "version": "1.2.1"
+}
+{
+  "name": "codemix/yii2-streamlog",
+  "version": "1.3.1"
+}
+{
+  "name": "doctrine/deprecations",
+  "version": "v1.0.0"
+}
+{
+  "name": "doctrine/lexer",
+  "version": "2.1.0"
+}
+{
+  "name": "egulias/email-validator",
+  "version": "3.2.5"
+}
+{
+  "name": "ezyang/htmlpurifier",
+  "version": "v4.16.0"
+}
+{
+  "name": "fillup/fake-bower-assets",
+  "version": "2.0.9"
+}
+{
+  "name": "firebase/php-jwt",
+  "version": "v6.4.0"
+}
+{
+  "name": "google/apiclient",
+  "version": "v2.13.2"
+}
+{
+  "name": "google/apiclient-services",
+  "version": "v0.296.0"
+}
+{
+  "name": "google/auth",
+  "version": "v1.26.0"
+}
+{
+  "name": "guzzlehttp/command",
+  "version": "1.0.0"
+}
+{
+  "name": "guzzlehttp/guzzle",
+  "version": "6.5.8"
+}
+{
+  "name": "guzzlehttp/guzzle-services",
+  "version": "1.1.3"
+}
+{
+  "name": "guzzlehttp/promises",
+  "version": "1.5.2"
+}
+{
+  "name": "guzzlehttp/psr7",
+  "version": "1.9.1"
+}
+{
+  "name": "mlocati/ip-lib",
+  "version": "1.18.0"
+}
+{
+  "name": "monolog/monolog",
+  "version": "2.9.1"
+}
+{
+  "name": "paragonie/constant_time_encoding",
+  "version": "v2.6.3"
+}
+{
+  "name": "paragonie/random_compat",
+  "version": "v9.99.100"
+}
+{
+  "name": "phpseclib/phpseclib",
+  "version": "3.0.19"
+}
+{
+  "name": "phpspec/php-diff",
+  "version": "v1.1.3"
+}
+{
+  "name": "psr/cache",
+  "version": "3.0.0"
+}
+{
+  "name": "psr/http-message",
+  "version": "1.1"
+}
+{
+  "name": "psr/log",
+  "version": "1.1.4"
+}
+{
+  "name": "ralouphie/getallheaders",
+  "version": "3.0.3"
+}
+{
+  "name": "ramsey/uuid",
+  "version": "3.9.7"
+}
+{
+  "name": "roave/security-advisories",
+  "version": "dev-master 20f03d2"
+}
+{
+  "name": "silinternational/email-service-php-client",
+  "version": "2.4.0"
+}
+{
+  "name": "silinternational/php-array-dot-notation",
+  "version": "0.1.0"
+}
+{
+  "name": "silinternational/php-env",
+  "version": "3.1.0"
+}
+{
+  "name": "silinternational/psr3-adapters",
+  "version": "3.1.0"
+}
+{
+  "name": "silinternational/yii2-email-log-target",
+  "version": "1.0.1"
+}
+{
+  "name": "silinternational/yii2-json-log-targets",
+  "version": "2.1.0"
+}
+{
+  "name": "swiftmailer/swiftmailer",
+  "version": "v6.3.0"
+}
+{
+  "name": "symfony/polyfill-ctype",
+  "version": "v1.27.0"
+}
+{
+  "name": "symfony/polyfill-iconv",
+  "version": "v1.27.0"
+}
+{
+  "name": "symfony/polyfill-intl-idn",
+  "version": "v1.27.0"
+}
+{
+  "name": "symfony/polyfill-intl-normalizer",
+  "version": "v1.27.0"
+}
+{
+  "name": "symfony/polyfill-mbstring",
+  "version": "v1.27.0"
+}
+{
+  "name": "symfony/polyfill-php72",
+  "version": "v1.27.0"
+}
+{
+  "name": "theiconic/php-ga-measurement-protocol",
+  "version": "v2.9.0"
+}
+{
+  "name": "yiisoft/yii2",
+  "version": "2.0.47"
+}
+{
+  "name": "yiisoft/yii2-composer",
+  "version": "2.0.10"
+}
+{
+  "name": "yiisoft/yii2-gii",
+  "version": "2.2.5"
+}
+{
+  "name": "yiisoft/yii2-swiftmailer",
+  "version": "2.1.3"
+}

--- a/application/dependencies.json
+++ b/application/dependencies.json
@@ -1,192 +1,194 @@
-{
-  "name": "bower-asset/inputmask",
-  "version": "3.3.11"
-}
-{
-  "name": "br33f/php-ga4-mp",
-  "version": "v0.1.3"
-}
-{
-  "name": "cebe/markdown",
-  "version": "1.2.1"
-}
-{
-  "name": "codemix/yii2-streamlog",
-  "version": "1.3.1"
-}
-{
-  "name": "doctrine/deprecations",
-  "version": "v1.1.1"
-}
-{
-  "name": "doctrine/lexer",
-  "version": "2.1.0"
-}
-{
-  "name": "egulias/email-validator",
-  "version": "3.2.6"
-}
-{
-  "name": "ezyang/htmlpurifier",
-  "version": "v4.16.0"
-}
-{
-  "name": "fillup/fake-bower-assets",
-  "version": "2.0.9"
-}
-{
-  "name": "firebase/php-jwt",
-  "version": "v6.8.0"
-}
-{
-  "name": "google/apiclient",
-  "version": "v2.14.0"
-}
-{
-  "name": "google/apiclient-services",
-  "version": "v0.306.0"
-}
-{
-  "name": "google/auth",
-  "version": "v1.26.0"
-}
-{
-  "name": "guzzlehttp/command",
-  "version": "1.0.0"
-}
-{
-  "name": "guzzlehttp/guzzle",
-  "version": "6.5.8"
-}
-{
-  "name": "guzzlehttp/guzzle-services",
-  "version": "1.1.3"
-}
-{
-  "name": "guzzlehttp/promises",
-  "version": "1.5.3"
-}
-{
-  "name": "guzzlehttp/psr7",
-  "version": "1.9.1"
-}
-{
-  "name": "mlocati/ip-lib",
-  "version": "1.18.0"
-}
-{
-  "name": "monolog/monolog",
-  "version": "2.9.1"
-}
-{
-  "name": "paragonie/constant_time_encoding",
-  "version": "v2.6.3"
-}
-{
-  "name": "paragonie/random_compat",
-  "version": "v9.99.100"
-}
-{
-  "name": "phpseclib/phpseclib",
-  "version": "3.0.20"
-}
-{
-  "name": "phpspec/php-diff",
-  "version": "v1.1.3"
-}
-{
-  "name": "psr/cache",
-  "version": "3.0.0"
-}
-{
-  "name": "psr/http-message",
-  "version": "1.1"
-}
-{
-  "name": "psr/log",
-  "version": "1.1.4"
-}
-{
-  "name": "ralouphie/getallheaders",
-  "version": "3.0.3"
-}
-{
-  "name": "ramsey/uuid",
-  "version": "3.9.7"
-}
-{
-  "name": "roave/security-advisories",
-  "version": "dev-master 9920192"
-}
-{
-  "name": "silinternational/email-service-php-client",
-  "version": "2.4.1"
-}
-{
-  "name": "silinternational/php-array-dot-notation",
-  "version": "0.1.0"
-}
-{
-  "name": "silinternational/php-env",
-  "version": "3.1.0"
-}
-{
-  "name": "silinternational/psr3-adapters",
-  "version": "3.1.0"
-}
-{
-  "name": "silinternational/yii2-email-log-target",
-  "version": "1.0.1"
-}
-{
-  "name": "silinternational/yii2-json-log-targets",
-  "version": "2.1.0"
-}
-{
-  "name": "swiftmailer/swiftmailer",
-  "version": "v6.3.0"
-}
-{
-  "name": "symfony/polyfill-ctype",
-  "version": "v1.27.0"
-}
-{
-  "name": "symfony/polyfill-iconv",
-  "version": "v1.27.0"
-}
-{
-  "name": "symfony/polyfill-intl-idn",
-  "version": "v1.27.0"
-}
-{
-  "name": "symfony/polyfill-intl-normalizer",
-  "version": "v1.27.0"
-}
-{
-  "name": "symfony/polyfill-mbstring",
-  "version": "v1.27.0"
-}
-{
-  "name": "symfony/polyfill-php72",
-  "version": "v1.27.0"
-}
-{
-  "name": "theiconic/php-ga-measurement-protocol",
-  "version": "v2.9.0"
-}
-{
-  "name": "yiisoft/yii2",
-  "version": "2.0.48.1"
-}
-{
-  "name": "yiisoft/yii2-composer",
-  "version": "2.0.10"
-}
-{
-  "name": "yiisoft/yii2-gii",
-  "version": "2.2.6"
-}
-{
-  "name": "yiisoft/yii2-swiftmailer",
-  "version": "2.1.3"
-}
+[
+  {
+    "name": "bower-asset/inputmask",
+    "version": "3.3.11"
+  },
+  {
+    "name": "br33f/php-ga4-mp",
+    "version": "v0.1.3"
+  },
+  {
+    "name": "cebe/markdown",
+    "version": "1.2.1"
+  },
+  {
+    "name": "codemix/yii2-streamlog",
+    "version": "1.3.1"
+  },
+  {
+    "name": "doctrine/deprecations",
+    "version": "v1.1.1"
+  },
+  {
+    "name": "doctrine/lexer",
+    "version": "2.1.0"
+  },
+  {
+    "name": "egulias/email-validator",
+    "version": "3.2.6"
+  },
+  {
+    "name": "ezyang/htmlpurifier",
+    "version": "v4.16.0"
+  },
+  {
+    "name": "fillup/fake-bower-assets",
+    "version": "2.0.9"
+  },
+  {
+    "name": "firebase/php-jwt",
+    "version": "v6.8.0"
+  },
+  {
+    "name": "google/apiclient",
+    "version": "v2.14.0"
+  },
+  {
+    "name": "google/apiclient-services",
+    "version": "v0.306.0"
+  },
+  {
+    "name": "google/auth",
+    "version": "v1.26.0"
+  },
+  {
+    "name": "guzzlehttp/command",
+    "version": "1.0.0"
+  },
+  {
+    "name": "guzzlehttp/guzzle",
+    "version": "6.5.8"
+  },
+  {
+    "name": "guzzlehttp/guzzle-services",
+    "version": "1.1.3"
+  },
+  {
+    "name": "guzzlehttp/promises",
+    "version": "1.5.3"
+  },
+  {
+    "name": "guzzlehttp/psr7",
+    "version": "1.9.1"
+  },
+  {
+    "name": "mlocati/ip-lib",
+    "version": "1.18.0"
+  },
+  {
+    "name": "monolog/monolog",
+    "version": "2.9.1"
+  },
+  {
+    "name": "paragonie/constant_time_encoding",
+    "version": "v2.6.3"
+  },
+  {
+    "name": "paragonie/random_compat",
+    "version": "v9.99.100"
+  },
+  {
+    "name": "phpseclib/phpseclib",
+    "version": "3.0.20"
+  },
+  {
+    "name": "phpspec/php-diff",
+    "version": "v1.1.3"
+  },
+  {
+    "name": "psr/cache",
+    "version": "3.0.0"
+  },
+  {
+    "name": "psr/http-message",
+    "version": "1.1"
+  },
+  {
+    "name": "psr/log",
+    "version": "1.1.4"
+  },
+  {
+    "name": "ralouphie/getallheaders",
+    "version": "3.0.3"
+  },
+  {
+    "name": "ramsey/uuid",
+    "version": "3.9.7"
+  },
+  {
+    "name": "roave/security-advisories",
+    "version": "dev-master 9920192"
+  },
+  {
+    "name": "silinternational/email-service-php-client",
+    "version": "2.4.1"
+  },
+  {
+    "name": "silinternational/php-array-dot-notation",
+    "version": "0.1.0"
+  },
+  {
+    "name": "silinternational/php-env",
+    "version": "3.1.0"
+  },
+  {
+    "name": "silinternational/psr3-adapters",
+    "version": "3.1.0"
+  },
+  {
+    "name": "silinternational/yii2-email-log-target",
+    "version": "1.0.1"
+  },
+  {
+    "name": "silinternational/yii2-json-log-targets",
+    "version": "2.1.0"
+  },
+  {
+    "name": "swiftmailer/swiftmailer",
+    "version": "v6.3.0"
+  },
+  {
+    "name": "symfony/polyfill-ctype",
+    "version": "v1.27.0"
+  },
+  {
+    "name": "symfony/polyfill-iconv",
+    "version": "v1.27.0"
+  },
+  {
+    "name": "symfony/polyfill-intl-idn",
+    "version": "v1.27.0"
+  },
+  {
+    "name": "symfony/polyfill-intl-normalizer",
+    "version": "v1.27.0"
+  },
+  {
+    "name": "symfony/polyfill-mbstring",
+    "version": "v1.27.0"
+  },
+  {
+    "name": "symfony/polyfill-php72",
+    "version": "v1.27.0"
+  },
+  {
+    "name": "theiconic/php-ga-measurement-protocol",
+    "version": "v2.9.0"
+  },
+  {
+    "name": "yiisoft/yii2",
+    "version": "2.0.48.1"
+  },
+  {
+    "name": "yiisoft/yii2-composer",
+    "version": "2.0.10"
+  },
+  {
+    "name": "yiisoft/yii2-gii",
+    "version": "2.2.6"
+  },
+  {
+    "name": "yiisoft/yii2-swiftmailer",
+    "version": "2.1.3"
+  }
+]

--- a/application/dependencies.json
+++ b/application/dependencies.json
@@ -16,7 +16,7 @@
 }
 {
   "name": "doctrine/deprecations",
-  "version": "v1.0.0"
+  "version": "v1.1.1"
 }
 {
   "name": "doctrine/lexer",
@@ -24,7 +24,7 @@
 }
 {
   "name": "egulias/email-validator",
-  "version": "3.2.5"
+  "version": "3.2.6"
 }
 {
   "name": "ezyang/htmlpurifier",
@@ -36,15 +36,15 @@
 }
 {
   "name": "firebase/php-jwt",
-  "version": "v6.4.0"
+  "version": "v6.8.0"
 }
 {
   "name": "google/apiclient",
-  "version": "v2.13.2"
+  "version": "v2.14.0"
 }
 {
   "name": "google/apiclient-services",
-  "version": "v0.296.0"
+  "version": "v0.306.0"
 }
 {
   "name": "google/auth",
@@ -64,7 +64,7 @@
 }
 {
   "name": "guzzlehttp/promises",
-  "version": "1.5.2"
+  "version": "1.5.3"
 }
 {
   "name": "guzzlehttp/psr7",
@@ -88,7 +88,7 @@
 }
 {
   "name": "phpseclib/phpseclib",
-  "version": "3.0.19"
+  "version": "3.0.20"
 }
 {
   "name": "phpspec/php-diff",
@@ -116,11 +116,11 @@
 }
 {
   "name": "roave/security-advisories",
-  "version": "dev-master 20f03d2"
+  "version": "dev-master 9920192"
 }
 {
   "name": "silinternational/email-service-php-client",
-  "version": "2.4.0"
+  "version": "2.4.1"
 }
 {
   "name": "silinternational/php-array-dot-notation",
@@ -176,7 +176,7 @@
 }
 {
   "name": "yiisoft/yii2",
-  "version": "2.0.47"
+  "version": "2.0.48.1"
 }
 {
   "name": "yiisoft/yii2-composer",
@@ -184,7 +184,7 @@
 }
 {
   "name": "yiisoft/yii2-gii",
-  "version": "2.2.5"
+  "version": "2.2.6"
 }
 {
   "name": "yiisoft/yii2-swiftmailer",

--- a/application/frontend/controllers/SiteController.php
+++ b/application/frontend/controllers/SiteController.php
@@ -66,39 +66,6 @@ class SiteController extends BaseRestController
         Yii::$app->response->statusCode = 204;
     }
 
-    private function checkEmailServiceStatus($emailer)
-    {
-        try {
-            $emailer->getSiteStatus();
-        } catch (GuzzleCommandException $e) {
-            $response = $e->getResponse();
-            if ($response) {
-                $responseBody = $response->getBody();
-                if ($responseBody) {
-                    $responseContents = $responseBody->getContents();
-                }
-                $responseHeaders = $response->getHeaders();
-            }
-            Yii::error([
-                'event' => 'email service guzzle command error',
-                'errorCode' => $e->getCode(),
-                'errorMessage' => $e->getMessage(),
-                'responseHeaders' => $responseHeaders ?? null,
-                'responseContents' => $responseContents ?? null,
-                'stackTrace' => $e->getTrace(),
-            ]);
-            throw new Http500('Email Service problem.', $e->getCode());
-        } catch (Exception $e) {
-            Yii::error([
-                'event' => 'email service status error',
-                'exceptionClass' => get_class($e),
-                'errorCode' => $e->getCode(),
-                'errorMessage' => $e->getMessage(),
-            ]);
-            throw new Http500('Email Service problem.', $e->getCode());
-        }
-    }
-
     public function actionUndefinedRequest()
     {
         $method = Yii::$app->request->method;

--- a/application/frontend/controllers/SiteController.php
+++ b/application/frontend/controllers/SiteController.php
@@ -49,9 +49,6 @@ class SiteController extends BaseRestController
             throw new Http500('Emailer config problem.');
         }
 
-        // Checking the email service status causes too many error emails to be sent out to the dev team
-        // $this->checkEmailServiceStatus($emailer);
-
         try {
             $webApp->get('totp');
         } catch (Exception $e) {

--- a/application/frontend/controllers/SiteController.php
+++ b/application/frontend/controllers/SiteController.php
@@ -26,14 +26,14 @@ class SiteController extends BaseRestController
     {
         /* @var $webApp yii\web\Application */
         $webApp = Yii::$app;
-        
+
         try {
             $dbComponent = $webApp->get('db');
         } catch (Exception $e) {
             Yii::error('DB config problem: ' . $e->getMessage());
             throw new Http500('DB config problem.');
         }
-        
+
         try {
             $dbComponent->open();
         } catch (Exception $e) {
@@ -51,6 +51,20 @@ class SiteController extends BaseRestController
 
         // Checking the email service status causes too many error emails to be sent out to the dev team
         // $this->checkEmailServiceStatus($emailer);
+
+        try {
+            $webApp->get('totp');
+        } catch (Exception $e) {
+            Yii::error('TOTP config problem: ' . $e->getMessage());
+            throw new Http500('TOTP config problem.');
+        }
+
+        try {
+            $webApp->get('webauthn');
+        } catch (Exception $e) {
+            Yii::error('Webauthn config problem: ' . $e->getMessage());
+            throw new Http500('Webauthn config problem.');
+        }
 
         Yii::$app->response->statusCode = 204;
     }

--- a/codeship-services.yml
+++ b/codeship-services.yml
@@ -38,9 +38,6 @@ app:
         HR_NOTIFICATIONS_EMAIL: hr@example.com
         ABANDONED_USER_bestPracticeUrl: http://www.example.com/best-practices.html
         ABANDONED_USER_deactivateInstructionsUrl: http://www.example.com/deactivate-instructions.html
-        MFA_TOTP_apiBaseUrl: notinuse/
-        MFA_TOTP_apiKey: 20345678-1234-1234-1234-123456789012
-        MFA_TOTP_apiSecret: 21345678-1234-1234-1234-12345678
         MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
         MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
         MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,9 +53,6 @@ services:
             MYSQL_DATABASE: appfortests
             MYSQL_USER: appfortests
             MYSQL_PASSWORD: appfortests
-            MFA_TOTP_apiBaseUrl: notinuse/
-            MFA_TOTP_apiKey: 10345678-1234-1234-1234-123456789012
-            MFA_TOTP_apiSecret: 11345678-1234-1234-1234-12345678
             MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
             MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
             MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678
@@ -168,9 +165,6 @@ services:
             EMAIL_SERVICE_assertValidIp: "false"
             EMAIL_SERVICE_baseUrl: dummy
             EMAIL_SIGNATURE: Dummy Signature for Test
-            MFA_TOTP_apiBaseUrl: notinuse:8080/
-            MFA_TOTP_apiKey: 10345678-1234-1234-1234-123456789012
-            MFA_TOTP_apiSecret: 11345678-1234-1234-1234-12345678
             MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
             MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
             MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678


### PR DESCRIPTION
### Fixed
- Check for required MFA configuration during the status check, not in root config file. This alleviates the need to provide dummy variables everywhere the broker image is used.
- Use a more deterministic dependency list format.
- Dependency update, including new `email-service-php-client` that reports DNS error correctly.
- Delete unused code (`Emailer->getSiteStatus()`)