### PR TITLE
Limit the length of the logged error-summary for external-groups syncs

### DIFF
--- a/application/common/components/ExternalGroupsSync.php
+++ b/application/common/components/ExternalGroupsSync.php
@@ -57,11 +57,16 @@ class ExternalGroupsSync extends Component
         ));
 
         if (! empty($errors)) {
-            Yii::error(sprintf(
-                'Errors that occurred while syncing %s external groups: %s',
+            $errorSummary = sprintf(
+                'Errors that occurred (%s) while syncing %s external groups: %s',
+                count($errors),
                 $appPrefix,
                 join(" / ", $errors)
-            ));
+            );
+            if (strlen($errorSummary) > 1000) {
+                $errorSummary = substr($errorSummary, 0, 997) . '...';
+            }
+            Yii::error($errorSummary);
         }
     }
 


### PR DESCRIPTION
[IDP-1183](https://itse.youtrack.cloud/issue/IDP-1183) Sync prefixed-groups from Google Sheet to ID Broker's `groups_external` field

---

### Added
- Include a count (in the logged error message) of the errors that occurred during an external-groups sync

### Fixed
- Limit the length of the logged error-summary for external-groups syncs

---

### Feature PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
