### PR TITLE
update the last_used_utc on the webauthn record IDP-690

### DIFF
--- a/application/common/components/MfaBackendWebAuthn.php
+++ b/application/common/components/MfaBackendWebAuthn.php
@@ -158,6 +158,9 @@ class MfaBackendWebAuthn extends Component implements MfaBackendInterface
             if ($webauthnCount < 1) {
                 throw new NotFoundHttpException("No MFA Webauthn record found for MFA ID: " . $mfa->id, 1659637860);
             }
+
+            $mfa->setLastUsed();
+
             return $this->client->webauthnValidateAuthentication($headers, $value);
         }
 

--- a/application/common/models/MfaWebauthn.php
+++ b/application/common/models/MfaWebauthn.php
@@ -92,4 +92,17 @@ class MfaWebauthn extends MfaWebauthnBase
 
         return $webauthn;
     }
+
+    public function setLastUsed()
+    {
+        $this->last_used_utc = MySqlDateTime::now();
+        if (! $this->save()) {
+            \Yii::error([
+                'action' => 'update webauthn last_used_utc',
+                'status' => 'error',
+                'mfa_id' => $this->id,
+                'error' => $this->getFirstErrors(),
+            ]);
+        }
+    }
 }

--- a/application/common/models/MfaWebauthn.php
+++ b/application/common/models/MfaWebauthn.php
@@ -96,7 +96,7 @@ class MfaWebauthn extends MfaWebauthnBase
     public function setLastUsed()
     {
         $this->last_used_utc = MySqlDateTime::now();
-        if (! $this->save()) {
+        if (! $this->save(true, ['last_used_utc'])) {
             \Yii::error([
                 'action' => 'update webauthn last_used_utc',
                 'status' => 'error',

--- a/application/features/bootstrap/MfaContext.php
+++ b/application/features/bootstrap/MfaContext.php
@@ -49,7 +49,7 @@ class MfaContext extends \FeatureContext
         ]);
 
         Assert::true($this->mfa->save(), 'Failed to add that MFA record to the database.');
-        
+
         if ($mfaType === 'backupcode') {
             $this->backupCodes = MfaBackupcode::createBackupCodes($this->mfa->id, 10);
         } elseif ($mfaType === 'manager') {
@@ -260,14 +260,6 @@ class MfaContext extends \FeatureContext
     {
         $this->setRequestBody('label', $label);
         $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id . '/verify/registration', 'created');
-    }
-
-    /**
-     * @When I request to verify the webauthn Mfa
-     */
-    public function iRequestToVerifyTheWebauthnMfa()
-    {
-        $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id . '/verify', 'created');
     }
 
     /**


### PR DESCRIPTION
### Fixed
- Update the `last_used_utc` column on a webauthn record when it is used. [IDP-690](https://itse.youtrack.cloud/issue/IDP-690)
- Removed unused test code.

---

### Feature PR Checklist
- [x] Documentation (README, local.env.dist, etc.)
- [ ] Unit tests created or updated
- [x] Run `make composershow`

_Code and test structure does not lend itself to testing the verification of a webauthn. It may be possible using the U2F simulator. I am not familiar with how to use that, though._