### PR TITLE
[IDP-1266, part 1] Track emails to non-users

### DIFF
--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -313,6 +313,7 @@ class Emailer extends Component
             EmailLog::MESSAGE_TYPE_MFA_RATE_LIMIT => $this->subjectForMfaRateLimit,
             EmailLog::MESSAGE_TYPE_PASSWORD_CHANGED => $this->subjectForPasswordChanged,
             EmailLog::MESSAGE_TYPE_WELCOME => $this->subjectForWelcome,
+            EmailLog::MESSAGE_TYPE_ABANDONED_USERS => $this->subjectForAbandonedUsers,
             EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS => $this->subjectForExtGroupSyncErrors,
             EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES => $this->subjectForGetBackupCodes,
             EmailLog::MESSAGE_TYPE_REFRESH_BACKUP_CODES => $this->subjectForRefreshBackupCodes,
@@ -381,6 +382,13 @@ class Emailer extends Component
         $ccAddress = $data['ccAddress'] ?? '';
         $bccAddress = $data['bccAddress'] ?? '';
         $subject = $this->getSubjectForMessage($messageType, $dataForEmail);
+
+        if (empty($subject)) {
+            \Yii::error(sprintf(
+                'No subject known for %s email messages.',
+                $messageType
+            ));
+        }
 
         $this->email($toAddress, $subject, $htmlBody, strip_tags($htmlBody), $ccAddress, $bccAddress, $delaySeconds);
 

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -194,6 +194,11 @@ class Emailer extends Component
     /**
      * Use the email service to send an email.
      *
+     * WARNING:
+     * You probably shouldn't be calling this directly. Instead, call the
+     * `sendMessageTo()` method so that the sending of this email will be
+     * logged.
+     *
      * @param string $toAddress The recipient's email address.
      * @param string $subject The subject.
      * @param string $htmlBody The email body (as HTML).
@@ -811,9 +816,14 @@ class Emailer extends Component
             $dataForEmail['users'] = User::getAbandonedUsers();
 
             if (!empty($dataForEmail['users'])) {
-                $htmlBody = \Yii::$app->view->render('@common/mail/abandoned-users.html.php', $dataForEmail);
-
-                $this->email($this->hrNotificationsEmail, $this->subjectForAbandonedUsers, $htmlBody, strip_tags($htmlBody));
+                $this->sendMessageTo(
+                    'abandoned-users',
+                    null,
+                    ArrayHelper::merge(
+                        $dataForEmail,
+                        ['toAddress' => $this->hrNotificationsEmail]
+                    )
+                );
             }
         }
     }

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -444,6 +444,26 @@ class Emailer extends Component
     }
 
     /**
+     * Whether we should send an abandoned-users message to HR.
+     *
+     * @return bool
+     */
+    public function shouldSendAbandonedUsersMessage(): bool
+    {
+        if (empty($this->hrNotificationsEmail)) {
+            return false;
+        }
+
+        $haveSentAbandonedUsersEmailRecently = $this->hasAddressReceivedMessageRecently(
+            $this->hrNotificationsEmail,
+            EmailLog::MESSAGE_TYPE_ABANDONED_USERS
+        );
+
+        return !$haveSentAbandonedUsersEmailRecently;
+    }
+
+
+    /**
      * Whether we should send an invite message to the given User.
      *
      * @param User $user The User in question.
@@ -816,14 +836,16 @@ class Emailer extends Component
             $dataForEmail['users'] = User::getAbandonedUsers();
 
             if (!empty($dataForEmail['users'])) {
-                $this->sendMessageTo(
-                    'abandoned-users',
-                    null,
-                    ArrayHelper::merge(
-                        $dataForEmail,
-                        ['toAddress' => $this->hrNotificationsEmail]
-                    )
-                );
+                if ($this->shouldSendAbandonedUsersMessage()) {
+                    $this->sendMessageTo(
+                        EmailLog::MESSAGE_TYPE_ABANDONED_USERS,
+                        null,
+                        ArrayHelper::merge(
+                            $dataForEmail,
+                            ['toAddress' => $this->hrNotificationsEmail]
+                        )
+                    );
+                }
             }
         }
     }

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -341,7 +341,7 @@ class Emailer extends Component
     }
 
     /**
-     * Send the specified type of message to the given User.
+     * Send the specified type of message to the given User (or non-User address).
      *
      * @param string $messageType The message type. Must be one of the
      *     EmailLog::MESSAGE_TYPE_* values.
@@ -385,7 +385,9 @@ class Emailer extends Component
         $this->email($toAddress, $subject, $htmlBody, strip_tags($htmlBody), $ccAddress, $bccAddress, $delaySeconds);
 
         if ($user !== null) {
-            EmailLog::logMessage($messageType, $user->id);
+            EmailLog::logMessageToUser($messageType, $user->id);
+        } else {
+            EmailLog::logMessageToNonUser($messageType, $toAddress);
         }
     }
 

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -425,14 +425,13 @@ class Emailer extends Component
     }
 
     /**
-     *
      * Whether the user has already been sent this type of email in the last X days
      *
      * @param int $userId
      * @param string $messageType
      * @return bool
      */
