### PR TITLE
Release 6.10.5 - Avoid sending abandoned-users email to HR too frequently

### DIFF
--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -313,6 +313,7 @@ class Emailer extends Component
             EmailLog::MESSAGE_TYPE_MFA_RATE_LIMIT => $this->subjectForMfaRateLimit,
             EmailLog::MESSAGE_TYPE_PASSWORD_CHANGED => $this->subjectForPasswordChanged,
             EmailLog::MESSAGE_TYPE_WELCOME => $this->subjectForWelcome,
+            EmailLog::MESSAGE_TYPE_ABANDONED_USERS => $this->subjectForAbandonedUsers,
             EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS => $this->subjectForExtGroupSyncErrors,
             EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES => $this->subjectForGetBackupCodes,
             EmailLog::MESSAGE_TYPE_REFRESH_BACKUP_CODES => $this->subjectForRefreshBackupCodes,
@@ -381,6 +382,13 @@ class Emailer extends Component
         $ccAddress = $data['ccAddress'] ?? '';
         $bccAddress = $data['bccAddress'] ?? '';
         $subject = $this->getSubjectForMessage($messageType, $dataForEmail);
+
+        if (empty($subject)) {
+            \Yii::error(sprintf(
+                'No subject known for %s email messages.',
+                $messageType
+            ));
+        }
 
         $this->email($toAddress, $subject, $htmlBody, strip_tags($htmlBody), $ccAddress, $bccAddress, $delaySeconds);
 

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -462,6 +462,26 @@ class Emailer extends Component
     }
 
     /**
+     * Whether we should send an abandoned-users message to HR.
+     *
+     * @return bool
+     */
+    public function shouldSendAbandonedUsersMessage(): bool
+    {
+        if (empty($this->hrNotificationsEmail)) {
+            return false;
+        }
+
+        $haveSentAbandonedUsersEmailRecently = $this->hasAddressReceivedMessageRecently(
+            $this->hrNotificationsEmail,
+            EmailLog::MESSAGE_TYPE_ABANDONED_USERS
+        );
+
+        return !$haveSentAbandonedUsersEmailRecently;
+    }
+
+
+    /**
      * Whether we should send an invite message to the given User.
      *
      * @param User $user The User in question.
@@ -834,14 +854,16 @@ class Emailer extends Component
             $dataForEmail['users'] = User::getAbandonedUsers();
 
             if (!empty($dataForEmail['users'])) {
-                $this->sendMessageTo(
-                    'abandoned-users',
-                    null,
-                    ArrayHelper::merge(
-                        $dataForEmail,
-                        ['toAddress' => $this->hrNotificationsEmail]
-                    )
-                );
+                if ($this->shouldSendAbandonedUsersMessage()) {
+                    $this->sendMessageTo(
+                        EmailLog::MESSAGE_TYPE_ABANDONED_USERS,
+                        null,
+                        ArrayHelper::merge(
+                            $dataForEmail,
+                            ['toAddress' => $this->hrNotificationsEmail]
+                        )
+                    );
+                }
             }
         }
     }

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -392,9 +392,7 @@ class Emailer extends Component
 
         $this->email($toAddress, $subject, $htmlBody, strip_tags($htmlBody), $ccAddress, $bccAddress, $delaySeconds);
 
-        if ($user !== null) {
-            EmailLog::logMessage($messageType, $toAddress);
-        }
+        EmailLog::logMessage($messageType, $toAddress);
     }
 
     /**

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -194,6 +194,11 @@ class Emailer extends Component
     /**
      * Use the email service to send an email.
      *
+     * WARNING:
+     * You probably shouldn't be calling this directly. Instead, call the
+     * `sendMessageTo()` method so that the sending of this email will be
+     * logged.
+     *
      * @param string $toAddress The recipient's email address.
      * @param string $subject The subject.
      * @param string $htmlBody The email body (as HTML).
@@ -829,9 +834,14 @@ class Emailer extends Component
             $dataForEmail['users'] = User::getAbandonedUsers();
 
             if (!empty($dataForEmail['users'])) {
-                $htmlBody = \Yii::$app->view->render('@common/mail/abandoned-users.html.php', $dataForEmail);
-
-                $this->email($this->hrNotificationsEmail, $this->subjectForAbandonedUsers, $htmlBody, strip_tags($htmlBody));
+                $this->sendMessageTo(
+                    'abandoned-users',
+                    null,
+                    ArrayHelper::merge(
+                        $dataForEmail,
+                        ['toAddress' => $this->hrNotificationsEmail]
+                    )
+                );
             }
         }
     }

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -6,6 +6,9 @@ use common\helpers\MySqlDateTime;
 use Yii;
 use yii\helpers\ArrayHelper;
 
+/**
+ * @property ?User $user
+ */
 class EmailLog extends EmailLogBase
 {
     /* Valid message_type values.
@@ -42,6 +45,16 @@ class EmailLog extends EmailLogBase
         return ArrayHelper::merge(parent::attributeLabels(), [
             'sent_utc' => Yii::t('app', 'Sent (UTC)'),
         ]);
+    }
+
+    /**
+     * Gets query for [[User]].
+     *
+     * @return \yii\db\ActiveQuery
+     */
+    public function getUser()
+    {
+        return $this->hasOne(User::class, ['email' => 'to_address']);
     }
 
     public static function getMessageTypes()

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -69,18 +69,18 @@ class EmailLog extends EmailLogBase
         ];
     }
 
