### PR TITLE
[IDP-1221] Optionally send external-groups sync-errors notification email

### DIFF
--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -358,7 +358,7 @@ class Emailer extends Component
         array $data = [],
         int $delaySeconds = 0
     ) {
-        if ($user?->active === 'no') {
+        if ($user && $user->active === 'no') {
             \Yii::warning([
                 'action' => 'send message',
                 'status' => 'canceled',
@@ -369,7 +369,7 @@ class Emailer extends Component
         }
 
         $dataForEmail = ArrayHelper::merge(
-            $user?->getAttributesForEmail() ?? [],
+            $user ? $user->getAttributesForEmail() : [],
             $this->otherDataForEmails,
             $data
         );

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -313,6 +313,7 @@ class Emailer extends Component
             EmailLog::MESSAGE_TYPE_MFA_RATE_LIMIT => $this->subjectForMfaRateLimit,
             EmailLog::MESSAGE_TYPE_PASSWORD_CHANGED => $this->subjectForPasswordChanged,
             EmailLog::MESSAGE_TYPE_WELCOME => $this->subjectForWelcome,
+            EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS => $this->subjectForExtGroupSyncErrors,
             EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES => $this->subjectForGetBackupCodes,
             EmailLog::MESSAGE_TYPE_REFRESH_BACKUP_CODES => $this->subjectForRefreshBackupCodes,
             EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY => $this->subjectForLostSecurityKey,

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -758,7 +758,7 @@ class Emailer extends Component
         string $appPrefix,
         array $errors,
         string $recipient,
-        string $googleSheetId
+        string $googleSheetUrl
     ) {
         $logData = [
             'action' => 'send external-groups sync errors email',
@@ -776,7 +776,7 @@ class Emailer extends Component
                 'toAddress' => $recipient,
                 'appPrefix' => $appPrefix,
                 'errors' => $errors,
-                'googleSheetUrl' => 'https://docs.google.com/spreadsheets/d/' . $googleSheetId,
+                'googleSheetUrl' => $googleSheetUrl,
                 'idpDisplayName' => \Yii::$app->params['idpDisplayName'],
             ]
         );

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -49,7 +49,7 @@ class Emailer extends Component
 
     public const SUBJ_ABANDONED_USER_ACCOUNTS = 'Unused {idpDisplayName} Identity Accounts';
 
-    public const SUBJ_SYNC_ERRORS = 'Errors while syncing {externalGroupsPrefix} external-groups to {idpDisplayName} IDP';
+    public const SUBJ_EXT_GROUP_SYNC_ERRORS = 'Errors while syncing {appPrefix} external-groups to {idpDisplayName} IDP';
 
     public const PROP_SUBJECT = 'subject';
     public const PROP_TO_ADDRESS = 'to_address';
@@ -143,7 +143,7 @@ class Emailer extends Component
 
     public $subjectForAbandonedUsers;
 
-    public $subjectForSyncErrors;
+    public $subjectForExtGroupSyncErrors;
 
     /* The email to contact for HR notifications */
     public $hrNotificationsEmail;
@@ -306,7 +306,7 @@ class Emailer extends Component
 
         $this->subjectForAbandonedUsers = $this->subjectForAbandonedUsers ?? self::SUBJ_ABANDONED_USER_ACCOUNTS;
 
-        $this->subjectForSyncErrors = $this->subjectForSyncErrors ?? self::SUBJ_SYNC_ERRORS;
+        $this->subjectForExtGroupSyncErrors = $this->subjectForExtGroupSyncErrors ?? self::SUBJ_EXT_GROUP_SYNC_ERRORS;
 
         $this->subjects = [
             EmailLog::MESSAGE_TYPE_INVITE => $this->subjectForInvite,

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -754,6 +754,38 @@ class Emailer extends Component
         ]));
     }
 
+    public function sendExternalGroupSyncErrorsEmail(
+        string $appPrefix,
+        array $errors,
+        string $recipient,
+        string $googleSheetId
+    ) {
+        $logData = [
+            'action' => 'send external-groups sync errors email',
+            'status' => 'starting',
+        ];
+
+        $this->logger->info(array_merge($logData, [
+            'errors' => count($errors)
+        ]));
+
+        $this->sendMessageTo(
+            EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS,
+            null,
+            [
+                'toAddress' => $recipient,
+                'appPrefix' => $appPrefix,
+                'errors' => $errors,
+                'googleSheetUrl' => 'https://docs.google.com/spreadsheets/d/' . $googleSheetId,
+                'idpDisplayName' => \Yii::$app->params['idpDisplayName'],
+            ]
+        );
+
+        $this->logger->info(array_merge($logData, [
+            'status' => 'finished',
+        ]));
+    }
+
     /**
      * Sends email alert to HR with all abandoned users, if any
      */

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -49,7 +49,7 @@ class Emailer extends Component
 
     public const SUBJ_ABANDONED_USER_ACCOUNTS = 'Unused {idpDisplayName} Identity Accounts';
 
-    public const SUBJ_EXT_GROUP_SYNC_ERRORS = 'Errors while syncing {appPrefix} external-groups to {idpDisplayName} IDP';
+    public const SUBJ_EXT_GROUP_SYNC_ERRORS = "Errors while syncing '{appPrefix}' external-groups to the {idpDisplayName} IDP";
 
     public const PROP_SUBJECT = 'subject';
     public const PROP_TO_ADDRESS = 'to_address';

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -49,6 +49,8 @@ class Emailer extends Component
 
     public const SUBJ_ABANDONED_USER_ACCOUNTS = 'Unused {idpDisplayName} Identity Accounts';
 
