### PR TITLE
Make our docker-compose.yml file work better cross-platform

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
     data:
         image: silintl/data-volume:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,7 +194,7 @@ services:
         # docker-compose run --rm test vendor/bin/behat --stop-on-failure features/user.feature:306
 
     phpmyadmin:
-        image: phpmyadmin/phpmyadmin
+        image: phpmyadmin:5
         ports:
             - "51141:80"
         depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -208,6 +208,7 @@ services:
 
     raml2html:
         image: mattjtodd/raml2html
+        platform: linux/amd64
         volumes:
             - ./api.raml:/api.raml
             - ./api.html:/api.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
     data:
         image: silintl/data-volume:latest
+        platform: linux/amd64
         volumes:
             - ./application:/data
             - ./auth.json:/root/.composer/auth.json
@@ -73,6 +74,7 @@ services:
 
     cli:
         image: silintl/php8:8.1
+        platform: linux/amd64
         volumes:
             - ${COMPOSER_CACHE_DIR}:/composer
         volumes_from:
@@ -86,6 +88,7 @@ services:
 
     dynamo:
         image: amazon/dynamodb-local
+        platform: linux/amd64
         ports:
             - "8000:8000"
         environment:
@@ -147,6 +150,7 @@ services:
 
     test:
         image: silintl/php8:8.1
+        platform: linux/amd64
         volumes_from:
             - data
         mem_limit: 200m


### PR DESCRIPTION
### Fixed
- Remove (deprecated) version line from docker-compose.yml
- Specify the platform where needed (in docker-compose.yml) 
  * Some images, including ours, only publish a single image, so other platforms sometimes have to specify that version of the image.
- Switch to official image for phpMyAdmin (with cross-platform support)

---

### Feature PR Checklist
- [ ] Documentation (README, local.env.dist, etc.)
- [ ] Unit tests created or updated
- [x] Run `make depsshow`
- [x] Run `make psr2`
