### PR TITLE
If an `authInit()` calls fails, skip loading that MFA's extra data

### DIFF
--- a/application/common/models/Mfa.php
+++ b/application/common/models/Mfa.php
@@ -76,7 +76,16 @@ class Mfa extends MfaBase
     {
         $this->data = [];
         if ($this->verified === 1 && $this->scenario === User::SCENARIO_AUTHENTICATE) {
-            $this->data += $this->authInit($rpOrigin);
+            try {
+                $this->data += $this->authInit($rpOrigin);
+            } catch (\Exception $exception) {
+                \Yii::error([
+                    'action' => 'load ' . $this->type . ' MFA data',
+                    'status' => 'error',
+                    'error' => 'authInit call failed (so skipping it): ' . $exception->getMessage(),
+                    'mfa_id' => $this->id,
+                ]);
+            }
         }
         if ($this->type === self::TYPE_BACKUPCODE || $this->type === self::TYPE_MANAGER) {
             $this->data += ['count' => count($this->mfaBackupcodes)];


### PR DESCRIPTION
### Changed (non-breaking)
- If an `authInit()` calls fails, skip loading that MFA's extra data
  * This should help us still allow a user to log in even if the WebAuthn MFA API is down, merely preventing those WebAuthn MFA options from working but allowing the "remember me" cookie and the other MFA options to work.

---

### Feature PR Checklist
- [ ] Documentation (README, local.env.dist, etc.)
- [ ] Unit tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
