### PR TITLE
[IDP-1266, part 2] Rate limit both non user emails, add EmailLog validation

### DIFF
--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -122,6 +122,11 @@ class EmailLog extends EmailLogBase
                 'non_user_address',
                 'emptyIfUserIsSet',
             ],
+            [
+                'non_user_address',
+                'requiredIfUserIsEmpty',
+                'skipOnEmpty' => false,
+            ],
         ], parent::rules());
     }
 
@@ -132,6 +137,19 @@ class EmailLog extends EmailLogBase
                 $attribute,
                 sprintf(
                     'Only a user_id or a %s may be set, not both',
+                    $attribute
+                )
+            );
+        }
+    }
+
+    public function requiredIfUserIsEmpty($attribute)
+    {
+        if (empty($this->user_id) && empty($this[$attribute])) {
+            $this->addError(
+                $attribute,
+                sprintf(
+                    'Either a user_id or a %s must be set',
                     $attribute
                 )
             );

--- a/application/common/models/EmailLog.php
+++ b/application/common/models/EmailLog.php
@@ -118,6 +118,23 @@ class EmailLog extends EmailLogBase
                 'default',
                 'value' => MySqlDateTime::now(),
             ],
+            [
+                'non_user_address',
+                'emptyIfUserIsSet',
+            ],
         ], parent::rules());
+    }
+
+    public function emptyIfUserIsSet($attribute)
+    {
+        if (!empty($this->user_id) && !empty($this[$attribute])) {
+            $this->addError(
+                $attribute,
+                sprintf(
+                    'Only a user_id or a %s may be set, not both',
+                    $attribute
+                )
+            );
+        }
     }
 }

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -60,6 +60,8 @@ class EmailContext extends YiiContext
 
     private string $dummyExtGroupsAppPrefix = 'ext-dummy';
 
+    private ?EmailLog $tempEmailLog;
+
     public const METHOD_EMAIL_ADDRESS = 'method@example.com';
     public const MANAGER_EMAIL = 'manager@example.com';
 
@@ -1329,5 +1331,29 @@ class EmailContext extends YiiContext
             EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS
         );
         Assert::eq($actualCount, $expectedCount);
+    }
+
+    /**
+     * @When I try to log an email as sent to that User and to a non-user address
+     */
+    public function iTryToLogAnEmailAsSentToThatUserAndToANonUserAddress()
+    {
+        $this->tempEmailLog = new EmailLog([
+            'message_type' => EmailLog::MESSAGE_TYPE_ABANDONED_USERS,
+            'non_user_address' => 'dummy@example.com',
+            'user_id' => $this->tempUser->id,
+        ]);
+        $this->tempEmailLog->save();
+    }
+
+    /**
+     * @Then an email log validation error should have occurred
+     */
+    public function anEmailLogValidationErrorShouldHaveOccurred()
+    {
+        Assert::notEmpty(
+            $this->tempEmailLog->errors,
+            'No EmailLog validation errors were found'
+        );
     }
 }

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1356,4 +1356,15 @@ class EmailContext extends YiiContext
             'No EmailLog validation errors were found'
         );
     }
