### PR TITLE
Fix logic for sync-errors email for when the Google Sheet ID isn't known

### DIFF
--- a/application/common/components/ExternalGroupsSync.php
+++ b/application/common/components/ExternalGroupsSync.php
@@ -120,11 +120,15 @@ class ExternalGroupsSync extends Component
             Yii::error($errorSummary);
 
             if (!empty($errorsEmailRecipient)) {
+                $googleSheetUrl = '';
+                if (!empty($googleSheetIdForEmail)) {
+                    $googleSheetUrl = 'https://docs.google.com/spreadsheets/d/' . $googleSheetIdForEmail;
+                }
                 self::sendSyncErrorsEmail(
                     $appPrefix,
                     $errors,
                     $errorsEmailRecipient,
-                    'https://docs.google.com/spreadsheets/d/' . $googleSheetIdForEmail
+                    $googleSheetUrl
                 );
             }
         }


### PR DESCRIPTION
[IDP-1221](https://itse.youtrack.cloud/issue/IDP-1221) Send error notification email for external-groups sync errors

---

### Fixed
- Fix logic for sync-errors email for when the Google Sheet ID isn't known

---

### Feature PR Checklist
- [x] Run `make composershow`
- [x] Run `make psr2`