-    public static function logMessage(string $messageType, $userId)
+    public static function logMessage(string $messageType, string $toAddress)
     {
         $emailLog = new EmailLog([
-            'user_id' => $userId,
+            'to_address' => $toAddress,
             'message_type' => $messageType,
         ]);
 
         if (!$emailLog->save()) {
             $errorMessage = sprintf(
-                'Failed to log %s email to User %s: %s',
+                'Failed to log %s email to %s: %s',
                 var_export($messageType, true),
-                var_export($userId, true),
+                var_export($toAddress, true),
                 \json_encode($emailLog->getFirstErrors(), JSON_PRETTY_PRINT)
             );
             \Yii::warning($errorMessage);

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -20,6 +20,7 @@ class EmailLog extends EmailLogBase
     public const MESSAGE_TYPE_MFA_RATE_LIMIT = 'mfa-rate-limit';
     public const MESSAGE_TYPE_PASSWORD_CHANGED = 'password-changed';
     public const MESSAGE_TYPE_WELCOME = 'welcome';
+    public const MESSAGE_TYPE_ABANDONED_USERS = 'abandoned-users';
     public const MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS = 'ext-group-sync-errors';
     public const MESSAGE_TYPE_GET_BACKUP_CODES = 'get-backup-codes';
     public const MESSAGE_TYPE_REFRESH_BACKUP_CODES = 'refresh-backup-codes';

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -3,6 +3,7 @@
 namespace common\models;
 
 use common\helpers\MySqlDateTime;
+use ReflectionClass;
 use Yii;
 use yii\helpers\ArrayHelper;
 
@@ -58,29 +59,16 @@ class EmailLog extends EmailLogBase
         return $this->hasOne(User::class, ['email' => 'to_address']);
     }
 
-    public static function getMessageTypes()
+    public static function getMessageTypes(): array
     {
-        return [
-            self::MESSAGE_TYPE_INVITE,
-            self::MESSAGE_TYPE_MFA_RATE_LIMIT,
-            self::MESSAGE_TYPE_PASSWORD_CHANGED,
-            self::MESSAGE_TYPE_WELCOME,
-            self::MESSAGE_TYPE_GET_BACKUP_CODES,
-            self::MESSAGE_TYPE_REFRESH_BACKUP_CODES,
-            self::MESSAGE_TYPE_LOST_SECURITY_KEY,
-            self::MESSAGE_TYPE_MFA_OPTION_ADDED,
-            self::MESSAGE_TYPE_MFA_OPTION_REMOVED,
-            self::MESSAGE_TYPE_MFA_ENABLED,
-            self::MESSAGE_TYPE_MFA_DISABLED,
-            self::MESSAGE_TYPE_METHOD_VERIFY,
-            self::MESSAGE_TYPE_METHOD_REMINDER,
-            self::MESSAGE_TYPE_METHOD_PURGED,
-            self::MESSAGE_TYPE_MFA_MANAGER,
-            self::MESSAGE_TYPE_MFA_MANAGER_HELP,
-            self::MESSAGE_TYPE_PASSWORD_EXPIRING,
-            self::MESSAGE_TYPE_PASSWORD_EXPIRED,
-            self::MESSAGE_TYPE_PASSWORD_PWNED,
-        ];
+        $reflectionClass = new ReflectionClass(__CLASS__);
+        $messageTypes = [];
+        foreach ($reflectionClass->getConstants() as $name => $value) {
+            if (str_starts_with($name, 'MESSAGE_TYPE_')) {
+                $messageTypes[] = $value;
+            }
+        }
+        return $messageTypes;
     }
 
     public static function logMessage(string $messageType, string $toAddress)

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -49,16 +49,6 @@ class EmailLog extends EmailLogBase
         ]);
     }
 
