### PR TITLE
Release 6.6.3 - Update u2f keys when updating the `last_used_utc` timestamp

### DIFF
--- a/application/common/components/MfaBackendWebAuthn.php
+++ b/application/common/components/MfaBackendWebAuthn.php
@@ -162,7 +162,10 @@ class MfaBackendWebAuthn extends Component implements MfaBackendInterface
             $response = $this->client->webauthnValidateAuthentication($headers, $value);
             $khh = $response['key_handle_hash'];
 
-            $mfaWebauthn = MfaWebauthn::findOne(['key_handle_hash' => $khh]);
+            $mfaWebauthn = MfaWebauthn::find()->
+                where(['key_handle_hash' => $khh])->
+                orWhere(['key_handle_hash' => 'u2f', 'mfa_id' => $mfa->id])->one();
+
             if ($mfaWebauthn == null) {
                 \Yii::error([
                     'action' => 'update MfaWebauth last_used_utc',

--- a/application/common/components/MfaBackendWebAuthn.php
+++ b/application/common/components/MfaBackendWebAuthn.php
@@ -164,12 +164,13 @@ class MfaBackendWebAuthn extends Component implements MfaBackendInterface
 
             $mfaWebauthn = MfaWebauthn::find()->
                 where(['key_handle_hash' => $khh])->
-                orWhere(['key_handle_hash' => 'u2f', 'mfa_id' => $mfa->id])->one();
+                orWhere(['key_handle_hash' => 'u2f', 'mfa_id' => $mfaId])->one();
 
             if ($mfaWebauthn == null) {
                 \Yii::error([
                     'action' => 'update MfaWebauth last_used_utc',
                     'status' => 'error',
+                    'mfa_id' => $mfaId,
                     'error' => 'No MfaWebauthn record with key_handle_hash: ' . $khh,
                 ]);
             } else {

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -201,7 +201,7 @@ return [
                     'clientOptions' => [
                         'attach_stacktrace' => false, // stack trace identifies the logger call stack, not helpful
                         'environment' => YII_ENV,
-                        'release' => 'idp-id-broker@6.6.3-pre',
+                        'release' => 'idp-id-broker@6.6.3',
                         'before_send' => function (Event $event) use ($idpName): ?Event {
                             $event->setExtra(['idp' => $idpName]);
                             return $event;

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -201,7 +201,7 @@ return [
                     'clientOptions' => [
                         'attach_stacktrace' => false, // stack trace identifies the logger call stack, not helpful
                         'environment' => YII_ENV,
-                        'release' => 'idp-id-broker@6.6.2',
+                        'release' => 'idp-id-broker@6.6.3-pre',
                         'before_send' => function (Event $event) use ($idpName): ?Event {
                             $event->setExtra(['idp' => $idpName]);
                             return $event;


### PR DESCRIPTION
### Fixed
- Also check for "u2f" keys when updating the `last_used_utc` timestamp.

---

### Release PR Checklist
- [x] Update version number in main.php Sentry configuration