+    public const SUBJ_SYNC_ERRORS = 'Errors while syncing {externalGroupsPrefix} external-groups to {idpDisplayName} IDP';
+
     public const PROP_SUBJECT = 'subject';
     public const PROP_TO_ADDRESS = 'to_address';
     public const PROP_CC_ADDRESS = 'cc_address';
@@ -140,6 +142,8 @@ class Emailer extends Component
     public $subjectForPasswordPwned;
 
     public $subjectForAbandonedUsers;
+
+    public $subjectForSyncErrors;
 
     /* The email to contact for HR notifications */
     public $hrNotificationsEmail;
@@ -301,6 +305,8 @@ class Emailer extends Component
         $this->subjectForPasswordPwned = $this->subjectForPasswordPwned ?? self::SUBJ_PASSWORD_PWNED;
 
         $this->subjectForAbandonedUsers = $this->subjectForAbandonedUsers ?? self::SUBJ_ABANDONED_USER_ACCOUNTS;
+
+        $this->subjectForSyncErrors = $this->subjectForSyncErrors ?? self::SUBJ_SYNC_ERRORS;
 
         $this->subjects = [
             EmailLog::MESSAGE_TYPE_INVITE => $this->subjectForInvite,

--- a/application/common/components/ExternalGroupsSync.php
+++ b/application/common/components/ExternalGroupsSync.php
@@ -50,7 +50,15 @@ class ExternalGroupsSync extends Component
         }
     }
 
-    private static function syncSet(
+    /**
+     * Sync the specified external-groups data with the specified Google Sheet.
+     *
+     * @param string $appPrefix
+     * @param string $googleSheetId
+     * @param string $jsonAuthString
+     * @throws \Google\Service\Exception
+     */
+    public static function syncSet(
         string $appPrefix,
         string $googleSheetId,
         string $jsonAuthString
@@ -59,9 +67,24 @@ class ExternalGroupsSync extends Component
             $googleSheetId,
             $jsonAuthString
         );
+        self::processUpdates($appPrefix, $desiredExternalGroups);
+    }
+
+    /**
+     * Update users' external-groups using the given data, and handle (and
+     * return) any errors.
+     *
+     * @param string $appPrefix
+     * @param array $desiredExternalGroups
+     * @return string[] -- The resulting error messages.
+     */
+    public static function processUpdates(
+        string $appPrefix,
+        array $desiredExternalGroups
+    ): array {
         $errors = User::updateUsersExternalGroups($appPrefix, $desiredExternalGroups);
         Yii::warning(sprintf(
-            "Ran sync for '%s' external groups.",
+            "Updated '%s' external groups.",
             $appPrefix
         ));
 
@@ -77,6 +100,7 @@ class ExternalGroupsSync extends Component
             }
             Yii::error($errorSummary);
         }
+        return $errors;
     }
 
     /**

--- a/application/common/components/ExternalGroupsSync.php
+++ b/application/common/components/ExternalGroupsSync.php
@@ -91,14 +91,15 @@ class ExternalGroupsSync extends Component
      * @param string $appPrefix
      * @param array $desiredExternalGroups
      * @param string $errorsEmailRecipient
-     * @param string $googleSheetId
+     * @param string $googleSheetIdForEmail -- The Google Sheet's ID, for use in
+     *     the sync-error notification email.
      * @return string[] -- The resulting error messages.
      */
     public static function processUpdates(
         string $appPrefix,
         array $desiredExternalGroups,
         string $errorsEmailRecipient = '',
-        string $googleSheetId = ''
+        string $googleSheetIdForEmail = ''
     ): array {
         $errors = User::updateUsersExternalGroups($appPrefix, $desiredExternalGroups);
         Yii::warning(sprintf(
@@ -123,7 +124,7 @@ class ExternalGroupsSync extends Component
                     $appPrefix,
                     $errors,
                     $errorsEmailRecipient,
-                    $googleSheetId
+                    'https://docs.google.com/spreadsheets/d/' . $googleSheetIdForEmail
                 );
             }
         }
@@ -178,14 +179,14 @@ class ExternalGroupsSync extends Component
      * @param string $appPrefix
      * @param string[] $errors
      * @param string $recipient
