### PR TITLE
use AWS AppConfig to load environment variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,8 @@ COPY dockerbuild/vhost.conf /etc/apache2/sites-enabled/
 # ErrorLog inside a VirtualHost block is ineffective for unknown reasons
 RUN sed -i -E 's@ErrorLog .*@ErrorLog /proc/self/fd/2@i' /etc/apache2/apache2.conf
 
+ADD https://github.com/silinternational/config-shim/releases/latest/download/config-shim_0.0.2-pre.3_linux_amd64.tar.gz config-shim.tar.gz
+RUN tar xzf config-shim.tar.gz --directory /usr/local/bin --wildcards config-shim && rm config-shim*tar.gz
+
 EXPOSE 80
 CMD ["/data/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,8 +24,8 @@ COPY dockerbuild/vhost.conf /etc/apache2/sites-enabled/
 # ErrorLog inside a VirtualHost block is ineffective for unknown reasons
 RUN sed -i -E 's@ErrorLog .*@ErrorLog /proc/self/fd/2@i' /etc/apache2/apache2.conf
 
-ADD https://github.com/silinternational/config-shim/releases/latest/download/config-shim_0.0.2-pre.3_linux_amd64.tar.gz config-shim.tar.gz
-RUN tar xzf config-shim.tar.gz --directory /usr/local/bin --wildcards config-shim && rm config-shim*tar.gz
+ADD https://github.com/silinternational/config-shim/releases/latest/download/config-shim.gz config-shim.gz
+RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
 
 EXPOSE 80
 CMD ["/data/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM silintl/php8:8.1
 
+ENV REFRESHED_AT 2024-02-27
+
 RUN apt-get update -y && \
     apt-get install -y make
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,15 @@ in the `local.env.dist` file. Optionally, you can define configuration in AWS Ap
 To do this, set the following environment variables to point to the configuration in
 AWS:
 
+* `AWS_REGION` - the AWS region in use
 * `APP_ID` - the application ID or name
 * `CONFIG_ID` - the configuration profile ID or name
 * `ENV_ID` - the environment ID or name
+
+In addition, the AWS PHP SDK requires authentication. It is best to use an access role
+such as an [ECS Task Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).
+If that is not an option, you can specify an access token using the `AWS_ACCESS_KEY_ID` and
+`AWS_SECRET_ACCESS_KEY` variables.
 
 The content of the configuration profile takes the form of a typical .env file, using
 `#` for comments and `=` for variable assignment. Any variables read from AppConfig 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ Windows (not actively maintained as a development platform)
    on a Linux computer. Otherwise, run `id -u` and `id -g` and use the resulting numbers in place of `1000`.
 5. Run `make start`, or if using Vagrant, run `vagrant up`
 
+## Configuration
+By default, configuration is read from environment variables. These are documented
+in the `local.env.dist` file. Optionally, you can define configuration in AWS AppConfig.
+To do this, set the following environment variables to point to the configuration in
+AWS:
+
+* `APP_ID` - the application ID or name
+* `CONFIG_ID` - the configuration profile ID or name
+* `ENV_ID` - the environment ID or name
+
+The content of the configuration profile takes the form of a typical .env file, using
+`#` for comments and `=` for variable assignment. Any variables read from AppConfig 
+will overwrite variables set in the execution environment.
+
 ## Composer / GitHub rate limit
 If you hit problems of composer unable to pull the necessary dependencies
 due to a GitHub rate limit, copy the `auth.json.dist` file to `auth.json` and

--- a/application/run.sh
+++ b/application/run.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
+
+# print script lines as they are executed
 set -x
+
+# exit if any line in the script fails
+set -e
 
 # establish a signal handler to catch the SIGTERM from a 'docker stop'
 # reference: https://medium.com/@gchudnov/trapping-signals-in-docker-containers-7a57fdda7d86
@@ -23,14 +28,14 @@ sleep $[ ( $RANDOM % 10 ) ]s
 
 
 # Run database migrations
-/data/yii migrate --interactive=0
+config-shim -v --app $APP_ID --config $CONFIG_ID --env $ENV_ID /data/yii migrate --interactive=0
 
 if [[ ! -z $RUN_TASK ]]; then
     ./yii $RUN_TASK
     exit $?
 fi
 
-apache2ctl -k start -D FOREGROUND
+config-shim -v --app $APP_ID --config $CONFIG_ID --env $ENV_ID apache2ctl -k start -D FOREGROUND
 
 # endless loop with a wait is needed for the trap to work
 while true

--- a/application/run.sh
+++ b/application/run.sh
@@ -6,14 +6,6 @@ set -x
 # exit if any line in the script fails
 set -e
 
-# establish a signal handler to catch the SIGTERM from a 'docker stop'
-# reference: https://medium.com/@gchudnov/trapping-signals-in-docker-containers-7a57fdda7d86
-term_handler() {
-  apache2ctl stop
-  exit 143; # 128 + 15 -- SIGTERM
-}
-trap 'kill ${!}; term_handler' SIGTERM
-
 if [[ $APP_ENV == "dev" ]]; then
     export XDEBUG_CONFIG="remote_enable=1 remote_host="$REMOTE_DEBUG_IP
     apt-get -y -q install php-xdebug
@@ -36,10 +28,3 @@ if [[ ! -z $RUN_TASK ]]; then
 fi
 
 config-shim -v --app $APP_ID --config $CONFIG_ID --env $ENV_ID apache2ctl -k start -D FOREGROUND
-
-# endless loop with a wait is needed for the trap to work
-while true
-do
-  tail -f /dev/null & wait ${!}
-done
-

--- a/application/run.sh
+++ b/application/run.sh
@@ -28,12 +28,12 @@ if [[ -z "${APP_ID}" ]]; then
 
   apache2ctl -k start -D FOREGROUND
 else
-  config-shim -v --app $APP_ID --config $CONFIG_ID --env $ENV_ID /data/yii migrate --interactive=0
+  config-shim --app $APP_ID --config $CONFIG_ID --env $ENV_ID /data/yii migrate --interactive=0
 
   if [[ ! -z $RUN_TASK ]]; then
-    config-shim -v --app $APP_ID --config $CONFIG_ID --env $ENV_ID ./yii $RUN_TASK
+    config-shim --app $APP_ID --config $CONFIG_ID --env $ENV_ID ./yii $RUN_TASK
     exit $?
   fi
 
-  config-shim -v --app $APP_ID --config $CONFIG_ID --env $ENV_ID apache2ctl -k start -D FOREGROUND
+  config-shim --app $APP_ID --config $CONFIG_ID --env $ENV_ID apache2ctl -k start -D FOREGROUND
 fi

--- a/local.env.dist
+++ b/local.env.dist
@@ -18,6 +18,21 @@
 IDP_NAME=
 
 
+# === AWS AppConfig ===
+
+# The AWS region in use
+AWS_REGION
+
+# The AppConfig Application ID (or name)
+APP_ID
+
+# The AppConfig Configuration Profile ID (or name)
+CONFIG_ID
+
+# The AppConfig Environment ID (or name)
+ENV_ID
+
+
 # === email template data ===
 
 # The user-friendly version of the name of this IdP. For example:


### PR DESCRIPTION

### Changed
- Read environment variables from AWS AppConfig at startup if APP_ID is defined

### Removed
- Removed the signal trap from the run script. It was broken a long while back by moving the apachectl command to the foreground, which was required to send logs to CloudWatch.

---

### Feature PR Checklist
- [x] Documentation (README, local.env.dist, etc.)