-    /**
-     * Gets query for [[User]].
-     *
-     * @return \yii\db\ActiveQuery
-     */
-    public function getUser()
-    {
-        return $this->hasOne(User::class, ['email' => 'to_address']);
-    }
-
     public static function getMessageTypes(): array
     {
         $reflectionClass = new ReflectionClass(__CLASS__);
@@ -69,6 +59,16 @@ class EmailLog extends EmailLogBase
             }
         }
         return $messageTypes;
+    }
+
+    /**
+     * Gets query for [[User]].
+     *
+     * @return \yii\db\ActiveQuery
+     */
+    public function getUser()
+    {
+        return $this->hasOne(User::class, ['email' => 'to_address']);
     }
 
     public static function logMessage(string $messageType, string $toAddress)

--- a/application/common/models/EmailLogBase.php
+++ b/application/common/models/EmailLogBase.php
@@ -11,6 +11,8 @@ use Yii;
  * @property string|null $message_type
  * @property string $sent_utc
  * @property string $to_address
+ *
+ * @property User $toAddress
  */
 class EmailLogBase extends \yii\db\ActiveRecord
 {
@@ -32,6 +34,7 @@ class EmailLogBase extends \yii\db\ActiveRecord
             [['sent_utc'], 'required'],
             [['sent_utc'], 'safe'],
             [['to_address'], 'string', 'max' => 255],
+            [['to_address'], 'exist', 'skipOnError' => true, 'targetClass' => User::class, 'targetAttribute' => ['to_address' => 'email']],
         ];
     }
 
@@ -46,5 +49,15 @@ class EmailLogBase extends \yii\db\ActiveRecord
             'sent_utc' => Yii::t('app', 'Sent Utc'),
             'to_address' => Yii::t('app', 'To Address'),
         ];
+    }
+
+    /**
+     * Gets query for [[ToAddress]].
+     *
+     * @return \yii\db\ActiveQuery
+     */
+    public function getToAddress()
+    {
+        return $this->hasOne(User::class, ['email' => 'to_address']);
     }
 }

--- a/application/common/models/EmailLogBase.php
+++ b/application/common/models/EmailLogBase.php
@@ -8,11 +8,9 @@ use Yii;
  * This is the model class for table "email_log".
  *
  * @property int $id
- * @property int $user_id
  * @property string|null $message_type
  * @property string $sent_utc
- *
- * @property User $user
+ * @property string $to_address
  */
 class EmailLogBase extends \yii\db\ActiveRecord
 {
@@ -30,11 +28,10 @@ class EmailLogBase extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['user_id', 'sent_utc'], 'required'],
-            [['user_id'], 'integer'],
             [['message_type'], 'string'],
+            [['sent_utc'], 'required'],
             [['sent_utc'], 'safe'],
-            [['user_id'], 'exist', 'skipOnError' => true, 'targetClass' => User::class, 'targetAttribute' => ['user_id' => 'id']],
+            [['to_address'], 'string', 'max' => 255],
         ];
     }
 
@@ -45,19 +42,9 @@ class EmailLogBase extends \yii\db\ActiveRecord
     {
         return [
             'id' => Yii::t('app', 'ID'),
-            'user_id' => Yii::t('app', 'User ID'),
             'message_type' => Yii::t('app', 'Message Type'),
             'sent_utc' => Yii::t('app', 'Sent Utc'),
+            'to_address' => Yii::t('app', 'To Address'),
         ];
-    }
-
-    /**
-     * Gets query for [[User]].
-     *
-     * @return \yii\db\ActiveQuery
-     */
-    public function getUser()
-    {
-        return $this->hasOne(User::class, ['id' => 'user_id']);
     }
 }

