### PR TITLE
Pass config values to `Sheets` instead of internally retrieving them

### DIFF
--- a/application/common/components/Sheets.php
+++ b/application/common/components/Sheets.php
@@ -49,12 +49,6 @@ class Sheets extends Component
      */
     public function init()
     {
-        $this->applicationName = \Yii::$app->params['google']['applicationName'];
-        $this->jsonAuthFilePath = \Yii::$app->params['google']['jsonAuthFilePath'];
-        $this->jsonAuthString = \Yii::$app->params['google']['jsonAuthString'];
-        $this->delegatedAdmin = \Yii::$app->params['google']['delegatedAdmin'];
-        $this->spreadsheetId = \Yii::$app->params['google']['spreadsheetId'];
-
         if (!empty($this->jsonAuthFilePath)) {
             if (file_exists($this->jsonAuthFilePath)) {
                 $this->jsonAuthString = \file_get_contents($this->jsonAuthFilePath);

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1536,7 +1536,13 @@ class User extends UserBase
             'status' => 'start',
         ]);
 
-        $googleSheetsClient = new Sheets();
+        $googleSheetsClient = new Sheets([
+            'applicationName' => Yii::$app->params['google']['applicationName'],
+            'jsonAuthFilePath' => Yii::$app->params['google']['jsonAuthFilePath'],
+            'jsonAuthString' => Yii::$app->params['google']['jsonAuthString'],
+            'delegatedAdmin' => Yii::$app->params['google']['delegatedAdmin'],
+            'spreadsheetId' => Yii::$app->params['google']['spreadsheetId'],
+        ]);
 
         $activeUsers = User::find()->where(['active' => 'yes'])->all();
         $table = [];


### PR DESCRIPTION

To support [IDP-1183](https://itse.youtrack.cloud/issue/IDP-1183) (Sync prefixed-groups from Google Sheet to ID Broker's `groups_external` field)

---

### Changed (non-breaking)
- Pass config values to `Sheets` component instead of internally retrieving them
  * This allows us to instantiate a different `Sheets` instance for interacting with a different Google Sheet.

---

### Feature PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
