### PR TITLE
[IDP-1182] Add endpoint for updating `groups_external`

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -59,7 +59,7 @@ types:
     example: |
       {
         "email_address": "john_smith@example.com",
-        "app_prefix": "myapp"
+        "app_prefix": "myapp",
         "groups": ["myapp-users", "myapp-managers"]
       }
   UserResponse:

--- a/api.raml
+++ b/api.raml
@@ -44,6 +44,21 @@ types:
         "code": 0,
         "status": 400
       }
+  GroupsExternalUpdate:
+    type: object
+    properties:
+      email_address: string
+      app_prefix: string
+      groups:
+        type: string[]
+        description: >
+          The desired list of groups, including the app-prefix.
+    example: |
+      {
+        "email_address": "john_smith@example.com",
+        "app_prefix": "myapp"
+        "groups": ["myapp-users", "myapp-managers"]
+      }
   UserResponse:
     description: >
       Information on user record. Password is not included if a password
@@ -418,6 +433,25 @@ types:
         description: A server-side error occurred.
         body:
           type: Error
+  /external-groups:
+    put:
+      description: >
+        Update a user's list of external groups for a given app-prefix to be
+        exactly the given list, leaving external groups with other prefixes
+        unchanged.
+      body:
+        type: GroupsExternalUpdate
+      responses:
+        204:
+          description: >
+            The user's external groups for that app-prefix were updated.
+        404:
+          description: >
+            No such user found.
+        422:
+          description: The given data does not satisfy some validation rule.
+          body:
+            type: Error
   /{employee_id}:
     get:
       description: Get information about a specific user.

--- a/api.raml
+++ b/api.raml
@@ -48,7 +48,10 @@ types:
     type: object
     properties:
       email_address: string
-      app_prefix: string
+      app_prefix:
+        type: string
+        description: >
+          The app-specific prefix, without the trailing hyphen.
       groups:
         type: string[]
         description: >

--- a/application/behat.yml
+++ b/application/behat.yml
@@ -23,6 +23,10 @@ default:
             paths:
                 - "features/groups-external.feature"
             contexts: [ Sil\SilIdBroker\Behat\Context\GroupsExternalContext ]
+        groups_external_updates_features:
+            paths:
+                - "features/groups-external-updates.feature"
+            contexts: [ Sil\SilIdBroker\Behat\Context\GroupsExternalUpdatesContext ]
         hibp_unit_tests_features:
             paths:
                 - "features/hibp-unit-tests.feature"

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1003,6 +1003,68 @@ class User extends UserBase
         return false;
     }
 
+    public function updateExternalGroups($appPrefix, $appExternalGroups): bool
+    {
+        $this->removeInMemoryExternalGroupsFor($appPrefix);
+        $this->addInMemoryExternalGroups($appExternalGroups);
+
+        $this->scenario = self::SCENARIO_UPDATE_USER;
+        $saved = $this->save(true, ['groups_external']);
+        if ($saved) {
+            return true;
+        } else {
+            Yii::warning(sprintf(
+                'Failed to update external groups for %s: %s',
+                $this->email,
+                join(', ', $this->getFirstErrors())
+            ));
+            return false;
+        }
+    }
+
+    /**
+     * Remove all entries from this User object's list of external groups that
+     * begin with the given prefix.
+     *
+     * NOTE:
+     * This only updates the property in memory. It leaves the calling code to
+     * call `save()` on this User when desired.
+     *
+     * @param $appPrefix
+     * @return void
+     */
+    private function removeInMemoryExternalGroupsFor($appPrefix)
+    {
+        $currentExternalGroups = explode(',', $this->groups_external);
+        $newExternalGroups = [];
+        foreach ($currentExternalGroups as $externalGroup) {
+            if (! str_starts_with($externalGroup, $appPrefix . '-')) {
+                $newExternalGroups[] = $externalGroup;
+            }
+        }
+        $this->groups_external = join(',', $newExternalGroups);
+    }
+
+    /**
+     * Add the given groups to this User objects' list of external groups.
+     *
+     * NOTE:
+     * This only updates the property in memory. It leaves the calling code to
+     * call `save()` on this User when desired.
+     *
+     * @param $newExternalGroups
+     * @return void
+     */
+    private function addInMemoryExternalGroups($newExternalGroups)
+    {
+        $newCommaSeparatedExternalGroups = sprintf(
+            '%s,%s',
+            $this->groups_external,
+            join(',', $newExternalGroups)
+        );
+        $this->groups_external .= trim($newCommaSeparatedExternalGroups, ',');
+    }
+
     /**
      * Update the date field that corresponds to the current nag state
      */

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1062,7 +1062,7 @@ class User extends UserBase
             $this->groups_external,
             join(',', $newExternalGroups)
         );
