### PR TITLE
Update config-shim to handle values that contain an equals sign

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY dockerbuild/vhost.conf /etc/apache2/sites-enabled/
 # ErrorLog inside a VirtualHost block is ineffective for unknown reasons
 RUN sed -i -E 's@ErrorLog .*@ErrorLog /proc/self/fd/2@i' /etc/apache2/apache2.conf
 
-ADD https://github.com/silinternational/config-shim/releases/latest/download/config-shim.gz config-shim.gz
+ADD https://github.com/silinternational/config-shim/releases/download/v0.0.4/config-shim.gz config-shim.gz
 RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
 
 EXPOSE 80


### PR DESCRIPTION
### Fixed
- Update `config-shim` to handle values that contain an equals sign
