### PR TITLE
Release 6.10.3 - Also push a `{major}` version tag (e.g. `6`)

### DIFF
--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -48,6 +48,7 @@ jobs:
             type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Build and push Docker image to Docker Hub
         uses: docker/build-push-action@v5


### PR DESCRIPTION
### WAITING FOR
- #380 

---

### Added
- Also push a `{major}` version tag (e.g. `6`)
  * This will probably be useful during local development, now that we are removing the `develop` tag.

---

### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)