-        $this->groups_external .= trim($newCommaSeparatedExternalGroups, ',');
+        $this->groups_external = trim($newCommaSeparatedExternalGroups, ',');
     }
 
     /**

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1005,6 +1005,18 @@ class User extends UserBase
 
     public function updateExternalGroups($appPrefix, $appExternalGroups): bool
     {
+        foreach ($appExternalGroups as $appExternalGroup) {
+            if (! str_starts_with($appExternalGroup, $appPrefix . '-')) {
+                $this->addErrors([
+                    'groups_external' => sprintf(
+                        'The given group %s does not start with the given prefix (%s)',
+                        json_encode($appExternalGroup),
+                        json_encode($appPrefix)
+                    ),
+                ]);
+                return false;
+            }
+        }
         $this->removeInMemoryExternalGroupsFor($appPrefix);
         $this->addInMemoryExternalGroups($appExternalGroups);
 

--- a/application/features/bootstrap/GroupsExternalContext.php
+++ b/application/features/bootstrap/GroupsExternalContext.php
@@ -67,6 +67,11 @@ class GroupsExternalContext extends FeatureContext
         ));
     }
 
+    protected function getUserEmailAddress(): string
+    {
+        return $this->userEmailAddress;
+    }
+
     /**
      * @Given that user's list of groups is :commaSeparatedGroups
      */

--- a/application/features/bootstrap/GroupsExternalUpdatesContext.php
+++ b/application/features/bootstrap/GroupsExternalUpdatesContext.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Sil\SilIdBroker\Behat\Context;
+
+use Behat\Gherkin\Node\TableNode;
+use common\models\User;
+use Webmozart\Assert\Assert;
+
+class GroupsExternalUpdatesContext extends GroupsExternalContext
+{
+    /**
+     * @When I update that user's list of :appPrefix external groups to the following:
+     */
+    public function iUpdateThatUsersListOfExternalGroupsToTheFollowing($appPrefix, TableNode $table)
+    {
+        $externalGroups = [];
+        foreach ($table as $row) {
+            $externalGroups[] = $row['externalGroup'];
+        }
+
+        $this->cleanRequestBody();
+        $this->setRequestBody('email_address', $this->getUserEmailAddress());
+        $this->setRequestBody('app_prefix', $appPrefix);
+        $this->setRequestBody('groups', $externalGroups);
+
+        $this->iRequestTheResourceBe('/user/external-groups', 'updated');
+    }
+
+    /**
+     * @Then that user's list of external groups should be :commaSeparatedExternalGroups
+     */
+    public function thatUsersListOfExternalGroupsShouldBe($commaSeparatedExternalGroups)
+    {
+        $user = User::findByEmail($this->getUserEmailAddress());
+        Assert::same($user->groups, $commaSeparatedExternalGroups);
+    }
+}

--- a/application/features/bootstrap/GroupsExternalUpdatesContext.php
+++ b/application/features/bootstrap/GroupsExternalUpdatesContext.php
@@ -32,6 +32,6 @@ class GroupsExternalUpdatesContext extends GroupsExternalContext
     public function thatUsersListOfExternalGroupsShouldBe($commaSeparatedExternalGroups)
     {
         $user = User::findByEmail($this->getUserEmailAddress());
-        Assert::same($user->groups, $commaSeparatedExternalGroups);
+        Assert::same($user->groups_external, $commaSeparatedExternalGroups);
     }
 }

--- a/application/features/groups-external-updates.feature
+++ b/application/features/groups-external-updates.feature
@@ -15,3 +15,4 @@ Feature: Updating a User's list of external groups
 
   # Scenario: Remove an external group from a user's list for a particular app
   # Scenario: Leave a user's external groups for a different app unchanged
+  # Scenario: Try to add an external group that does not match the given app-prefix