-    public function hasUserReceivedMessageRecently($userId, string $messageType)
+    public function hasUserReceivedMessageRecently(int $userId, string $messageType): bool
     {
         $latestEmail = EmailLog::find()->where(['user_id' => $userId, 'message_type' => $messageType])
             ->orderBy('sent_utc DESC')->one();
@@ -446,11 +445,11 @@ class Emailer extends Component
     /**
      * Whether the non-user address has already been sent this type of email in the last X days
      *
-     * @param int $userId
+     * @param string $emailAddress
      * @param string $messageType
      * @return bool
      */
-    public function hasNonUserReceivedMessageRecently(string $emailAddress, string $messageType)
+    public function hasNonUserReceivedMessageRecently(string $emailAddress, string $messageType): bool
     {
         $latestEmail = EmailLog::find()->where([
             'message_type' => $messageType,

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -261,6 +261,13 @@ class Emailer extends Component
     {
         $subject = $this->subjects[$messageType] ?? '';
 
+        if (empty($subject)) {
+            \Yii::error(sprintf(
+                'No subject known for %s email messages.',
+                $messageType
+            ));
+        }
+
         foreach ($data as $key => $value) {
             if (is_scalar($value)) {
                 $subject = str_replace('{' . $key . '}', $value, $subject);
@@ -382,13 +389,6 @@ class Emailer extends Component
         $ccAddress = $data['ccAddress'] ?? '';
         $bccAddress = $data['bccAddress'] ?? '';
         $subject = $this->getSubjectForMessage($messageType, $dataForEmail);
-
-        if (empty($subject)) {
-            \Yii::error(sprintf(
-                'No subject known for %s email messages.',
-                $messageType
-            ));
-        }
 
         $this->email($toAddress, $subject, $htmlBody, strip_tags($htmlBody), $ccAddress, $bccAddress, $delaySeconds);
 

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -70,7 +70,7 @@ class EmailLog extends EmailLogBase
         ];
     }
 
-    public static function logMessage(string $messageType, $userId)
+    public static function logMessageToUser(string $messageType, $userId)
     {
         $emailLog = new EmailLog([
             'user_id' => $userId,
@@ -86,6 +86,25 @@ class EmailLog extends EmailLogBase
             );
             \Yii::warning($errorMessage);
             throw new \Exception($errorMessage, 1502398588);
+        }
+    }
+
+    public static function logMessageToNonUser(string $messageType, string $emailAddress)
+    {
+        $emailLog = new EmailLog([
+            'non_user_address' => $emailAddress,
+            'message_type' => $messageType,
+        ]);
+
+        if (!$emailLog->save()) {
+            $errorMessage = sprintf(
+                'Failed to log %s email to %s: %s',
+                var_export($messageType, true),
+                var_export($emailAddress, true),
+                \json_encode($emailLog->getFirstErrors(), JSON_PRETTY_PRINT)
+            );
+            \Yii::warning($errorMessage);
+            throw new \Exception($errorMessage, 1730909932);
         }
     }
 

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -41,6 +41,7 @@ class EmailLog extends EmailLogBase
     {
         return ArrayHelper::merge(parent::attributeLabels(), [
             'sent_utc' => Yii::t('app', 'Sent (UTC)'),
+            'non_user_address' => Yii::t('app', 'Non-User Address'),
         ]);
     }
 

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -17,6 +17,7 @@ class EmailLog extends EmailLogBase
     public const MESSAGE_TYPE_MFA_RATE_LIMIT = 'mfa-rate-limit';
     public const MESSAGE_TYPE_PASSWORD_CHANGED = 'password-changed';
     public const MESSAGE_TYPE_WELCOME = 'welcome';
+    public const MESSAGE_TYPE_ABANDONED_USERS = 'abandoned-users';
     public const MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS = 'ext-group-sync-errors';
     public const MESSAGE_TYPE_GET_BACKUP_CODES = 'get-backup-codes';
     public const MESSAGE_TYPE_REFRESH_BACKUP_CODES = 'refresh-backup-codes';

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -3,6 +3,7 @@
 namespace common\models;
 
 use common\helpers\MySqlDateTime;
+use ReflectionClass;
 use Yii;
 use yii\helpers\ArrayHelper;
 
@@ -48,27 +49,14 @@ class EmailLog extends EmailLogBase
 
     public static function getMessageTypes()
     {
-        return [
-            self::MESSAGE_TYPE_INVITE,
-            self::MESSAGE_TYPE_MFA_RATE_LIMIT,
-            self::MESSAGE_TYPE_PASSWORD_CHANGED,
-            self::MESSAGE_TYPE_WELCOME,
-            self::MESSAGE_TYPE_GET_BACKUP_CODES,
-            self::MESSAGE_TYPE_REFRESH_BACKUP_CODES,
-            self::MESSAGE_TYPE_LOST_SECURITY_KEY,
-            self::MESSAGE_TYPE_MFA_OPTION_ADDED,
-            self::MESSAGE_TYPE_MFA_OPTION_REMOVED,
-            self::MESSAGE_TYPE_MFA_ENABLED,
-            self::MESSAGE_TYPE_MFA_DISABLED,
-            self::MESSAGE_TYPE_METHOD_VERIFY,
-            self::MESSAGE_TYPE_METHOD_REMINDER,
-            self::MESSAGE_TYPE_METHOD_PURGED,
-            self::MESSAGE_TYPE_MFA_MANAGER,
-            self::MESSAGE_TYPE_MFA_MANAGER_HELP,
-            self::MESSAGE_TYPE_PASSWORD_EXPIRING,
-            self::MESSAGE_TYPE_PASSWORD_EXPIRED,
-            self::MESSAGE_TYPE_PASSWORD_PWNED,
-        ];
+        $reflectionClass = new ReflectionClass(__CLASS__);
+        $messageTypes = [];
+        foreach ($reflectionClass->getConstants() as $name => $value) {
+            if (str_starts_with($name, 'MESSAGE_TYPE_')) {
+                $messageTypes[] = $value;
+            }
+        }
+        return $messageTypes;
     }
 
     public static function logMessageToUser(string $messageType, $userId)

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -47,7 +47,7 @@ class EmailLog extends EmailLogBase
         ]);
     }
 
-    public static function getMessageTypes()
+    public static function getMessageTypes(): array
     {
         $reflectionClass = new ReflectionClass(__CLASS__);
         $messageTypes = [];

--- a/application/common/models/EmailLogBase.php
+++ b/application/common/models/EmailLogBase.php
@@ -8,9 +8,10 @@ use Yii;
  * This is the model class for table "email_log".
  *
  * @property int $id
- * @property int $user_id
+ * @property int|null $user_id
  * @property string|null $message_type
  * @property string $sent_utc
+ * @property string|null $non_user_address
  *
  * @property User $user
  */
@@ -30,10 +31,11 @@ class EmailLogBase extends \yii\db\ActiveRecord
     public function rules()
     {
         return [
-            [['user_id', 'sent_utc'], 'required'],
             [['user_id'], 'integer'],
             [['message_type'], 'string'],
+            [['sent_utc'], 'required'],
             [['sent_utc'], 'safe'],
+            [['non_user_address'], 'string', 'max' => 255],
             [['user_id'], 'exist', 'skipOnError' => true, 'targetClass' => User::class, 'targetAttribute' => ['user_id' => 'id']],
         ];
     }
@@ -48,6 +50,7 @@ class EmailLogBase extends \yii\db\ActiveRecord
             'user_id' => Yii::t('app', 'User ID'),
             'message_type' => Yii::t('app', 'Message Type'),
             'sent_utc' => Yii::t('app', 'Sent Utc'),
+            'non_user_address' => Yii::t('app', 'Non User Address'),
         ];
     }
 

--- a/application/console/migrations/m241029_200547_add_email_log_message_types.php
+++ b/application/console/migrations/m241029_200547_add_email_log_message_types.php
@@ -1,0 +1,27 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m241029_200547_add_email_log_message_types
+ */
+class m241029_200547_add_email_log_message_types extends Migration
+{
+    public function safeUp()
+    {
+        $this->alterColumn(
+            '{{email_log}}',
+            'message_type',
+            "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes','refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed','mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help','method-reminder','method-purged','password-expiring','password-expired','password-pwned','ext-group-sync-errors','abandoned-users') null"
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->alterColumn(
+            '{{email_log}}',
+            'message_type',
+            "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes','refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed','mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help','method-reminder','method-purged','password-expiring','password-expired','password-pwned') null"
+        );
+    }
+}

--- a/application/console/migrations/m241106_155829_enable_logging_non_user_emails.php
+++ b/application/console/migrations/m241106_155829_enable_logging_non_user_emails.php
@@ -1,0 +1,42 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m241106_155829_enable_logging_non_user_emails
+ */
+class m241106_155829_enable_logging_non_user_emails extends Migration
+{
+    public function safeUp()
+    {
+        $this->addColumn(
+            '{{email_log}}',
+            'non_user_address',
+            $this->string()->null()
+        );
+        $this->alterColumn(
+            '{{email_log}}',
+            'user_id',
+            $this->integer()->null()
+        );
+    }
+
+    public function safeDown()
+    {
+        $this->delete(
+            '{{email_log}}',
+            [
+                'user_id' => null,
+            ]
+        );
+        $this->alterColumn(
+            '{{email_log}}',
+            'user_id',
+            $this->integer()->notNull()
+        );
+        $this->dropColumn(
+            '{{email_log}}',
+            'non_user_address'
+        );
+    }
+}

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1255,21 +1255,28 @@ class EmailContext extends YiiContext
      */
     public function theAbandonedUserEmailHasOrHasNotBeenSent($hasOrHasNot)
     {
-        $emails = $this->fakeEmailer->getFakeEmailsSent();
-        $hasBeenSent = false;
-
-        foreach ($emails as $email) {
-            if ($email[Emailer::PROP_SUBJECT] === $this->fakeEmailer->subjectForAbandonedUsers) {
-                $hasBeenSent = true;
-                break;
-            }
-        }
+        $numberSent = $this->countEmailsSent(EmailLog::MESSAGE_TYPE_ABANDONED_USERS);
+        $hasBeenSent = ($numberSent > 0);
 
         if ($hasOrHasNot === 'has') {
             Assert::true($hasBeenSent);
         } else {
             Assert::false($hasBeenSent);
         }
+    }
+
+    protected function countEmailsSent(string $messageType): int
+    {
+        $emails = $this->fakeEmailer->getFakeEmailsSent();
+        $actualCount = 0;
+
+        foreach ($emails as $email) {
+            $subject = $email[Emailer::PROP_SUBJECT];
+            if ($this->fakeEmailer->isSubjectForMessageType($subject, $messageType)) {
+                $actualCount++;
+            }
+        }
+        return $actualCount;
     }
 
     /**

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -784,7 +784,7 @@ class EmailContext extends YiiContext
     {
         $messageType = EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES;
         $this->getBackupCodesEmailHasBeenSent = $this->fakeEmailer->hasUserReceivedMessageRecently(
-            $this->tempUser,
+            $this->tempUser->id,
             $messageType
         );
     }

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -783,7 +783,10 @@ class EmailContext extends YiiContext
     public function iCheckIfAGetBackupCodesEmailHasBeenSentRecently()
     {
         $messageType = EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES;
-        $this->getBackupCodesEmailHasBeenSent = $this->fakeEmailer->hasReceivedMessageRecently($this->tempUser, $messageType);
+        $this->getBackupCodesEmailHasBeenSent = $this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser,
+            $messageType
+        );
     }
 
     /**
@@ -952,7 +955,10 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheFirstUserHasReceivedALostSecurityKeyEmail()
     {
-        Assert::true($this->fakeEmailer->hasReceivedMessageRecently($this->tempUser->id, EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY));
+        Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser->id,
+            EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY
+        ));
     }
 
     /**
@@ -960,7 +966,10 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheSecondUserHasReceivedAGetBackupCodesEmail()
     {
-        Assert::true($this->fakeEmailer->hasReceivedMessageRecently($this->tempUser2->id, EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES));
+        Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser2->id,
+            EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES
+        ));
     }
 
     /**
@@ -968,7 +977,10 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheFirstUserHasNotReceivedALostSecurityKeyEmail()
     {
-        Assert::false($this->fakeEmailer->hasReceivedMessageRecently($this->tempUser->id, EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY));
+        Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser->id,
+            EmailLog::MESSAGE_TYPE_LOST_SECURITY_KEY
+        ));
     }
 
     /**
@@ -976,7 +988,10 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatTheSecondUserHasNotReceivedAGetBackupCodesEmail()
     {
-        Assert::false($this->fakeEmailer->hasReceivedMessageRecently($this->tempUser2->id, EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES));
+        Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently(
+            $this->tempUser2->id,
+            EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES
+        ));
     }
 
     /**
@@ -1108,7 +1123,7 @@ class EmailContext extends YiiContext
      */
     public function iSeeThatARecoveryMethodReminderHasNotBeenSent($hasOrHasNot)
     {
-        $hasBeenSent = $this->fakeEmailer->hasReceivedMessageRecently(
+        $hasBeenSent = $this->fakeEmailer->hasUserReceivedMessageRecently(
             $this->tempUser->id,
             EmailLog::MESSAGE_TYPE_METHOD_REMINDER
         );

--- a/application/features/bootstrap/fakes/FakeEmailer.php
+++ b/application/features/bootstrap/fakes/FakeEmailer.php
@@ -64,8 +64,11 @@ class FakeEmailer extends Emailer
         return $this->getEmailServiceClient()->emailsSent;
     }
 
-    public function isSubjectForMessageType(string $subject, string $messageType, ?User $user)
-    {
+    public function isSubjectForMessageType(
+        string $subject,
+        string $messageType,
+        ?User $user = null
+    ): bool {
         $dataForEmail = ArrayHelper::merge(
             $user ? $user->getAttributesForEmail() : [],
             $this->otherDataForEmails


### PR DESCRIPTION
[IDP-1266](https://itse.youtrack.cloud/issue/IDP-1266) Run the external-groups sync every 12 hours

(This is a refactor of the previous attempt, replacing PR #383.)

---

### Changed (non-breaking)
- Allow `email_log.user_id` to be null, and add `non_user_address` column

### Added
- Log emails sent to non-user addresses, too

### Fixed
- Add 'ext-group-sync-errors' and 'abandoned-users' EmailLog message types
- Fix argument within `iCheckIfAGetBackupCodesEmailHasBeenSentRecently()`
  * It was passing a `User` when it should have been passing the User ID.
- Use reflection to avoid need to maintain duplicate list of message types

---

### PR Checklist
- [ ] ~~Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)~~
- [ ] ~~Documentation (README, local.env.dist, api.raml, etc.)~~
- [x] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
