### PR TITLE
Prefix external-groups prefixes with `ext-`

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1043,6 +1043,15 @@ class User extends UserBase
         array $desiredExternalGroupsByUserEmail
     ): array {
         $errors = [];
+
+        if (preg_match('/^ext-[a-z0-9]+$/', $appPrefix) === 0) {
+            $errors[] = sprintf(
+                "The external-groups app-prefix must begin with 'ext-', then "
+                . "some combination of lowercase letters and/or numbers."
+            );
+            return $errors;
+        }
+
         $emailAddressesOfCurrentMatches = self::listUsersWithExternalGroupWith($appPrefix);
 
         // Indicate that users not in the "desired" list should not have any

--- a/application/features/bootstrap/GroupsExternalSyncContext.php
+++ b/application/features/bootstrap/GroupsExternalSyncContext.php
@@ -108,7 +108,10 @@ class GroupsExternalSyncContext extends GroupsExternalContext
      */
     public function thereShouldHaveBeenASyncError()
     {
-        Assert::notEmpty($this->syncErrors);
+        Assert::notEmpty(
+            $this->syncErrors,
+            'Expected sync errors, but found none.'
+        );
         foreach ($this->syncErrors as $syncError) {
             echo $syncError . PHP_EOL;
         }

--- a/application/features/bootstrap/GroupsExternalSyncContext.php
+++ b/application/features/bootstrap/GroupsExternalSyncContext.php
@@ -65,7 +65,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
     {
         $this->syncErrors = User::updateUsersExternalGroups(
             $appPrefix,
-            $this->externalGroupsLists[$appPrefix]
+            $this->externalGroupsLists[$appPrefix] ?? []
         );
     }
 
@@ -115,5 +115,23 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         foreach ($this->syncErrors as $syncError) {
             echo $syncError . PHP_EOL;
         }
+    }
+
+    /**
+     * @Then there should have been a sync error that mentions :text
+     */
+    public function thereShouldHaveBeenASyncErrorThatMentions($text)
+    {
+        $foundMatch = false;
+        foreach ($this->syncErrors as $syncError) {
+            echo $syncError . PHP_EOL;
+            if (str_contains($syncError, $text)) {
+                $foundMatch = true;
+            }
+        }
+        Assert::true($foundMatch, sprintf(
+            "Did not find a sync error that mentions '%s'",
+            $text
+        ));
     }
 }

--- a/application/features/groups-external-sync.feature
+++ b/application/features/groups-external-sync.feature
@@ -77,6 +77,10 @@ Feature: Syncing a specific app-prefix of external groups with an external list
         | email                  | groups   |
         | john_smith@example.org | map-asia |
 
+  Scenario: Try to use an app-prefix that does not begin with "ext-"
+    When I sync the list of "wiki" external groups
+    Then there should have been a sync error that mentions "ext-"
+
   Scenario: Try to add an external group that does not match the given app-prefix
     Given the following users exist, with these external groups:
         | email                  | groups   |

--- a/application/features/groups-external-sync.feature
+++ b/application/features/groups-external-sync.feature
@@ -2,80 +2,80 @@ Feature: Syncing a specific app-prefix of external groups with an external list
 
   Scenario: Add an external group to a user's list for a particular app
     Given the following users exist, with these external groups:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-one |
-      And the "wiki" external groups list is the following:
-        | email                  | groups            |
-        | john_smith@example.org | wiki-one,wiki-two |
-    When I sync the list of "wiki" external groups
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-one |
+      And the "ext-wiki" external groups list is the following:
+        | email                  | groups                    |
+        | john_smith@example.org | ext-wiki-one,ext-wiki-two |
+    When I sync the list of "ext-wiki" external groups
     Then there should not have been any sync errors
       And the following users should have the following external groups:
-        | email                  | groups            |
-        | john_smith@example.org | wiki-one,wiki-two |
+        | email                  | groups                    |
+        | john_smith@example.org | ext-wiki-one,ext-wiki-two |
 
   Scenario: Change the external group in a user's list for a particular app
     Given the following users exist, with these external groups:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-one |