--- a/application/common/models/EmailLogBase.php
+++ b/application/common/models/EmailLogBase.php
@@ -11,8 +11,6 @@ use Yii;
  * @property string|null $message_type
  * @property string $sent_utc
  * @property string $to_address
- *
- * @property User $toAddress
  */
 class EmailLogBase extends \yii\db\ActiveRecord
 {
@@ -34,7 +32,6 @@ class EmailLogBase extends \yii\db\ActiveRecord
             [['sent_utc'], 'required'],
             [['sent_utc'], 'safe'],
             [['to_address'], 'string', 'max' => 255],
-            [['to_address'], 'exist', 'skipOnError' => true, 'targetClass' => User::class, 'targetAttribute' => ['to_address' => 'email']],
         ];
     }
 
@@ -49,15 +46,5 @@ class EmailLogBase extends \yii\db\ActiveRecord
             'sent_utc' => Yii::t('app', 'Sent Utc'),
             'to_address' => Yii::t('app', 'To Address'),
         ];
-    }
-
-    /**
-     * Gets query for [[ToAddress]].
-     *
-     * @return \yii\db\ActiveQuery
-     */
-    public function getToAddress()
-    {
-        return $this->hasOne(User::class, ['email' => 'to_address']);
     }
 }

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -20,6 +20,9 @@ use yii\db\conditions\LikeCondition;
 use yii\db\conditions\OrCondition;
 use yii\helpers\ArrayHelper;
 
