### PR TITLE
[IDP-1176] Add `groups_external` field, part 2 (cleanup)

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -569,21 +569,7 @@ class User extends UserBase
             },
             'hide',
             'member' => function (self $model) {
-                if (!empty($model->groups)) {
-                    $member = explode(',', $model->groups);
-                } else {
-                    $member = [];
-                }
-
-                $externalGroups = explode(',', $model->groups_external);
-                foreach ($externalGroups as $externalGroup) {
-                    if (!empty($externalGroup)) {
-                        $member[] = $externalGroup;
-                    }
-                }
-
-                $member[] = \Yii::$app->params['idpName'];
-                return $member;
+                return $model->getMemberList();
             },
             'mfa',
             'method' => function (self $model) {
@@ -613,6 +599,26 @@ class User extends UserBase
     public function getDisplayName()
     {
         return $this->display_name ?? "$this->first_name $this->last_name";
+    }
+
+    /** @return string[] */
+    public function getMemberList(): array
+    {
+        if (!empty($this->groups)) {
+            $member = explode(',', $this->groups);
+        } else {
+            $member = [];
+        }
+
+        $externalGroups = explode(',', $this->groups_external);
+        foreach ($externalGroups as $externalGroup) {
+            if (!empty($externalGroup)) {
+                $member[] = $externalGroup;
+            }
+        }
+
+        $member[] = \Yii::$app->params['idpName'];
+        return $member;
     }
 
     /**


### PR DESCRIPTION
[IDP-1176](https://itse.youtrack.cloud/issue/IDP-1176) Add groups_external field to ID Broker's database

---

### WAITING FOR
- #352

### Fixed
- Extract `User->getMemberList()` method
  * The only change to the extracted code was replacing `$model` with `$this` in a few places.
  * This helps reduce the complexity of the `User->fields()` method, which was getting overly complicated.

---

### Feature PR Checklist
- [ ] Documentation (README, local.env.dist, etc.)
- [ ] Unit tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
