### PR TITLE
[IDP-1218] add a custom user agent header to the mfa client

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @silinternational/php-devs

--- a/application/common/components/MfaApiClient.php
+++ b/application/common/components/MfaApiClient.php
@@ -3,8 +3,8 @@
 namespace common\components;
 
 use GuzzleHttp\Client as GuzzleClient;
-use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Exception\ServerException;
 use Psr\Http\Message\ResponseInterface;
@@ -55,6 +55,7 @@ class MfaApiClient
             'X-MFA-APIKey' => $apiKey,
             'X-MFA-APISecret' => $apiSecret,
             'Content-type' => 'application/json',
+            'User-Agent' => 'idp-id-broker',
         ];
 
         $this->client = new GuzzleClient([
@@ -116,7 +117,6 @@ class MfaApiClient
             throw $e;
         }
     }
-
 
 
     /**


### PR DESCRIPTION
[IDP-1218](https://itse.youtrack.cloud/issue/IDP-1218) Configure Cloudflare so our MFA is 'known' and not blocked with certain bot settings

---

### Added
- Added a User-Agent header to the MFA client. This may help id-broker look less like a bot to Cloudflare, or at least make it possible to register it as acceptable.

---

### Feature PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [x] Run `make psr2`
