### PR TITLE
use the latest version of serverless-mfa-api-go that works for testing

### DIFF
--- a/serverless-mfa-api/Dockerfile
+++ b/serverless-mfa-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM silintl/serverless-mfa-api-go:develop
+FROM silintl/serverless-mfa-api-go:v2.1.0
 WORKDIR /src
 
 RUN mkdir override


### PR DESCRIPTION
version 2.1.1 fails tests mfa.feature:75, mfa:feature:81, and mfa.feature:88

The POST /webauthn/register endpoint crashes with error "failed to begin registration: dynamoUser, john_smith, missing WebAuthClient in BeginRegistration"

The log output of the mfapi container contains this message: "error occurred validating the configuration: must provide at least one value to the 'RPOrigins' field"