+/**
+ * @property EmailLog[] $emailLogs
+ */
 class User extends UserBase
 {
     public const SCENARIO_NEW_USER        = 'new_user';
@@ -1276,6 +1279,16 @@ class User extends UserBase
     public function getEmailAddress(): string
     {
         return $this->email ?? $this->personal_email ?? '';
+    }
+
+    /**
+     * Gets query for [[EmailLogs]].
+     *
+     * @return \yii\db\ActiveQuery
+     */
+    public function getEmailLogs()
+    {
+        return $this->hasMany(EmailLog::class, ['to_address' => 'email']);
     }
 
     /**

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -139,7 +139,7 @@ class User extends UserBase
                     'status' => 'error',
                     'error' => $emailLog->getFirstErrors(),
                     'email log id' => $emailLog->id,
-                    'user_id' => $emailLog->user_id,
+                    'user_id' => $this->id,
                 ]);
                 return false;
             }

--- a/application/common/models/UserBase.php
+++ b/application/common/models/UserBase.php
@@ -35,7 +35,6 @@ use Yii;
  * @property string|null $deactivated_utc
  *
  * @property Password $currentPassword
- * @property EmailLog[] $emailLogs
  * @property Invite[] $invites
  * @property Method[] $methods
  * @property Mfa[] $mfas
@@ -112,16 +111,6 @@ class UserBase extends \yii\db\ActiveRecord
     public function getCurrentPassword()
     {
         return $this->hasOne(Password::class, ['id' => 'current_password_id']);
-    }
-
-    /**
-     * Gets query for [[EmailLogs]].
-     *
-     * @return \yii\db\ActiveQuery
-     */
-    public function getEmailLogs()
-    {
-        return $this->hasMany(EmailLog::class, ['user_id' => 'id']);
     }
 
     /**

--- a/application/common/models/UserBase.php
+++ b/application/common/models/UserBase.php
@@ -35,7 +35,6 @@ use Yii;
  * @property string|null $deactivated_utc
  *
  * @property Password $currentPassword
- * @property EmailLog[] $emailLogs
  * @property Invite[] $invites
  * @property Method[] $methods
  * @property Mfa[] $mfas
@@ -112,16 +111,6 @@ class UserBase extends \yii\db\ActiveRecord
     public function getCurrentPassword()
     {
         return $this->hasOne(Password::class, ['id' => 'current_password_id']);
-    }
-
-    /**
-     * Gets query for [[EmailLogs]].
-     *
-     * @return \yii\db\ActiveQuery
-     */
-    public function getEmailLogs()
-    {
-        return $this->hasMany(EmailLog::class, ['to_address' => 'email']);
     }
 
     /**

--- a/application/common/models/UserBase.php
+++ b/application/common/models/UserBase.php
@@ -35,6 +35,7 @@ use Yii;
  * @property string|null $deactivated_utc
  *
  * @property Password $currentPassword
+ * @property EmailLog[] $emailLogs
  * @property Invite[] $invites
  * @property Method[] $methods
  * @property Mfa[] $mfas
@@ -111,6 +112,16 @@ class UserBase extends \yii\db\ActiveRecord
     public function getCurrentPassword()
     {
         return $this->hasOne(Password::class, ['id' => 'current_password_id']);
+    }
+
+    /**
+     * Gets query for [[EmailLogs]].
+     *
+     * @return \yii\db\ActiveQuery
+     */
+    public function getEmailLogs()
+    {
+        return $this->hasMany(EmailLog::class, ['to_address' => 'email']);
     }
 
     /**

--- a/application/console/migrations/m241029_200547_add_email_log_message_types.php
+++ b/application/console/migrations/m241029_200547_add_email_log_message_types.php
@@ -1,0 +1,27 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m241029_200547_add_email_log_message_types
+ */
+class m241029_200547_add_email_log_message_types extends Migration
+{
+    public function safeUp()
+    {
+        $this->alterColumn(
+            '{{email_log}}',
+            'message_type',
+            "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes','refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed','mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help','method-reminder','method-purged','password-expiring','password-expired','password-pwned','ext-group-sync-errors','abandoned-users') null"
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->alterColumn(
+            '{{email_log}}',
+            'message_type',
+            "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes','refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed','mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help','method-reminder','method-purged','password-expiring','password-expired','password-pwned') null"
+        );
+    }
+}

--- a/application/console/migrations/m241029_202830_refactor_email_log_to_use_address.php
+++ b/application/console/migrations/m241029_202830_refactor_email_log_to_use_address.php
@@ -1,0 +1,37 @@
+<?php
+
+use yii\db\Migration;
+use yii\db\Query;
+
+/**
+ * Class m241029_202830_refactor_email_log_to_use_address
+ */
+class m241029_202830_refactor_email_log_to_use_address extends Migration
+{
+    public function safeUp()
+    {
+        // Add the `to_address` column.
+        $this->addColumn(
+            '{{email_log}}',
+            'to_address',
+            $this->string()->notNull()->defaultValue('')
+        );
+
+        // Populate the `to_address` column for existing records.
+        $this->execute(
+        'UPDATE `email_log`, `user`
+             SET `email_log`.`to_address` = `user`.`email`
+             WHERE `email_log`.`user_id` = `user`.`id`'
+        );
+
+        // Remove the `user_id` column.
+        $this->dropForeignKey('fk_user_id', '{{email_log}}');
+        $this->dropColumn('{{email_log}}', 'user_id');
+    }
+
+    public function safeDown()
+    {
+        echo "m241029_202830_refactor_email_log_to_use_address cannot be reverted.\n";
+        return false;
+    }
+}

--- a/application/console/migrations/m241029_202830_refactor_email_log_to_use_address.php
+++ b/application/console/migrations/m241029_202830_refactor_email_log_to_use_address.php
@@ -24,17 +24,6 @@ class m241029_202830_refactor_email_log_to_use_address extends Migration
              WHERE `email_log`.`user_id` = `user`.`id`'
         );
 
-        // Add a foreign key on `to_address`.
-        $this->addForeignKey(
-            'fk_to_address',
-            '{{email_log}}',
-            'to_address',
-            '{{user}}',
-            'email',
-            'NO ACTION',
-            'NO ACTION'
-        );
-
         // Remove the `user_id` column.
         $this->dropForeignKey('fk_user_id', '{{email_log}}');
         $this->dropColumn('{{email_log}}', 'user_id');

--- a/application/console/migrations/m241029_202830_refactor_email_log_to_use_address.php
+++ b/application/console/migrations/m241029_202830_refactor_email_log_to_use_address.php
@@ -18,11 +18,11 @@ class m241029_202830_refactor_email_log_to_use_address extends Migration
         );
 
         // Populate the `to_address` column for existing records.