-      And the "wiki" external groups list is the following:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-two |
-    When I sync the list of "wiki" external groups
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-one |
+      And the "ext-wiki" external groups list is the following:
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-two |
+    When I sync the list of "ext-wiki" external groups
     Then there should not have been any sync errors
       And the following users should have the following external groups:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-two |
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-two |
 
   Scenario: Leave a user's external groups for a different app unchanged
     Given the following users exist, with these external groups:
-        | email                  | groups              |
-        | john_smith@example.org | wiki-one,map-europe |
-      And the "wiki" external groups list is the following:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-two |
-    When I sync the list of "wiki" external groups
+        | email                  | groups                      |
+        | john_smith@example.org | ext-wiki-one,ext-map-europe |
+      And the "ext-wiki" external groups list is the following:
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-two |
+    When I sync the list of "ext-wiki" external groups
     Then there should not have been any sync errors
       And the following users should have the following external groups:
-        | email                  | groups               |
-        | john_smith@example.org | wiki-two,map-europe |
+        | email                  | groups                      |
+        | john_smith@example.org | ext-wiki-two,ext-map-europe |
 
   Scenario: Remove an external group from a user's list for a particular app
     Given the following users exist, with these external groups:
-        | email                  | groups            |
-        | john_smith@example.org | wiki-one,wiki-two |
-      And the "wiki" external groups list is the following:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-one |
-    When I sync the list of "wiki" external groups
+        | email                  | groups                    |
+        | john_smith@example.org | ext-wiki-one,ext-wiki-two |
+      And the "ext-wiki" external groups list is the following:
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-one |
+    When I sync the list of "ext-wiki" external groups
     Then there should not have been any sync errors
       And the following users should have the following external groups:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-one |
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-one |
 
   Scenario: Remove all external groups from a user's list for a particular app (no entry in list)
     Given the following users exist, with these external groups:
-        | email                  | groups                     |
-        | john_smith@example.org | wiki-one,wiki-two,map-asia |
-      And the "wiki" external groups list is the following:
+        | email                  | groups                                 |
+        | john_smith@example.org | ext-wiki-one,ext-wiki-two,ext-map-asia |
+      And the "ext-wiki" external groups list is the following:
         | email | groups |
-    When I sync the list of "wiki" external groups
+    When I sync the list of "ext-wiki" external groups
     Then there should not have been any sync errors
       And the following users should have the following external groups:
-        | email                  | groups   |
-        | john_smith@example.org | map-asia |
+        | email                  | groups       |
+        | john_smith@example.org | ext-map-asia |
 
   Scenario: Remove all external groups from a user's list for a particular app (blank entry in list)
     Given the following users exist, with these external groups:
-        | email                  | groups                     |
-        | john_smith@example.org | wiki-one,wiki-two,map-asia |
-      And the "wiki" external groups list is the following:
+        | email                  | groups                                 |
+        | john_smith@example.org | ext-wiki-one,ext-wiki-two,ext-map-asia |
+      And the "ext-wiki" external groups list is the following:
         | email                  | groups |
         | john_smith@example.org |        |
-    When I sync the list of "wiki" external groups
+    When I sync the list of "ext-wiki" external groups
     Then there should not have been any sync errors
       And the following users should have the following external groups:
-        | email                  | groups   |
-        | john_smith@example.org | map-asia |
+        | email                  | groups       |
+        | john_smith@example.org | ext-map-asia |
 
   Scenario: Try to use an app-prefix that does not begin with "ext-"
     When I sync the list of "wiki" external groups
@@ -83,42 +83,42 @@ Feature: Syncing a specific app-prefix of external groups with an external list
 
   Scenario: Try to add an external group that does not match the given app-prefix
     Given the following users exist, with these external groups:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-one |
