### PR TITLE
Include external-groups sync when running all ID Broker cron jobs

### DIFF
--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -160,6 +160,7 @@ class CronController extends Controller
             'actionSendMethodReminderEmails',
             'actionSendPasswordExpiryEmails',
             'actionGoogleAnalytics',
+            'actionSyncExternalGroups',
         ];
 
         if (\Yii::$app->params['google']['enableSheetsExport']) {


### PR DESCRIPTION
[IDP-1183](https://itse.youtrack.cloud/issue/IDP-1183) Sync prefixed-groups from Google Sheet to ID Broker's `groups_external` field

---

### Added
- Include external-groups sync when running all ID Broker cron jobs

---

### Feature PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