--- a/application/features/groups-external-updates.feature
+++ b/application/features/groups-external-updates.feature
@@ -22,5 +22,13 @@ Feature: Updating a User's list of external groups
     Then the response status code should be 204
      And that user's list of external groups should be "wiki-managers"
 
-  # Scenario: Leave a user's external groups for a different app unchanged
+  Scenario: Leave a user's external groups for a different app unchanged
+    Given a user exists
+      And that user's list of external groups is "wiki-users,map-europe"
+    When I update that user's list of "map" external groups to the following:
+      | externalGroup |
+      | map-america   |
+    Then the response status code should be 204
+    And that user's list of external groups should be "wiki-users,map-america"
+
   # Scenario: Try to add an external group that does not match the given app-prefix

--- a/application/features/groups-external-updates.feature
+++ b/application/features/groups-external-updates.feature
@@ -1,0 +1,17 @@
+Feature: Updating a User's list of external groups
+
+  Background:
+    Given the requester is authorized
+
+  Scenario: Add an external group to a user's list for a particular app
+    Given a user exists
+      And that user's list of external groups is "app-one"
+    When I update that user's list of "app" external groups to the following:
+      | externalGroup |
+      | app-one       |
+      | app-two       |
+    Then the response status code should be 200
+     And that user's list of external groups should be "app-one,app-two"
+
+  # Scenario: Remove an external group from a user's list for a particular app
+  # Scenario: Leave a user's external groups for a different app unchanged

--- a/application/features/groups-external-updates.feature
+++ b/application/features/groups-external-updates.feature
@@ -5,22 +5,22 @@ Feature: Updating a User's list of external groups
 
   Scenario: Add an external group to a user's list for a particular app
     Given a user exists
-      And that user's list of external groups is "app-one"
-    When I update that user's list of "app" external groups to the following:
+      And that user's list of external groups is "wiki-users"
+    When I update that user's list of "wiki" external groups to the following:
       | externalGroup |
-      | app-one       |
-      | app-two       |
+      | wiki-users    |
+      | wiki-managers |
     Then the response status code should be 204
-     And that user's list of external groups should be "app-one,app-two"
+     And that user's list of external groups should be "wiki-users,wiki-managers"
 
   Scenario: Remove an external group from a user's list for a particular app
     Given a user exists
-      And that user's list of external groups is "app-one,app-two"
-    When I update that user's list of "app" external groups to the following:
+      And that user's list of external groups is "wiki-users,wiki-managers"
+    When I update that user's list of "wiki" external groups to the following:
       | externalGroup |
-      | app-two       |
+      | wiki-managers |
     Then the response status code should be 204
-     And that user's list of external groups should be "app-two"
+     And that user's list of external groups should be "wiki-managers"
 
   # Scenario: Leave a user's external groups for a different app unchanged
   # Scenario: Try to add an external group that does not match the given app-prefix

--- a/application/features/groups-external-updates.feature
+++ b/application/features/groups-external-updates.feature
@@ -11,7 +11,7 @@ Feature: Updating a User's list of external groups
       | wiki-users    |
       | wiki-managers |
     Then the response status code should be 204
-     And that user's list of external groups should be "wiki-users,wiki-managers"
+      And that user's list of external groups should be "wiki-users,wiki-managers"
 
   Scenario: Remove an external group from a user's list for a particular app
     Given a user exists
@@ -20,7 +20,7 @@ Feature: Updating a User's list of external groups
       | externalGroup |
       | wiki-managers |
     Then the response status code should be 204
-     And that user's list of external groups should be "wiki-managers"
+      And that user's list of external groups should be "wiki-managers"
 
   Scenario: Leave a user's external groups for a different app unchanged
     Given a user exists
@@ -29,6 +29,6 @@ Feature: Updating a User's list of external groups
       | externalGroup |
       | map-america   |
     Then the response status code should be 204
-    And that user's list of external groups should be "wiki-users,map-america"
+      And that user's list of external groups should be "wiki-users,map-america"
 
   # Scenario: Try to add an external group that does not match the given app-prefix

--- a/application/features/groups-external-updates.feature
+++ b/application/features/groups-external-updates.feature
@@ -13,6 +13,14 @@ Feature: Updating a User's list of external groups
     Then the response status code should be 204
      And that user's list of external groups should be "app-one,app-two"
 