-      And the "wiki" external groups list is the following:
-        | email                  | groups            |
-        | john_smith@example.org | wiki-one,map-asia |
-    When I sync the list of "wiki" external groups
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-one |
+      And the "ext-wiki" external groups list is the following:
+        | email                  | groups                    |
+        | john_smith@example.org | ext-wiki-one,ext-map-asia |
+    When I sync the list of "ext-wiki" external groups
     Then there should have been a sync error
       And the following users should have the following external groups:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-one |
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-one |
 
   Scenario: Properly handle (trim) spaces around external groups
     Given the following users exist, with these external groups:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-one |
-      And the "wiki" external groups list is the following:
-        | email                  | groups             |
-        | john_smith@example.org | wiki-one, wiki-two |
-    When I sync the list of "wiki" external groups
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-one |
+      And the "ext-wiki" external groups list is the following:
+        | email                  | groups                     |
+        | john_smith@example.org | ext-wiki-one, ext-wiki-two |
+    When I sync the list of "ext-wiki" external groups
     Then there should not have been any sync errors
       And the following users should have the following external groups:
-        | email                  | groups            |
-        | john_smith@example.org | wiki-one,wiki-two |
+        | email                  | groups                    |
+        | john_smith@example.org | ext-wiki-one,ext-wiki-two |
 
   Scenario: Properly handle an empty email address
     Given the following users exist, with these external groups:
-        | email                  | groups   |
-        | john_smith@example.org | wiki-one |
-      And the "wiki" external groups list is the following:
-        | email                  | groups            |
-        |                        | wiki-one          |
-        | john_smith@example.org | wiki-one,wiki-two |
-    When I sync the list of "wiki" external groups
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-one |
+      And the "ext-wiki" external groups list is the following:
+        | email                  | groups                    |
+        |                        | ext-wiki-one              |
+        | john_smith@example.org | ext-wiki-one,ext-wiki-two |
+    When I sync the list of "ext-wiki" external groups
     Then there should have been a sync error
       And the following users should have the following external groups:
-        | email                  | groups            |
-        | john_smith@example.org | wiki-one,wiki-two |
+        | email                  | groups                    |
+        | john_smith@example.org | ext-wiki-one,ext-wiki-two |
 
   # Scenario: Send 1 notification email if sync finds group(s) for a user not in this IDP

--- a/application/features/groups-external.feature
+++ b/application/features/groups-external.feature
@@ -3,31 +3,29 @@ Feature: Incorporating custom (external) groups in a User's `members` list
   Background:
     Given the requester is authorized
 
-  # Scenarios that belong here in ID Broker:
-
   Scenario: Include external groups in a User's `members` list
     Given a user exists
       And that user's list of groups is "one,two"
-      And that user's list of external groups is "app-three,app-four"
+      And that user's list of external groups is "ext-app-three,ext-app-four"
     When I sign in as that user
     Then the response should contain a member array with only these elements:
-      | element   |
-      | one       |
-      | two       |
-      | app-three |
-      | app-four  |
-      | {idpName} |
+      | element       |
+      | one           |
+      | two           |
+      | ext-app-three |
+      | ext-app-four  |
+      | {idpName}     |
 
   Scenario: Gracefully handle an empty list of groups in a User's `members` list
     Given a user exists
       And that user's list of groups is ""
-      And that user's list of external groups is "app-three,app-four"
+      And that user's list of external groups is "ext-app-three,ext-app-four"
     When I sign in as that user
     Then the response should contain a member array with only these elements:
-      | element   |
-      | app-three |
-      | app-four  |
-      | {idpName} |
+      | element       |
+      | ext-app-three |
+      | ext-app-four  |
+      | {idpName}     |
 
   Scenario: Gracefully handle an empty list of external groups in a User's `members` list
     Given a user exists


### PR DESCRIPTION
[IDP-1188](https://itse.youtrack.cloud/issue/IDP-1188) Prefix all external groups synced into ID Broker with "ext-"

---

### Fixed
- Require external-groups app-prefixes to start with "ext-"
- Improve error message for test step confirming there was a sync error

---

### Feature PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [x] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
