### PR TITLE
IDP-690 -- fix MfaWebauthn last_used_utc

### DIFF
--- a/application/common/components/MfaApiClient.php
+++ b/application/common/components/MfaApiClient.php
@@ -133,13 +133,13 @@ class MfaApiClient
     /**
      * @param array $additionalHeaders
      * @param array $signResultJson
-     * @return bool
+     * @return array
      * @throws GuzzleException
      */
-    public function webauthnValidateAuthentication(array $additionalHeaders, array $signResultJson): bool
+    public function webauthnValidateAuthentication(array $additionalHeaders, array $signResultJson): array
     {
-        $this->callApi('webauthn/login', 'PUT', $signResultJson, $additionalHeaders);
-        return true;
+        $response = $this->callApi('webauthn/login', 'PUT', $signResultJson, $additionalHeaders);
+        return Json::decode($response->getBody()->getContents());
     }
 
     /**

--- a/application/common/components/MfaBackendWebAuthn.php
+++ b/application/common/components/MfaBackendWebAuthn.php
@@ -160,12 +160,13 @@ class MfaBackendWebAuthn extends Component implements MfaBackendInterface
             }
 
             $response = $this->client->webauthnValidateAuthentication($headers, $value);
-            $webauthnId = $response['credentialId'];
+            $khh = $response['key_handle_hash'];
 
-            $mfaWebauthn = MfaWebauthn::findOne(['id' => $webauthnId]);
+            $mfaWebauthn = MfaWebauthn::findOne(['key_handle_hash' => $khh]);
             if ($mfaWebauthn == null) {
-                throw new NotFoundHttpException("No MfaWebauthn record with ID: " . $webauthnId, 1697229804);
+                throw new NotFoundHttpException("No MfaWebauthn record with key_handle_hash: " . $khh, 1697229804);
             }
+
             $mfaWebauthn->setLastUsed();
             return true;
         }

--- a/application/common/components/MfaBackendWebAuthn.php
+++ b/application/common/components/MfaBackendWebAuthn.php
@@ -156,9 +156,18 @@ class MfaBackendWebAuthn extends Component implements MfaBackendInterface
         if ($verifyType != Mfa::VERIFY_REGISTRATION) {
             $webauthnCount = $mfa->getMfaWebauthns()->count();
             if ($webauthnCount < 1) {
-                throw new NotFoundHttpException("No MFA Webauthn record found for MFA ID: " . $mfa->id, 1659637860);
+                throw new NotFoundHttpException("No MfaWebauthn records found for Mfa ID: " . $mfa->id, 1659637860);
             }
-            return $this->client->webauthnValidateAuthentication($headers, $value);
+
+            $response = $this->client->webauthnValidateAuthentication($headers, $value);
+            $webauthnId = $response['credentialId'];
+
+            $mfaWebauthn = MfaWebauthn::findOne(['id' => $webauthnId]);
+            if ($mfaWebauthn == null) {
+                throw new NotFoundHttpException("No MfaWebauthn record with ID: " . $webauthnId, 1697229804);
+            }
+            $mfaWebauthn->setLastUsed();
+            return true;
         }
 
         // Assume a new webauthn was requested and finish its registration process

--- a/application/common/models/MfaWebauthn.php
+++ b/application/common/models/MfaWebauthn.php
@@ -92,4 +92,17 @@ class MfaWebauthn extends MfaWebauthnBase
 
         return $webauthn;
     }
+
+    public function setLastUsed()
+    {
+        $this->last_used_utc = MySqlDateTime::now();
+        if (! $this->save(true, ['last_used_utc'])) {
+            \Yii::error([
+                'action' => 'update webauthn last_used_utc',
+                'status' => 'error',
+                'mfa_id' => $this->id,
+                'error' => $this->getFirstErrors(),
+            ]);
+        }
+    }
 }

--- a/application/features/bootstrap/MfaContext.php
+++ b/application/features/bootstrap/MfaContext.php
@@ -49,7 +49,7 @@ class MfaContext extends \FeatureContext
         ]);
 
         Assert::true($this->mfa->save(), 'Failed to add that MFA record to the database.');
-        
+
         if ($mfaType === 'backupcode') {
             $this->backupCodes = MfaBackupcode::createBackupCodes($this->mfa->id, 10);
         } elseif ($mfaType === 'manager') {
@@ -260,14 +260,6 @@ class MfaContext extends \FeatureContext
     {
         $this->setRequestBody('label', $label);
         $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id . '/verify/registration', 'created');
-    }
-
-    /**
-     * @When I request to verify the webauthn Mfa
-     */
-    public function iRequestToVerifyTheWebauthnMfa()
-    {
-        $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id . '/verify', 'created');
     }
 
     /**


### PR DESCRIPTION
### Fixed
- Update `last_used_utc` when an MfaWebauthn is used [IDP-690](https://itse.youtrack.cloud/issue/IDP-690). This fix is dependent upon an upcoming release of  [serverless-mfa-api-go](https://github.com/silinternational/serverless-mfa-api-go). See [PR #63](https://github.com/silinternational/serverless-mfa-api-go/pull/63)
- Remove unused test code

---

### Feature PR Checklist
- [x] Documentation (README, local.env.dist, etc.)
- [ ] Unit tests created or updated
- [x] Run `make composershow`

_Code and test structure does not lend itself to testing the verification of a webauthn. It may be possible using the U2F simulator. I am not familiar with how to use that, though. I did test it locally in combination with the [idp-profile-ui](https://github.com/silinternational/idp-profile-ui) and [serverless-mfa-api-go](https://github.com/silinternational/serverless-mfa-api-go) services._