### PR TITLE
Release 6.6.4 - fix bug introduced in 6.6.3

### DIFF
--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -201,7 +201,7 @@ return [
                     'clientOptions' => [
                         'attach_stacktrace' => false, // stack trace identifies the logger call stack, not helpful
                         'environment' => YII_ENV,
-                        'release' => 'idp-id-broker@6.6.4-pre',
+                        'release' => 'idp-id-broker@6.6.4',
                         'before_send' => function (Event $event) use ($idpName): ?Event {
                             $event->setExtra(['idp' => $idpName]);
                             return $event;

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -201,7 +201,7 @@ return [
                     'clientOptions' => [
                         'attach_stacktrace' => false, // stack trace identifies the logger call stack, not helpful
                         'environment' => YII_ENV,
-                        'release' => 'idp-id-broker@6.6.3',
+                        'release' => 'idp-id-broker@6.6.4-pre',
                         'before_send' => function (Event $event) use ($idpName): ?Event {
                             $event->setExtra(['idp' => $idpName]);
                             return $event;


### PR DESCRIPTION
### Fixed
- When searching for webauthn records to update the last-used timestamp, don't look for one with a `key_handle_hash` of "u2f" unless one cannot be found matching the key_handle_hash received from the webauthn API.

---

### Release PR Checklist
- [x] Update version number in main.php Sentry configuration
