### PR TITLE
Release 6.10.2 - Remove `develop`, PR straight to `main`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,8 @@
 
 ---
 
-### Feature PR Checklist
+### PR Checklist
+- [ ] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
 - [ ] Documentation (README, local.env.dist, api.raml, etc.)
 - [ ] Tests created or updated
 - [ ] Run `make composershow`


### PR DESCRIPTION
### Removed
- NOTE: There will no longer be a maintained `develop` tag for this repo's [Docker images](https://hub.docker.com/r/silintl/idp-id-broker/tags).

### Fixed
- Update PR checklist to reflect the fact that every PR will be a release
  * We are removing the `develop` branch. Every PR will go straight to `main` by default now.

---

### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] Documentation (README, local.env.dist, api.raml, etc.)