### PR TITLE
Refine ID Broker's pull-request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,6 @@
 
 ### Feature PR Checklist
 - [ ] Documentation (README, local.env.dist, etc.)
-- [ ] Unit tests created or updated
+- [ ] Tests created or updated
 - [ ] Run `make composershow`
 - [ ] Run `make psr2`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,10 @@
 ### Added
 - 
 
-### Changed
+### Changed (non-breaking)
+-
+
+### Changed (BREAKING)
 -
 
 ### Deprecated

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,7 @@
+(Backlog issue's ID and title)
+
+---
+
 ### Added
 - 
 


### PR DESCRIPTION
### Added
- Add a place/reminder to paste the YouTrack issue's ID and title in PRs 
  * This is easily obtained (with the ID as a link, even) by clicking the "Copy ID and summary to clipboard" icon beside a YouTrack issue's ID link, near the top-left of the page when viewing an issue in a sufficiently-wide browser window, and it seems worth including.

![Screenshot 2024-08-19 at 3 20 45 PM](https://github.com/user-attachments/assets/93d2e628-eec1-4512-96b0-5e890019ac7f)

### Changed (non-breaking)
- Separate the PR template "Changed" section for breaking vs. non-breaking
- Simplify the wording of the checklist to simply say "Tests...", not specifically "Unit tests..."