+
+    /**
+     * @When I try to log an email as sent to neither a User nor a non-user address
+     */
+    public function iTryToLogAnEmailAsSentToNeitherAUserNorANonUserAddress()
+    {
+        $this->tempEmailLog = new EmailLog([
+            'message_type' => EmailLog::MESSAGE_TYPE_ABANDONED_USERS,
+        ]);
+        $this->tempEmailLog->save();
+    }
 }

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1243,7 +1243,7 @@ class EmailContext extends YiiContext
     }
 
     /**
-     * @When I send abandoned user email
+     * @When I send abandoned user email (again)
      */
     public function iSendAbandonedUserEmail()
     {
@@ -1291,5 +1291,14 @@ class EmailContext extends YiiContext
         Method::deleteAll();
         User::deleteAll();
         $this->fakeEmailer->forgetFakeEmailsSent();
+    }
+
+    /**
+     * @Then the abandoned user email has been sent :expectedNumber time(s)
+     */
+    public function theAbandonedUserEmailHasBeenSentTime($expectedCount)
+    {
+        $actualCount = $this->countEmailsSent(EmailLog::MESSAGE_TYPE_ABANDONED_USERS);
+        Assert::eq($actualCount, $expectedCount);
     }
 }

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1295,7 +1295,7 @@ class EmailContext extends YiiContext
     }
 
     /**
-     * @Then the abandoned user email has been sent :expectedNumber time(s)
+     * @Then the abandoned user email has been sent :expectedCount time(s)
      */
     public function theAbandonedUserEmailHasBeenSentTime($expectedCount)
     {

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -11,7 +11,6 @@ use common\models\Mfa;
 use common\models\MfaBackupcode;
 use common\models\MfaWebauthn;
 use common\models\User;
-use Sil\SilIdBroker\Behat\Context\YiiContext;
 use Webmozart\Assert\Assert;
 
 class EmailContext extends YiiContext

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -59,6 +59,8 @@ class EmailContext extends YiiContext
     /** @var array<array> */
     protected $matchingFakeEmails;
 
+    private string $dummyExtGroupsAppPrefix = 'ext-dummy';
+
     public const METHOD_EMAIL_ADDRESS = 'method@example.com';
     public const MANAGER_EMAIL = 'manager@example.com';
 
@@ -1299,6 +1301,34 @@ class EmailContext extends YiiContext
     public function theAbandonedUserEmailHasBeenSentTime($expectedCount)
     {
         $actualCount = $this->countEmailsSent(EmailLog::MESSAGE_TYPE_ABANDONED_USERS);
+        Assert::eq($actualCount, $expectedCount);
+    }
+
+    /**
+     * @Given I send an external-groups sync-error email (again)
+     */
+    public function iSendAnExternalGroupsSyncErrorEmail()
+    {
+        $this->fakeEmailer->sendExternalGroupSyncErrorsEmail(
+            $this->dummyExtGroupsAppPrefix,
+            ['dummy error'],
+            'dummy@example.com',
+            ''
+        );
+    }
+
+    /**
+     * @Then the external-groups sync-error email has been sent :expectedCount time(s)
+     */
+    public function theExternalGroupsSyncErrorEmailHasBeenSentTime($expectedCount)
+    {
+        // The $appPrefix is needed by the FakeEmailer, to find the appropriate
+        // emails (by being able to accurately generate the expected subject).
+        $this->fakeEmailer->otherDataForEmails['appPrefix'] = $this->dummyExtGroupsAppPrefix;
+
+        $actualCount = $this->countEmailsSent(
+            EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS
+        );
         Assert::eq($actualCount, $expectedCount);
     }
 }

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -431,3 +431,9 @@ Feature: Email
       And I send abandoned user email
     When I send abandoned user email again
     Then the abandoned user email has been sent 1 time
+
+  Scenario: Not sending external-group sync-error emails too frequently
+    Given the database has been purged
+      And I send an external-groups sync-error email
+    When I send an external-groups sync-error email again
+    Then the external-groups sync-error email has been sent 1 time

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -437,3 +437,8 @@ Feature: Email
       And I send an external-groups sync-error email
     When I send an external-groups sync-error email again
     Then the external-groups sync-error email has been sent 1 time
+
+  Scenario: Ensure no EmailLog is to both a User and a non-user address
+    Given a user already exists
+    When I try to log an email as sent to that User and to a non-user address
+    Then an email log validation error should have occurred

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -404,7 +404,6 @@ Feature: Email
       | to send      | -1     | has          | should NOT     |
       | NOT to send  | -1     | has NOT      | should NOT     |
 
-
   Scenario Outline: HR notification users
     Given hr notification email <isOrIsNot> set
       And the database has been purged
@@ -423,3 +422,12 @@ Feature: Email
       | is        | an inactive | 7 months  | has NOT     |
       | is        | a           | 5 months  | has NOT     |
       | is        | a           | 7 months  | has         |
+
+  Scenario: Not sending HR notification emails too frequently
+    Given hr notification email is set
+      And the database has been purged
+      And a user already exists
+      And the user has not logged in for "7 months"
+      And I send abandoned user email
+    When I send abandoned user email again
+    Then the abandoned user email has been sent 1 time

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -442,3 +442,7 @@ Feature: Email
     Given a user already exists
     When I try to log an email as sent to that User and to a non-user address
     Then an email log validation error should have occurred
+
+  Scenario: Ensure each EmailLog is to either a User or a non-user address
+    When I try to log an email as sent to neither a User nor a non-user address
+    Then an email log validation error should have occurred


### PR DESCRIPTION
[IDP-1266](https://itse.youtrack.cloud/issue/IDP-1266) (partial:) Run the external-groups sync every 12 hours

---

### Changed (non-breaking)
- Avoid sending 'ext-groups-sync-errors' email too frequently

### Fixed
- Add a test that the 'abandoned-user' email isn't sent too frequently
- Add a test that the 'ext-groups-sync-errors' email isn't sent too frequently
- Remove unneeded use import in a test file
- Ensure we don't log an email as to both a User and non-user address
- Ensure every email we log is to either a User or a non-user address

---

### PR Checklist
- [ ] ~~Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)~~
- [ ] ~~Documentation (README, local.env.dist, api.raml, etc.)~~
- [x] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