-        $this->execute(
-        'UPDATE `email_log`, `user`
-             SET `email_log`.`to_address` = `user`.`email`
-             WHERE `email_log`.`user_id` = `user`.`id`'
-        );
+        $this->execute('
+            UPDATE `email_log`, `user`
+            SET `email_log`.`to_address` = `user`.`email`
+            WHERE `email_log`.`user_id` = `user`.`id`
+        ');
 
         // Remove the `user_id` column.
         $this->dropForeignKey('fk_user_id', '{{email_log}}');

--- a/application/console/migrations/m241029_202830_refactor_email_log_to_use_address.php
+++ b/application/console/migrations/m241029_202830_refactor_email_log_to_use_address.php
@@ -24,6 +24,17 @@ class m241029_202830_refactor_email_log_to_use_address extends Migration
              WHERE `email_log`.`user_id` = `user`.`id`'
         );
 
+        // Add a foreign key on `to_address`.
+        $this->addForeignKey(
+            'fk_to_address',
+            '{{email_log}}',
+            'to_address',
+            '{{user}}',
+            'email',
+            'NO ACTION',
+            'NO ACTION'
+        );
+
         // Remove the `user_id` column.
         $this->dropForeignKey('fk_user_id', '{{email_log}}');
         $this->dropColumn('{{email_log}}', 'user_id');

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1255,16 +1255,8 @@ class EmailContext extends YiiContext
      */
     public function theAbandonedUserEmailHasOrHasNotBeenSent($hasOrHasNot)
     {
-        $emails = $this->fakeEmailer->getFakeEmailsSent();
-        $hasBeenSent = false;
-
-        foreach ($emails as $email) {
-            $subject = $email[Emailer::PROP_SUBJECT];
-            if ($this->fakeEmailer->isSubjectForMessageType($subject, 'abandoned-users')) {
-                $hasBeenSent = true;
-                break;
-            }
-        }
+        $numberSent = $this->countEmailsSent(EmailLog::MESSAGE_TYPE_ABANDONED_USERS);
+        $hasBeenSent = ($numberSent > 0);
 
         if ($hasOrHasNot === 'has') {
             Assert::true($hasBeenSent);
@@ -1292,16 +1284,22 @@ class EmailContext extends YiiContext
      */
     public function theAbandonedUserEmailHasBeenSentTime($expectedCount)
     {
+        $actualCount = $this->countEmailsSent(EmailLog::MESSAGE_TYPE_ABANDONED_USERS);
+
+        Assert::eq($actualCount, $expectedCount);
+    }
+
+    protected function countEmailsSent(string $messageType): int
+    {
         $emails = $this->fakeEmailer->getFakeEmailsSent();
         $actualCount = 0;
 
         foreach ($emails as $email) {
             $subject = $email[Emailer::PROP_SUBJECT];
-            if ($this->fakeEmailer->isSubjectForMessageType($subject, 'abandoned-users')) {
+            if ($this->fakeEmailer->isSubjectForMessageType($subject, $messageType)) {
                 $actualCount++;
             }
         }
-
-        Assert::eq($actualCount, $expectedCount);
+        return $actualCount;
     }
 }

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -955,7 +955,10 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheFirstUserHasReceivedALostSecurityKeyEmail()
     {
-        Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser->id, EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY));
+        Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser->id,
+            EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY
+        ));
     }
 
     /**
@@ -963,7 +966,10 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheSecondUserHasReceivedAGetBackupCodesEmail()
     {
-        Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser2->id, EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES));
+        Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser2->id,
+            EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES
+        ));
     }
 
     /**
@@ -971,7 +977,10 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheFirstUserHasNotReceivedALostSecurityKeyEmail()
     {
-        Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser->id, EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY));
+        Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser->id,
+            EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY
+        ));
     }
 
     /**
@@ -979,7 +988,10 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheSecondUserHasNotReceivedAGetBackupCodesEmail()
     {
-        Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser2->id, EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES));
+        Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser2->id,
+            EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES
+        ));
     }
 
     /**

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -783,7 +783,10 @@ class EmailContext extends YiiContext
     public function iCheckIfAGetBackupCodesEmailHasBeenSentRecently()
     {
         $messageType = EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES;
-        $this->getBackupCodesEmailHasBeenSent = $this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser, $messageType);
+        $this->getBackupCodesEmailHasBeenSent = $this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser->id,
+            $messageType
+        );
     }
 
     /**

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -90,7 +90,7 @@ class EmailContext extends YiiContext
     {
         $emailLogs = EmailLog::findAll([
             'message_type' => $messageType,
-            'user_id' => $this->tempUser->id,
+            'to_address' => $this->tempUser->email,
         ]);
         Assert::isEmpty($emailLogs, sprintf(
             'Expected NOT to find any email logs for a(n) %s email to User %s, '
@@ -217,13 +217,13 @@ class EmailContext extends YiiContext
     {
         $emailLogs = EmailLog::findAll([
             'message_type' => $messageType,
-            'user_id' => $this->tempUser->id,
+            'to_address' => $this->tempUser->email,
         ]);
         Assert::count($emailLogs, 1, sprintf(
-            'Expected to find an email log for a(n) %s email to User %s, but '
+            'Expected to find an email log for a(n) %s email to %s, but '
                 . 'instead found %s of them.',
             var_export($messageType, true),
-            var_export($this->tempUser->id, true),
+            var_export($this->tempUser->email, true),
             count($emailLogs)
         ));
         Assert::true(
@@ -331,7 +331,7 @@ class EmailContext extends YiiContext
         }
 
         $emailLog = new EmailLog([
-            'user_id' => $this->tempUser->id,
+            'to_address' => $this->tempUser->email,
             'message_type' => $messageType,
         ]);
 
@@ -351,7 +351,7 @@ class EmailContext extends YiiContext
     public function anEmailHasBeenSentToThatUser(string $messageType)
     {
         $emailLog = new EmailLog([
-            'user_id' => $this->tempUser->id,
+            'to_address' => $this->tempUser->email,
             'message_type' => $messageType,
         ]);
 
@@ -363,7 +363,7 @@ class EmailContext extends YiiContext
      */
     public function anEmailHasNotBeenSentToThatUser(string $messageType)
     {
-        EmailLog::deleteAll(['user_id' => $this->tempUser->id, 'message_type' => $messageType]);
+        EmailLog::deleteAll(['to_address' => $this->tempUser->email, 'message_type' => $messageType]);
     }
 
     /**
@@ -783,7 +783,7 @@ class EmailContext extends YiiContext
     public function iCheckIfAGetBackupCodesEmailHasBeenSentRecently()
     {
         $messageType = EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES;
-        $this->getBackupCodesEmailHasBeenSent = $this->fakeEmailer->hasReceivedMessageRecently($this->tempUser, $messageType);
+        $this->getBackupCodesEmailHasBeenSent = $this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser, $messageType);
     }
 
     /**
@@ -952,7 +952,7 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheFirstUserHasReceivedALostSecurityKeyEmail()
     {
-        Assert::true($this->fakeEmailer->hasReceivedMessageRecently($this->tempUser->id, EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY));
+        Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser->id, EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY));
     }
 
     /**
@@ -960,7 +960,7 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheSecondUserHasReceivedAGetBackupCodesEmail()
     {
-        Assert::true($this->fakeEmailer->hasReceivedMessageRecently($this->tempUser2->id, EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES));
+        Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser2->id, EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES));
     }
 
     /**
@@ -968,7 +968,7 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheFirstUserHasNotReceivedALostSecurityKeyEmail()
     {
-        Assert::false($this->fakeEmailer->hasReceivedMessageRecently($this->tempUser->id, EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY));
+        Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser->id, EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY));
     }
 
     /**
@@ -976,7 +976,7 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheSecondUserHasNotReceivedAGetBackupCodesEmail()
     {
-        Assert::false($this->fakeEmailer->hasReceivedMessageRecently($this->tempUser2->id, EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES));
+        Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently($this->tempUser2->id, EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES));
     }
 
     /**
@@ -1108,7 +1108,7 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatARecoveryMethodReminderHasNotBeenSent($hasOrHasNot)
     {
-        $hasBeenSent = $this->fakeEmailer->hasReceivedMessageRecently(
+        $hasBeenSent = $this->fakeEmailer->hasUserReceivedMessageRecently(
             $this->tempUser->id,
             EmailLog::MESSAGE_TYPE_METHOD_REMINDER
         );

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1259,7 +1259,8 @@ class EmailContext extends YiiContext
         $hasBeenSent = false;
 
         foreach ($emails as $email) {
-            if ($email[Emailer::PROP_SUBJECT] === $this->fakeEmailer->subjectForAbandonedUsers) {
+            $subject = $email[Emailer::PROP_SUBJECT];
+            if ($this->fakeEmailer->isSubjectForMessageType($subject, 'abandoned-users')) {
                 $hasBeenSent = true;
                 break;
             }
@@ -1295,7 +1296,8 @@ class EmailContext extends YiiContext
         $actualCount = 0;
 
         foreach ($emails as $email) {
-            if ($email[Emailer::PROP_SUBJECT] === $this->fakeEmailer->subjectForAbandonedUsers) {
+            $subject = $email[Emailer::PROP_SUBJECT];
+            if ($this->fakeEmailer->isSubjectForMessageType($subject, 'abandoned-users')) {
                 $actualCount++;
             }
         }

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1228,7 +1228,7 @@ class EmailContext extends YiiContext
     }
 
     /**
-     * @When I send abandoned user email
+     * @When I send abandoned user email (again)
      */
     public function iSendAbandonedUserEmail()
     {
@@ -1269,5 +1269,22 @@ class EmailContext extends YiiContext
         Method::deleteAll();
         User::deleteAll();
         $this->fakeEmailer->forgetFakeEmailsSent();
+    }
+
+    /**
+     * @Then the abandoned user email has been sent :expectedNumber time(s)
+     */
+    public function theAbandonedUserEmailHasBeenSentTime($expectedCount)
+    {
+        $emails = $this->fakeEmailer->getFakeEmailsSent();
+        $actualCount = 0;
+
+        foreach ($emails as $email) {
+            if ($email[Emailer::PROP_SUBJECT] === $this->fakeEmailer->subjectForAbandonedUsers) {
+                $actualCount++;
+            }
+        }
+
+        Assert::eq($actualCount, $expectedCount);
     }
 }