-     * @param string $googleSheetId
+     * @param string $googleSheetUrl
      * @return void
      */
     private static function sendSyncErrorsEmail(
         string $appPrefix,
         array $errors,
         string $recipient,
-        string $googleSheetId
+        string $googleSheetUrl
     ) {
         /* @var $emailer Emailer */
         $emailer = \Yii::$app->emailer;
@@ -193,7 +194,7 @@ class ExternalGroupsSync extends Component
             $appPrefix,
             $errors,
             $recipient,
-            $googleSheetId
+            $googleSheetUrl
         );
     }
 }

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -125,7 +125,7 @@ return [
             'subjectForPasswordExpiring' => Env::get('SUBJECT_FOR_PASSWORD_EXPIRING'),
             'subjectForPasswordExpired' => Env::get('SUBJECT_FOR_PASSWORD_EXPIRED'),
             'subjectForAbandonedUsers' => Env::get('SUBJECT_FOR_ABANDONED_USERS'),
-            'subjectForSyncErrors' => Env::get('SUBJECT_FOR_SYNC_ERRORS'),
+            'subjectForExtGroupSyncErrors' => Env::get('SUBJECT_FOR_EXT_GROUP_SYNC_ERRORS'),
 
             'lostSecurityKeyEmailDays' => Env::get('LOST_SECURITY_KEY_EMAIL_DAYS', 62),
             'minimumBackupCodesBeforeNag' => Env::get('MINIMUM_BACKUP_CODES_BEFORE_NAG', 4),

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -125,6 +125,7 @@ return [
             'subjectForPasswordExpiring' => Env::get('SUBJECT_FOR_PASSWORD_EXPIRING'),
             'subjectForPasswordExpired' => Env::get('SUBJECT_FOR_PASSWORD_EXPIRED'),
             'subjectForAbandonedUsers' => Env::get('SUBJECT_FOR_ABANDONED_USERS'),
+            'subjectForSyncErrors' => Env::get('SUBJECT_FOR_SYNC_ERRORS'),
 
             'lostSecurityKeyEmailDays' => Env::get('LOST_SECURITY_KEY_EMAIL_DAYS', 62),
             'minimumBackupCodesBeforeNag' => Env::get('MINIMUM_BACKUP_CODES_BEFORE_NAG', 4),

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -82,6 +82,7 @@ return [
             'otherDataForEmails' => [
                 'emailSignature' => Env::get('EMAIL_SIGNATURE', ''),
                 'helpCenterUrl' => Env::get('HELP_CENTER_URL'),
+                'idpName' => $idpName,
                 'idpDisplayName' => $idpDisplayName,
                 'passwordProfileUrl' => $passwordProfileUrl . '/#',
                 'supportEmail' => Env::get('SUPPORT_EMAIL'),

--- a/application/common/mail/ext-group-sync-errors.html.php
+++ b/application/common/mail/ext-group-sync-errors.html.php
@@ -37,4 +37,8 @@ if (empty ($googleSheetUrl)) {
 }
 ?>
 
+<p>
+    Other users' external groups may have been synced successfully.
+</p>
+
 <p><i><?= nl2br(yHtml::encode($emailSignature), false) ?></i></p>

--- a/application/common/mail/ext-group-sync-errors.html.php
+++ b/application/common/mail/ext-group-sync-errors.html.php
@@ -17,7 +17,7 @@ use yii\helpers\Html as yHtml;
 <?= yHtml::ul($errors) ?>
 
 <?php
-if (empty ($googleSheetUrl)) {
+if (empty($googleSheetUrl)) {
     ?>
     <p>
         If any of these seem like simple data problems, you can potentially fix them

--- a/application/common/mail/ext-group-sync-errors.html.php
+++ b/application/common/mail/ext-group-sync-errors.html.php
@@ -1,0 +1,40 @@
+<?php
+use yii\helpers\Html as yHtml;
+
+/**
+ * @var string $appPrefix
+ * @var string[] $errors
+ * @var string $googleSheetUrl
+ * @var string $emailSignature
+ * @var string $idpDisplayName
+ * @var string $idpName
+ */
+?>
+<p>
+    The following errors occurred when syncing the <?= yHtml::encode($appPrefix) ?>
+    external groups to the <?= yHtml::encode($idpDisplayName) ?> IDP:
+</p>
+<?= yHtml::ul($errors) ?>
+
+<?php
+if (empty ($googleSheetUrl)) {
+    ?>
+    <p>
+        If any of these seem like simple data problems, you can potentially fix them
+        by updating the information in the Google Sheet used for this
+        external-groups sync.
+    </p>
+    <?php
+} else {
+    ?>
+    <p>
+        If any of these seem like simple data problems, you can potentially fix them
+        by updating the information in the "<?= yHtml::encode($idpName) ?>" tab of
+        this Google Sheet: <br />
+        <?= yHtml::a($googleSheetUrl, $googleSheetUrl) ?>
+    </p>
+    <?php
+}
+?>
+
+<p><i><?= nl2br(yHtml::encode($emailSignature), false) ?></i></p>

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -17,6 +17,7 @@ class EmailLog extends EmailLogBase
     public const MESSAGE_TYPE_MFA_RATE_LIMIT = 'mfa-rate-limit';
     public const MESSAGE_TYPE_PASSWORD_CHANGED = 'password-changed';
     public const MESSAGE_TYPE_WELCOME = 'welcome';
+    public const MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS = 'ext-group-sync-errors';
     public const MESSAGE_TYPE_GET_BACKUP_CODES = 'get-backup-codes';
     public const MESSAGE_TYPE_REFRESH_BACKUP_CODES = 'refresh-backup-codes';
     public const MESSAGE_TYPE_LOST_SECURITY_KEY = 'lost-security-key';

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1031,7 +1031,8 @@ class User extends UserBase
     }
 
     /**
-     * Update users' external-groups data using the given external-groups data.
+     * Update users' external-groups data using the given external-groups data
+     * and return a list of any errors that occurred.
      *
      * @param string $appPrefix -- Example: "wiki"
      * @param array $desiredExternalGroupsByUserEmail -- The authoritative list

--- a/application/composer.json
+++ b/application/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "php": ">=8.0",
+    "php": ">=7.4",
     "ext-json": "*",
     "codemix/yii2-streamlog": "^1.3",
     "fillup/fake-bower-assets": "2.0.9",

--- a/application/composer.json
+++ b/application/composer.json
@@ -8,7 +8,7 @@
     }
   ],
   "require": {
-    "php": ">=7.4",
+    "php": ">=8.0",
     "ext-json": "*",
     "codemix/yii2-streamlog": "^1.3",
     "fillup/fake-bower-assets": "2.0.9",

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,14 +4,14 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6394a68d2985d79e5ff26536b6a65dc2",
+    "content-hash": "d3c1b5411338aa77af05227eaeca95c1",
     "packages": [
         {
             "name": "bower-asset/inputmask",
             "version": "3.3.11",
             "source": {
                 "type": "git",
-                "url": "https://github.com/RobinHerbots/Inputmask.git",
+                "url": "git@github.com:RobinHerbots/Inputmask.git",
                 "reference": "5e670ad62f50c738388d4dcec78d2888505ad77b"
             },
             "dist": {
@@ -8123,7 +8123,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=8.0",
+        "php": ">=7.4",
         "ext-json": "*"
     },
     "platform-dev": [],

--- a/application/composer.lock
+++ b/application/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3c1b5411338aa77af05227eaeca95c1",
+    "content-hash": "6394a68d2985d79e5ff26536b6a65dc2",
     "packages": [
         {
             "name": "bower-asset/inputmask",
@@ -676,16 +676,16 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.373.0",
+            "version": "v0.375.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "88ee17077a2048ba0b2c637754b599be0523fe36"
+                "reference": "ad8c4fcf925fd10198c20e2d7a3390183dc24bf1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/88ee17077a2048ba0b2c637754b599be0523fe36",
-                "reference": "88ee17077a2048ba0b2c637754b599be0523fe36",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/ad8c4fcf925fd10198c20e2d7a3390183dc24bf1",
+                "reference": "ad8c4fcf925fd10198c20e2d7a3390183dc24bf1",
                 "shasum": ""
             },
             "require": {
@@ -714,9 +714,9 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.373.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.375.0"
             },
-            "time": "2024-09-16T00:56:51+00:00"
+            "time": "2024-09-29T01:10:26+00:00"
         },
         {
             "name": "google/auth",
@@ -1656,16 +1656,16 @@
         },
         {
             "name": "php-http/client-common",
-            "version": "2.7.1",
+            "version": "2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/client-common.git",
-                "reference": "1e19c059b0e4d5f717bf5d524d616165aeab0612"
+                "reference": "0cfe9858ab9d3b213041b947c881d5b19ceeca46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/client-common/zipball/1e19c059b0e4d5f717bf5d524d616165aeab0612",
-                "reference": "1e19c059b0e4d5f717bf5d524d616165aeab0612",
+                "url": "https://api.github.com/repos/php-http/client-common/zipball/0cfe9858ab9d3b213041b947c881d5b19ceeca46",
+                "reference": "0cfe9858ab9d3b213041b947c881d5b19ceeca46",
                 "shasum": ""
             },
             "require": {
@@ -1719,9 +1719,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/client-common/issues",
-                "source": "https://github.com/php-http/client-common/tree/2.7.1"
+                "source": "https://github.com/php-http/client-common/tree/2.7.2"
             },
-            "time": "2023-11-30T10:31:25+00:00"
+            "time": "2024-09-24T06:21:48+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -1804,16 +1804,16 @@
         },
         {
             "name": "php-http/httplug",
-            "version": "2.4.0",
+            "version": "2.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/httplug.git",
-                "reference": "625ad742c360c8ac580fcc647a1541d29e257f67"
+                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/httplug/zipball/625ad742c360c8ac580fcc647a1541d29e257f67",
-                "reference": "625ad742c360c8ac580fcc647a1541d29e257f67",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/5cad731844891a4c282f3f3e1b582c46839d22f4",
+                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4",
                 "shasum": ""
             },
             "require": {
@@ -1855,9 +1855,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/httplug/issues",
-                "source": "https://github.com/php-http/httplug/tree/2.4.0"
+                "source": "https://github.com/php-http/httplug/tree/2.4.1"
             },
-            "time": "2023-04-14T15:10:03+00:00"
+            "time": "2024-09-23T11:39:58+00:00"
         },
         {
             "name": "php-http/message",
@@ -2648,12 +2648,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "cc2d3a57b378c3fcdfbe06d7b4b68e31eeac214a"
+                "reference": "6f63660a573ec1e6d48d54ff7c44dfb1e303f30d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/cc2d3a57b378c3fcdfbe06d7b4b68e31eeac214a",
-                "reference": "cc2d3a57b378c3fcdfbe06d7b4b68e31eeac214a",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/6f63660a573ec1e6d48d54ff7c44dfb1e303f30d",
+                "reference": "6f63660a573ec1e6d48d54ff7c44dfb1e303f30d",
                 "shasum": ""
             },
             "conflict": {
@@ -2664,7 +2664,7 @@
                 "aimeos/ai-admin-graphql": ">=2022.04.1,<2022.10.10|>=2023.04.1,<2023.10.6|>=2024.04.1,<2024.04.6",
                 "aimeos/ai-admin-jsonadm": "<2020.10.13|>=2021.04.1,<2021.10.6|>=2022.04.1,<2022.10.3|>=2023.04.1,<2023.10.4|==2024.04.1",
                 "aimeos/ai-client-html": ">=2020.04.1,<2020.10.27|>=2021.04.1,<2021.10.22|>=2022.04.1,<2022.10.13|>=2023.04.1,<2023.10.15|>=2024.04.1,<2024.04.7",
-                "aimeos/ai-controller-frontend": "<2020.10.15|>=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.8|>=2023.04.1,<2023.10.9",
+                "aimeos/ai-controller-frontend": "<2020.10.15|>=2021.04.1,<2021.10.8|>=2022.04.1,<2022.10.8|>=2023.04.1,<2023.10.9|==2024.04.1",
                 "aimeos/aimeos-core": ">=2022.04.1,<2022.10.17|>=2023.04.1,<2023.10.17|>=2024.04.1,<2024.04.7",
                 "aimeos/aimeos-typo3": "<19.10.12|>=20,<20.10.5",
                 "airesvsg/acf-to-rest-api": "<=3.1",
@@ -2766,7 +2766,7 @@
                 "cuyz/valinor": "<0.12",
                 "czim/file-handling": "<1.5|>=2,<2.3",
                 "czproject/git-php": "<4.0.3",
-                "damienharper/auditor-bundle": "<6",
+                "damienharper/auditor-bundle": "<5.2.6",
                 "dapphp/securimage": "<3.6.6",
                 "darylldoyle/safe-svg": "<1.9.10",
                 "datadog/dd-trace": ">=0.30,<0.30.2",
@@ -2791,9 +2791,9 @@
                 "dolibarr/dolibarr": "<19.0.2",
                 "dompdf/dompdf": "<2.0.4",
                 "doublethreedigital/guest-entries": "<3.1.2",
-                "drupal/core": ">=6,<6.38|>=7,<7.96|>=8,<10.1.8|>=10.2,<10.2.2|==11.9999999.9999999.9999999-dev",
-                "drupal/core-recommended": "==11.9999999.9999999.9999999-dev",
-                "drupal/drupal": ">=5,<5.11|>=6,<6.38|>=7,<7.80|>=8,<8.9.16|>=9,<9.1.12|>=9.2,<9.2.4|==11.9999999.9999999.9999999-dev",
+                "drupal/core": ">=6,<6.38|>=7,<7.96|>=8,<=11.0.4",
+                "drupal/core-recommended": ">=8,<=11.0.4",
+                "drupal/drupal": ">=5,<5.11|>=6,<6.38|>=7,<7.80|>=8,<=11.0.4",
                 "duncanmcclean/guest-entries": "<3.1.2",
                 "dweeves/magmi": "<=0.7.24",
                 "ec-cube/ec-cube": "<2.4.4|>=2.11,<=2.17.1|>=3,<=3.0.18.0-patch4|>=4,<=4.1.2",
@@ -2836,6 +2836,8 @@
                 "feehi/cms": "<=2.1.1",
                 "feehi/feehicms": "<=2.1.1",
                 "fenom/fenom": "<=2.12.1",
+                "filament/infolists": ">=3,<3.2.115",
+                "filament/tables": ">=3,<3.2.115",
                 "filegator/filegator": "<7.8",
                 "filp/whoops": "<2.1.13",
                 "fineuploader/php-traditional-server": "<=1.2.2",
@@ -2993,10 +2995,11 @@
                 "magneto/core": "<1.9.4.4-dev",
                 "maikuolan/phpmussel": ">=1,<1.6",
                 "mainwp/mainwp": "<=4.4.3.3",
-                "mantisbt/mantisbt": "<2.26.2",
+                "mantisbt/mantisbt": "<=2.26.3",
                 "marcwillmann/turn": "<0.3.3",
                 "matyhtf/framework": "<3.0.6",
-                "mautic/core": "<4.4.12|>=5.0.0.0-alpha,<5.0.4",
+                "mautic/core": "<4.4.13|>=5,<5.1.1",
+                "mautic/core-lib": ">=1.0.0.0-beta,<4.4.13|>=5.0.0.0-alpha,<5.1.1",
                 "mdanter/ecc": "<2",
                 "mediawiki/core": "<1.36.2",
                 "mediawiki/matomo": "<2.4.3",
@@ -3226,6 +3229,7 @@
                 "spoonity/tcpdf": "<6.2.22",
                 "squizlabs/php_codesniffer": ">=1,<2.8.1|>=3,<3.0.1",
                 "ssddanbrown/bookstack": "<24.05.1",
+                "starcitizentools/citizen-skin": ">=2.6.3,<2.31",
                 "statamic/cms": "<4.46|>=5.3,<5.6.2",
                 "stormpath/sdk": "<9.9.99",
                 "studio-42/elfinder": "<=2.1.64",
@@ -3463,7 +3467,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-17T22:04:37+00:00"
+            "time": "2024-09-30T18:06:02+00:00"
         },
         {
             "name": "sentry/sdk",
@@ -4050,16 +4054,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "4c92046bb788648ff1098cc66da69aa7eac8cb65"
+                "reference": "fbebfcce21084d3e91ea987ae5bdd8c71ff0fd56"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/4c92046bb788648ff1098cc66da69aa7eac8cb65",
-                "reference": "4c92046bb788648ff1098cc66da69aa7eac8cb65",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/fbebfcce21084d3e91ea987ae5bdd8c71ff0fd56",
+                "reference": "fbebfcce21084d3e91ea987ae5bdd8c71ff0fd56",
                 "shasum": ""
             },
             "require": {
@@ -4123,7 +4127,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.4.11"
+                "source": "https://github.com/symfony/http-client/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -4139,7 +4143,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-26T06:30:21+00:00"
+            "time": "2024-09-20T08:21:33+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -5820,24 +5824,24 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.4.2",
+            "version": "3.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6"
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/c51258e759afdb17f1fd1fe83bc12baaef6309d6",
-                "reference": "c51258e759afdb17f1fd1fe83bc12baaef6309d6",
+                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.4",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
             },
             "type": "library",
             "extra": {
@@ -5881,7 +5885,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.2"
+                "source": "https://github.com/composer/semver/tree/3.4.3"
             },
             "funding": [
                 {
@@ -5897,7 +5901,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-12T11:35:52+00:00"
+            "time": "2024-09-19T14:15:21+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -6966,16 +6970,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "42686880adaacdad1835ee8fc2a9ec5b7bd63998"
+                "reference": "72d080eb9edf80e36c19be61f72c98ed8273b765"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/42686880adaacdad1835ee8fc2a9ec5b7bd63998",
-                "reference": "42686880adaacdad1835ee8fc2a9ec5b7bd63998",
+                "url": "https://api.github.com/repos/symfony/console/zipball/72d080eb9edf80e36c19be61f72c98ed8273b765",
+                "reference": "72d080eb9edf80e36c19be61f72c98ed8273b765",
                 "shasum": ""
             },
             "require": {
@@ -7040,7 +7044,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.11"
+                "source": "https://github.com/symfony/console/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -7056,20 +7060,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-15T22:48:29+00:00"
+            "time": "2024-09-20T08:15:52+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "e93c8368dc9915c2fe12018ff22fcbbdd32c9a9e"
+                "reference": "cfb9d34a1cdd4911bc737a5358fd1cf8ebfb536e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/e93c8368dc9915c2fe12018ff22fcbbdd32c9a9e",
-                "reference": "e93c8368dc9915c2fe12018ff22fcbbdd32c9a9e",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/cfb9d34a1cdd4911bc737a5358fd1cf8ebfb536e",
+                "reference": "cfb9d34a1cdd4911bc737a5358fd1cf8ebfb536e",
                 "shasum": ""
             },
             "require": {
@@ -7121,7 +7125,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.11"
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -7137,7 +7141,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-29T08:15:38+00:00"
+            "time": "2024-09-20T08:18:25+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -7297,16 +7301,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.9",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463"
+                "reference": "f810e3cbdf7fdc35983968523d09f349fa9ada12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b51ef8059159330b74a4d52f68e671033c0fe463",
-                "reference": "b51ef8059159330b74a4d52f68e671033c0fe463",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f810e3cbdf7fdc35983968523d09f349fa9ada12",
+                "reference": "f810e3cbdf7fdc35983968523d09f349fa9ada12",
                 "shasum": ""
             },
             "require": {
@@ -7343,7 +7347,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.9"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -7359,7 +7363,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:49:33+00:00"
+            "time": "2024-09-16T16:01:33+00:00"
         },
         {
             "name": "symfony/finder",
@@ -7581,16 +7585,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.8",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5"
+                "reference": "3f94e5f13ff58df371a7ead461b6e8068900fbb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/8d92dd79149f29e89ee0f480254db595f6a6a2c5",
-                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3f94e5f13ff58df371a7ead461b6e8068900fbb3",
+                "reference": "3f94e5f13ff58df371a7ead461b6e8068900fbb3",
                 "shasum": ""
             },
             "require": {
@@ -7622,7 +7626,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.8"
+                "source": "https://github.com/symfony/process/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -7638,7 +7642,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-09-17T12:47:12+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -7704,16 +7708,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b"
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
-                "reference": "5bc3eb632cf9c8dbfd6529d89be9950d1518883b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f8a1ccebd0997e16112dfecfd74220b78e5b284b",
+                "reference": "f8a1ccebd0997e16112dfecfd74220b78e5b284b",
                 "shasum": ""
             },
             "require": {
@@ -7770,7 +7774,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.11"
+                "source": "https://github.com/symfony/string/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -7786,20 +7790,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-12T09:55:28+00:00"
+            "time": "2024-09-20T08:15:52+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v6.4.10",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "94041203f8ac200ae9e7c6a18fa6137814ccecc9"
+                "reference": "cf8360b8352b086be620fae8342c4d96e391a489"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/94041203f8ac200ae9e7c6a18fa6137814ccecc9",
-                "reference": "94041203f8ac200ae9e7c6a18fa6137814ccecc9",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/cf8360b8352b086be620fae8342c4d96e391a489",
+                "reference": "cf8360b8352b086be620fae8342c4d96e391a489",
                 "shasum": ""
             },
             "require": {
@@ -7865,7 +7869,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.4.10"
+                "source": "https://github.com/symfony/translation/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -7881,7 +7885,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-26T12:30:32+00:00"
+            "time": "2024-09-16T06:02:54+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -8040,16 +8044,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.11",
+            "version": "v6.4.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "be37e7f13195e05ab84ca5269365591edd240335"
+                "reference": "762ee56b2649659380e0ef4d592d807bc17b7971"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/be37e7f13195e05ab84ca5269365591edd240335",
-                "reference": "be37e7f13195e05ab84ca5269365591edd240335",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/762ee56b2649659380e0ef4d592d807bc17b7971",
+                "reference": "762ee56b2649659380e0ef4d592d807bc17b7971",
                 "shasum": ""
             },
             "require": {
@@ -8092,7 +8096,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.11"
+                "source": "https://github.com/symfony/yaml/tree/v6.4.12"
             },
             "funding": [
                 {
@@ -8108,7 +8112,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-12T09:55:28+00:00"
+            "time": "2024-09-17T12:47:12+00:00"
         }
     ],
     "aliases": [],
@@ -8119,7 +8123,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "ext-json": "*"
     },
     "platform-dev": [],

--- a/application/dependencies.json
+++ b/application/dependencies.json
@@ -49,7 +49,7 @@
   },
   {
     "name": "google/apiclient-services",
-    "version": "v0.373.0"
+    "version": "v0.375.0"
   },
   {
     "name": "google/auth",
@@ -105,7 +105,7 @@
   },
   {
     "name": "php-http/client-common",
-    "version": "2.7.1"
+    "version": "2.7.2"
   },
   {
     "name": "php-http/discovery",
@@ -113,7 +113,7 @@
   },
   {
     "name": "php-http/httplug",
-    "version": "2.4.0"
+    "version": "2.4.1"
   },
   {
     "name": "php-http/message",
@@ -169,7 +169,7 @@
   },
   {
     "name": "roave/security-advisories",
-    "version": "dev-master cc2d3a5"
+    "version": "dev-master 6f63660"
   },
   {
     "name": "sentry/sdk",
@@ -213,7 +213,7 @@
   },
   {
     "name": "symfony/http-client",
-    "version": "v6.4.11"
+    "version": "v6.4.12"
   },
   {
     "name": "symfony/http-client-contracts",

--- a/application/features/bootstrap/GroupsExternalSyncContext.php
+++ b/application/features/bootstrap/GroupsExternalSyncContext.php
@@ -171,7 +171,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         $syncErrorEmails = [];
 
         foreach ($emails as $email) {
-            if ($email[Emailer::PROP_SUBJECT] === $this->fakeEmailer->subjectForSyncErrors) {
+            if ($email[Emailer::PROP_SUBJECT] === $this->fakeEmailer->subjectForExtGroupSyncErrors) {
                 $syncErrorEmails[] = $email;
             }
         }

--- a/application/features/bootstrap/GroupsExternalSyncContext.php
+++ b/application/features/bootstrap/GroupsExternalSyncContext.php
@@ -4,6 +4,7 @@ namespace Sil\SilIdBroker\Behat\Context;
 
 use Behat\Gherkin\Node\TableNode;
 use common\components\Emailer;
+use common\components\ExternalGroupsSync;
 use common\models\User;
 use Sil\PhpEnv\Env;
 use Webmozart\Assert\Assert;
@@ -65,7 +66,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
      */
     public function iSyncTheListOfExternalGroups($appPrefix)
     {
-        $this->syncErrors = User::updateUsersExternalGroups(
+        $this->syncErrors = ExternalGroupsSync::processUpdates(
             $appPrefix,
             $this->externalGroupsLists[$appPrefix] ?? []
         );

--- a/application/features/bootstrap/GroupsExternalSyncContext.php
+++ b/application/features/bootstrap/GroupsExternalSyncContext.php
@@ -147,10 +147,10 @@ class GroupsExternalSyncContext extends GroupsExternalContext
      */
     public function onlyTheFollowingUsersExistWithTheseExternalGroups(TableNode $table)
     {
-        Assert::eq(
+        Assert::inArray(
             Env::get('MYSQL_DATABASE'),
-            'appfortests',
-            'This test should only be run against the test database (it deletes users)'
+            ['appfortests', 'test'],
+            'This test should only be run against a test database (because it deletes users)'
         );
 
         $usersThatShouldExist = [];

--- a/application/features/bootstrap/GroupsExternalSyncContext.php
+++ b/application/features/bootstrap/GroupsExternalSyncContext.php
@@ -3,14 +3,16 @@
 namespace Sil\SilIdBroker\Behat\Context;
 
 use Behat\Gherkin\Node\TableNode;
-use common\components\Emailer;
 use common\components\ExternalGroupsSync;
+use common\models\EmailLog;
 use common\models\User;
 use Sil\PhpEnv\Env;
 use Webmozart\Assert\Assert;
 
 class GroupsExternalSyncContext extends GroupsExternalContext
 {
+    private string $errorsEmailRecipient = '';
+
     /**
      * The lists of external groups for use by these tests. Example:
      * ```
@@ -68,7 +70,9 @@ class GroupsExternalSyncContext extends GroupsExternalContext
     {
         $this->syncErrors = ExternalGroupsSync::processUpdates(
             $appPrefix,
-            $this->externalGroupsLists[$appPrefix] ?? []
+            $this->externalGroupsLists[$appPrefix] ?? [],
+            $this->errorsEmailRecipient,
+            'dummy-google-sheet-id'
         );
     }
 
@@ -163,19 +167,34 @@ class GroupsExternalSyncContext extends GroupsExternalContext
     }
 
     /**
-     * @Then we should have sent exactly :expectedCount sync-error notification email
+     * @Then we should have sent exactly :expectedCount :appPrefix sync-error notification email
      */
-    public function weShouldHaveSentExactlySyncErrorNotificationEmail($expectedCount)
+    public function weShouldHaveSentExactlySyncErrorNotificationEmail($expectedCount, $appPrefix)
     {
-        $emails = $this->fakeEmailer->getFakeEmailsSent();
-        $syncErrorEmails = [];
+        $fakeEmailer = $this->fakeEmailer;
 
-        foreach ($emails as $email) {
-            if ($email[Emailer::PROP_SUBJECT] === $this->fakeEmailer->subjectForExtGroupSyncErrors) {
-                $syncErrorEmails[] = $email;
-            }
-        }
+        // The $appPrefix is needed by the FakeEmailer, to find the appropriate
+        // emails (by being able to accurately generate the expected subject).
+        $fakeEmailer->otherDataForEmails['appPrefix'] = $appPrefix;
+        $syncErrorEmails = $fakeEmailer->getFakeEmailsOfTypeSentToUser(
+            EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS,
+            $this->errorsEmailRecipient
+        );
 
-        Assert::count($syncErrorEmails, $expectedCount);
+        Assert::count($syncErrorEmails, $expectedCount, sprintf(
+            'Expected %s sync-error emails (to %s), but found %s. Emails sent: %s',
+            $expectedCount,
+            $this->errorsEmailRecipient,
+            count($syncErrorEmails),
+            json_encode($fakeEmailer->getFakeEmailsSent(), JSON_PRETTY_PRINT)
+        ));
+    }
+
+    /**
+     * @Given we have provided an error-notifications email address
+     */
+    public function weHaveProvidedAnErrorNotificationsEmailAddress()
+    {
+        $this->errorsEmailRecipient = 'sync-errors@example.com';
     }
 }

--- a/application/features/bootstrap/fakes/FakeEmailer.php
+++ b/application/features/bootstrap/fakes/FakeEmailer.php
@@ -67,7 +67,7 @@ class FakeEmailer extends Emailer
     public function isSubjectForMessageType(string $subject, string $messageType, ?User $user)
     {
         $dataForEmail = ArrayHelper::merge(
-            $user?->getAttributesForEmail() ?? [],
+            $user ? $user->getAttributesForEmail() : [],
             $this->otherDataForEmails
         );
 

--- a/application/features/bootstrap/fakes/FakeEmailer.php
+++ b/application/features/bootstrap/fakes/FakeEmailer.php
@@ -39,10 +39,10 @@ class FakeEmailer extends Emailer
      *
      * @param string $messageType The type of message.
      * @param string $emailAddress Email address to find.
-     * @param User $user User record for subject text completion.
+     * @param ?User $user User record for subject text completion, if applicable.
      * @return array[]
      */
-    public function getFakeEmailsOfTypeSentToUser(string $messageType, string $emailAddress, User $user)
+    public function getFakeEmailsOfTypeSentToUser(string $messageType, string $emailAddress, ?User $user = null)
     {
         $fakeEmailer = $this;
         $fakeEmailsSent = $fakeEmailer->getFakeEmailsSent();
@@ -64,10 +64,10 @@ class FakeEmailer extends Emailer
         return $this->getEmailServiceClient()->emailsSent;
     }
 
-    public function isSubjectForMessageType(string $subject, string $messageType, User $user)
+    public function isSubjectForMessageType(string $subject, string $messageType, ?User $user)
     {
         $dataForEmail = ArrayHelper::merge(
-            $user->getAttributesForEmail(),
+            $user?->getAttributesForEmail() ?? [],
             $this->otherDataForEmails
         );
 

--- a/application/features/groups-external-sync.feature
+++ b/application/features/groups-external-sync.feature
@@ -146,9 +146,10 @@ Feature: Syncing a specific app-prefix of external groups with an external list
         | jane_doe@example.org      | ext-wiki-one |
         | john_smith@example.org    | ext-wiki-two |
         | bob_mcmanager@example.org | ext-wiki-two |
+      And we have provided an error-notifications email address
     When I sync the list of "ext-wiki" external groups
     Then there should have been a sync error
-      And we should have sent exactly 1 sync-error notification email
+      And we should have sent exactly 1 "ext-wiki" sync-error notification email
       And the following users should have the following external groups:
         | email                  | groups       |
         | john_smith@example.org | ext-wiki-two |

--- a/application/features/groups-external-sync.feature
+++ b/application/features/groups-external-sync.feature
@@ -121,4 +121,18 @@ Feature: Syncing a specific app-prefix of external groups with an external list
         | email                  | groups                    |
         | john_smith@example.org | ext-wiki-one,ext-wiki-two |
 
-  # Scenario: Send 1 notification email if sync finds group(s) for a user not in this IDP
+  Scenario: Send 1 notification email if sync includes user(s) not in this IDP
+    Given only the following users exist, with these external groups:
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-one |
+      And the "ext-wiki" external groups list is the following:
+        | email                     | groups       |
+        | jane_doe@example.org      | ext-wiki-one |
+        | john_smith@example.org    | ext-wiki-two |
+        | bob_mcmanager@example.org | ext-wiki-two |
+    When I sync the list of "ext-wiki" external groups
+    Then there should have been a sync error
+      And we should have sent exactly 1 sync-error notification email
+      And the following users should have the following external groups:
+        | email                  | groups       |
+        | john_smith@example.org | ext-wiki-two |

--- a/local.env.dist
+++ b/local.env.dist
@@ -345,7 +345,13 @@ GOOGLE_spreadsheetId=putAnActualSheetIDHerejD70xAjqPnOCHlDK3YomH
 # EXTERNAL_GROUPS_SYNC_set1AppPrefix=
 # EXTERNAL_GROUPS_SYNC_set1GoogleSheetId=
 # EXTERNAL_GROUPS_SYNC_set1JsonAuthString=
+## Optional:
+# EXTERNAL_GROUPS_SYNC_set1ErrorsEmailRecipient=
+
 # EXTERNAL_GROUPS_SYNC_set2AppPrefix=
 # EXTERNAL_GROUPS_SYNC_set2GoogleSheetId=
 # EXTERNAL_GROUPS_SYNC_set2JsonAuthString=
+## Optional:
+# EXTERNAL_GROUPS_SYNC_set2ErrorsEmailRecipient=
+
 # ... with as many sets as you want.


### PR DESCRIPTION
[IDP-1221](https://itse.youtrack.cloud/issue/IDP-1221) Send error notification email for external-groups sync errors

---

### Added
- Optionally send external-groups sync-errors notification email (see `local.env.dist` for the environment variable name)

### Changed (non-breaking)
- Enable the `Emailer` to send to an arbitrary email address

### Fixed
- Update dependencies

---

### Feature PR Checklist
- [x] Documentation (README, local.env.dist, api.raml, etc.)
- [x] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
