### PR TITLE
[IDP-1183, partial] Add cron-based sync of `groups_external` data from Google Sheet

### DIFF
--- a/application/common/components/ExternalGroupsSync.php
+++ b/application/common/components/ExternalGroupsSync.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace common\components;
+
+use common\models\User;
+use Yii;
+use yii\base\Component;
+
+class ExternalGroupsSync extends Component
+{
+    public const MAX_SYNC_SETS = 20;
+
+    public static function syncAllSets(array $syncSetsParams)
+    {
+        for ($i = 1; $i <= self::MAX_SYNC_SETS; $i++) {
+            $appPrefixKey = sprintf('set%uAppPrefix', $i);
+            $googleSheetIdKey = sprintf('set%uGoogleSheetId', $i);
+
+            if (! array_key_exists($appPrefixKey, $syncSetsParams)) {
+                Yii::warning(sprintf(
+                    'Finished syncing external groups after %s sync set(s).',
+                    ($i - 1)
+                ));
+                break;
+            }
+
+            $appPrefix = $syncSetsParams[$appPrefixKey] ?? null;
+            $googleSheetId = $syncSetsParams[$googleSheetIdKey] ?? null;
+
+            if (empty($appPrefix) || empty($googleSheetId)) {
+                Yii::error(sprintf(
+                    'Unable to do external-groups sync set %s: '
+                    . 'app-prefix (%s) or Google Sheet ID (%s) was empty.',
+                    $i,
+                    json_encode($appPrefix),
+                    json_encode($googleSheetId),
+                ));
+            } else {
+                Yii::warning(sprintf(
+                    'Syncing %s external groups from Google Sheet (%s)...',
+                    json_encode($appPrefix),
+                    $googleSheetId
+                ));
+                self::syncSet($appPrefix, $googleSheetId);
+            }
+        }
+    }
+
+    private static function syncSet(string $appPrefix, string $googleSheetId)
+    {
+        $desiredExternalGroups = self::getExternalGroupsFromGoogleSheet($googleSheetId);
+        $errors = User::syncExternalGroups($appPrefix, $desiredExternalGroups);
+        Yii::warning(sprintf(
+            'Ran sync for %s external groups.',
+            $appPrefix
+        ));
+
+        if (! empty($errors)) {
+            Yii::error(sprintf(
+                "Errors that occurred while syncing %s external groups: \n%s",
+                $appPrefix,
+                join("\n", $errors)
+            ));
+        }
+    }
+}

--- a/application/common/components/ExternalGroupsSync.php
+++ b/application/common/components/ExternalGroupsSync.php
@@ -37,8 +37,8 @@ class ExternalGroupsSync extends Component
                 ));
             } else {
                 Yii::warning(sprintf(
-                    'Syncing %s external groups from Google Sheet (%s)...',
-                    json_encode($appPrefix),
+                    "Syncing '%s' external groups from Google Sheet (%s)...",
+                    $appPrefix,
                     $googleSheetId
                 ));
                 self::syncSet($appPrefix, $googleSheetId);
@@ -51,7 +51,7 @@ class ExternalGroupsSync extends Component
         $desiredExternalGroups = self::getExternalGroupsFromGoogleSheet($googleSheetId);
         $errors = User::syncExternalGroups($appPrefix, $desiredExternalGroups);
         Yii::warning(sprintf(
-            'Ran sync for %s external groups.',
+            "Ran sync for '%s' external groups.",
             $appPrefix
         ));
 

--- a/application/common/components/ExternalGroupsSync.php
+++ b/application/common/components/ExternalGroupsSync.php
@@ -57,9 +57,9 @@ class ExternalGroupsSync extends Component
 
         if (! empty($errors)) {
             Yii::error(sprintf(
-                "Errors that occurred while syncing %s external groups: \n%s",
+                'Errors that occurred while syncing %s external groups: %s',
                 $appPrefix,
-                join("\n", $errors)
+                join(" / ", $errors)
             ));
         }
     }

--- a/application/common/components/Sheets.php
+++ b/application/common/components/Sheets.php
@@ -2,6 +2,7 @@
 
 namespace common\components;
 
+use Google\Service\Exception;
 use InvalidArgumentException;
 use yii\base\Component;
 use yii\helpers\Json;
@@ -125,6 +126,43 @@ class Sheets extends Component
             ['majorDimension' => 'ROWS']
         );
         return $header['values'][0];