--- a/application/features/bootstrap/fakes/FakeEmailer.php
+++ b/application/features/bootstrap/fakes/FakeEmailer.php
@@ -64,7 +64,7 @@ class FakeEmailer extends Emailer
         return $this->getEmailServiceClient()->emailsSent;
     }
 
-    public function isSubjectForMessageType(string $subject, string $messageType, ?User $user)
+    public function isSubjectForMessageType(string $subject, string $messageType, ?User $user = null)
     {
         $dataForEmail = ArrayHelper::merge(
             $user ? $user->getAttributesForEmail() : [],

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -423,7 +423,7 @@ Feature: Email
       | is        | a           | 5 months  | has NOT     |
       | is        | a           | 7 months  | has         |
 
-  Scenario: Not sending HR notification emails to frequently
+  Scenario: Not sending HR notification emails too frequently
     Given hr notification email is set
       And the database has been purged
       And a user already exists

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -404,7 +404,6 @@ Feature: Email
       | to send      | -1     | has          | should NOT     |
       | NOT to send  | -1     | has NOT      | should NOT     |
 
-
   Scenario Outline: HR notification users
     Given hr notification email <isOrIsNot> set
       And the database has been purged
@@ -423,3 +422,12 @@ Feature: Email
       | is        | an inactive | 7 months  | has NOT     |
       | is        | a           | 5 months  | has NOT     |
       | is        | a           | 7 months  | has         |
+
+  Scenario: Not sending HR notification emails to frequently
+    Given hr notification email is set
+      And the database has been purged
+      And a user already exists
+      And the user has not logged in for "7 months"
+      And I send abandoned user email
+    When I send abandoned user email again
+    Then the abandoned user email has been sent 1 time


### PR DESCRIPTION
[IDP-1266](https://itse.youtrack.cloud/issue/IDP-1266) Run the external-groups sync every 12 hours

* This is pre-work, to enable us to avoid sending both the abandoned-users email and the external-groups sync-errors email too frequently.
* Another PR will follow that "rate limits" the external-groups sync-errors email.
* That, in turn, will allow us to run the cron as frequently as we want (e.g. every 12 hours).

---

### Changed (non-breaking)
- Switch `EmailLog` from tracking by `user_id` to by `to_address`
- Log all emails sent, not just those to Users in our database

### Fixed
- Add 'ext-group-sync-errors' and 'abandoned-users' EmailLog message types
- Fix argument within `iCheckIfAGetBackupCodesEmailHasBeenSentRecently()`
  * It was passing a `User` when it should have been passing the User ID.
- Use reflection to avoid need to maintain duplicate list of message types
- Avoid sending abandoned-users email to HR too frequently

---

### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [x] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
