### PR TITLE
[IDP-1266, part 3:] Deprecate ID Broker's use of Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The API is described by [api.raml](api.raml), and an auto-generated [api.html](a
    * `./vendor/bin/behat features/authentication.feature`
    * `./vendor/bin/behat features/authentication.feature:298`
 
-## Google Analytics Calls
+## Google Analytics Calls - DEPRECATED
 Calls are made to Google Analytics regarding users' mfas and whether a password has been pwned.
 
 If you want to have an indication that those calls are likely to succeed, run 

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -50,6 +50,11 @@ class CronController extends Controller
     {
         $eventCategory = 'mfa-usage';
 
+        \Yii::warning(
+            'Reporting ID Broker metrics to Google Analytics is deprecated and '
+            . 'will be removed in a future release.'
+        );
+
         $gaEvents = [
             'active_users' => User::find()->where(['active' => 'yes'])->count(),
             'active_users_with_require_mfa' => User::countUsersWithRequireMfa(),

--- a/application/console/controllers/GaController.php
+++ b/application/console/controllers/GaController.php
@@ -15,6 +15,10 @@ class GaController extends Controller
      */
     public function actionRegister_event()
     {
+        \Yii::warning(
+            'Sending ID Broker data to Google Analytics is deprecated and will '
+            . 'be removed in a future release.'
+        );
 
         list($gaService, $gaRequest) = Utils::GoogleAnalyticsServiceAndRequest("cron");
         if ($gaService === null) {


### PR DESCRIPTION
[IDP-1266](https://itse.youtrack.cloud/issue/IDP-1266), part 3: Run the external-groups sync every 12 hours

---

### Deprecated
- Deprecate ID Broker's use of Google Analytics

---

### PR Checklist
- [ ] ~~Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)~~
- [x] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] ~~Tests created or updated~~
- [ ] ~~Run `make composershow`~~
- [ ] ~~Run `make psr2`~~