-  # Scenario: Remove an external group from a user's list for a particular app
+  Scenario: Remove an external group from a user's list for a particular app
+    Given a user exists
+      And that user's list of external groups is "app-one,app-two"
+    When I update that user's list of "app" external groups to the following:
+      | externalGroup |
+      | app-two       |
+    Then the response status code should be 204
+     And that user's list of external groups should be "app-two"
+
   # Scenario: Leave a user's external groups for a different app unchanged
   # Scenario: Try to add an external group that does not match the given app-prefix

--- a/application/features/groups-external-updates.feature
+++ b/application/features/groups-external-updates.feature
@@ -31,4 +31,12 @@ Feature: Updating a User's list of external groups
     Then the response status code should be 204
       And that user's list of external groups should be "wiki-users,map-america"
 
-  # Scenario: Try to add an external group that does not match the given app-prefix
+  Scenario: Try to add an external group that does not match the given app-prefix
+    Given a user exists
+      And that user's list of external groups is "wiki-users"
+    When I update that user's list of "wiki" external groups to the following:
+      | externalGroup |
+      | map-america   |
+    Then the response status code should be 422
+      And the response body should contain "prefix"
+      And that user's list of external groups should be "wiki-users"

--- a/application/features/groups-external-updates.feature
+++ b/application/features/groups-external-updates.feature
@@ -10,7 +10,7 @@ Feature: Updating a User's list of external groups
       | externalGroup |
       | app-one       |
       | app-two       |
-    Then the response status code should be 200
+    Then the response status code should be 204
      And that user's list of external groups should be "app-one,app-two"
 
   # Scenario: Remove an external group from a user's list for a particular app

--- a/application/features/groups-external.feature
+++ b/application/features/groups-external.feature
@@ -40,8 +40,6 @@ Feature: Incorporating custom (external) groups in a User's `members` list
       | two       |
       | {idpName} |
 
-#  Scenario: Update a user's `groups_external` list, given a group prefix and list of groups
-
 #  # Scenarios that belong in the new "groups_external" sync:
 #  Scenario: Send 1 notification email if sync finds group(s) for a user not in this IDP
 #  Scenario: Add entries in the synced Google Sheet to the `groups_external` field

--- a/application/frontend/config/main.php
+++ b/application/frontend/config/main.php
@@ -48,6 +48,7 @@ return [
                 'GET  user'                                  => 'user/index',
                 'GET  user/<employeeId:\w+>'                 => 'user/view',
                 'POST user'                                  => 'user/create',
+                'PUT  user/external-groups'                  => 'user/update-external-groups',
                 'PUT  user/<employeeId:\w+>'                 => 'user/update',
                 'PUT  user/<employeeId:\w+>/password'        => 'user/update-password',
                 'PUT  user/<employeeId:\w+>/password/assess' => 'user/assess-password',

--- a/application/frontend/controllers/UserController.php
+++ b/application/frontend/controllers/UserController.php
@@ -75,6 +75,27 @@ class UserController extends BaseRestController
         return $user;
     }
 
+    public function actionUpdateExternalGroups()
+    {
+        $emailAddress = Yii::$app->request->getBodyParam('email_address');
+        $appPrefix = Yii::$app->request->getBodyParam('app_prefix');
+        $externalGroups = Yii::$app->request->getBodyParam('groups');
+
+        $user = User::findByEmail($emailAddress);
+        if ($user === null) {
+            Yii::$app->response->statusCode = 404;
+            return;
+        }
+
+        if ($user->updateExternalGroups($appPrefix, $externalGroups)) {
+            Yii::$app->response->statusCode = 204;
+            return;
+        }
+
+        $errors = join(', ', $user->getFirstErrors());
+        throw new UnprocessableEntityHttpException($errors);
+    }
+
     public function actionUpdatePassword(string $employeeId)
     {
         $user = User::findOne(['employee_id' => $employeeId]);


### PR DESCRIPTION
[IDP-1182](https://itse.youtrack.cloud/issue/IDP-1182) Provide a way to set `user.groups_external`

---

### Added
- Add an API endpoint (with documentation and tests) for updating a prefix-specific subset of a User's list of external groups

---

### Feature PR Checklist
- [x] Documentation (README, local.env.dist, etc.)
- [x] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