+    }
+
+    /**
+     * Get all the values from the specified tab in this Google Sheet.
+     *
+     * @param string $tabName
+     * @param string $range
+     * @return array[]
+     *     Example:
+     *     ```
+     *     [
+     *         [
+     *             "A1's value",
+     *             "B1's value"
+     *         ],
+     *         [
+     *             "A2's value",
+     *             "B2's value"
+     *         ],
+     *         [
+     *             "A3's value",
+     *             "B3's value"
+     *         ]
+     *     ]
+     *     ```
+     * @throws Exception
+     */
+    public function getValuesFromTab(string $tabName, string $range = 'A:ZZ'): array
+    {
+        $client = $this->getGoogleClient();
+
+        $valueRange = $client->spreadsheets_values->get(
+            $this->spreadsheetId,
+            $tabName . '!' . $range
+        );
+
+        return $valueRange->values;
     }
 
     /**

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -239,6 +239,7 @@ return [
             ],
             Env::getArrayFromPrefix('ABANDONED_USER_')
         ),
+        'externalGroupsSyncSets' => Env::getArrayFromPrefix('EXTERNAL_GROUPS_SYNC_'),
         'googleAnalytics'               => [
             'apiSecret' => Env::get('GA_API_SECRET'),
             'measurementId' => Env::get('GA_MEASUREMENT_ID'),

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1094,17 +1094,7 @@ class User extends UserBase
         $this->addInMemoryExternalGroups($appExternalGroups);
 
         $this->scenario = self::SCENARIO_UPDATE_USER;
-        $saved = $this->save(true, ['groups_external']);
-        if ($saved) {
-            return true;
-        } else {
-            Yii::warning(sprintf(
-                'Failed to update external groups for %s: %s',
-                $this->email,
-                join(', ', $this->getFirstErrors())
-            ));
-            return false;
-        }
+        return $this->save(true, ['groups_external']);
     }
 
     /**

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1060,9 +1060,9 @@ class User extends UserBase
             $successful = $user->updateExternalGroups($appPrefix, $groupsForPrefix);
             if (! $successful) {
                 $errors[] = sprintf(
-                    "Failed to update external groups for %s: \n%s",
+                    'Failed to update external groups for %s: %s',
                     $email,
-                    json_encode($user->getFirstErrors(), JSON_PRETTY_PRINT)
+                    join(' / ', $user->getFirstErrors())
                 );
             }
         }
@@ -1082,9 +1082,9 @@ class User extends UserBase
             if (! str_starts_with($appExternalGroup, $appPrefix . '-')) {
                 $this->addErrors([
                     'groups_external' => sprintf(
-                        'The given group %s does not start with the given prefix (%s)',
-                        json_encode($appExternalGroup),
-                        json_encode($appPrefix)
+                        'The given group (%s) does not start with the given prefix (%s)',
+                        $appExternalGroup,
+                        $appPrefix
                     ),
                 ]);
                 return false;

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -2,6 +2,7 @@
 
 namespace console\controllers;
 
+use common\components\ExternalGroupsSync;
 use common\helpers\Utils;
 use common\models\Invite;
 use common\models\Method;
@@ -135,6 +136,16 @@ class CronController extends Controller
     public function actionExportToSheets()
     {
         User::exportToSheets();
+    }
+
+    /**
+     * Sync external groups from Google Sheets
+     */
+    public function actionSyncExternalGroups()
+    {
+        ExternalGroupsSync::syncAllSets(
+            \Yii::$app->params['externalGroupsSyncSets'] ?? []
+        );
     }
 
     /**

--- a/local.env.dist
+++ b/local.env.dist
@@ -337,3 +337,11 @@ GOOGLE_delegatedAdmin=admin@example.com
 
 # spreadsheet ID
 GOOGLE_spreadsheetId=putAnActualSheetIDHerejD70xAjqPnOCHlDK3YomH
+
+# === external groups sync sets === #
+
+# EXTERNAL_GROUPS_SYNC_set1AppPrefix=
+# EXTERNAL_GROUPS_SYNC_set1GoogleSheetId=
+# EXTERNAL_GROUPS_SYNC_set2AppPrefix=
+# EXTERNAL_GROUPS_SYNC_set2GoogleSheetId=
+# ... with as many sets as you want.


### PR DESCRIPTION
[IDP-1183](https://itse.youtrack.cloud/issue/IDP-1183) Sync prefixed-groups from Google Sheet to ID Broker's `groups_external` field

---

### Added
- Add cron-based sync of `groups_external` data from Google Sheet

### Fixed
- Clean up some external-groups log message formatting
- Remove redundant log message from `$user->updateExternalGroups()`

---

### Feature PR Checklist
- [x] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
