### PR TITLE
[IDP-1266, part 4:] Send external-groups sync-errors email more often

### DIFF
--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -513,8 +513,8 @@ class Emailer extends Component
             $emailAddress,
             EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS,
             '11 hours' /* Use slightly less than the desired interval, to avoid
-                                 * inconsistent results due to being a few seconds before
-                                 * or after the cutoff. */
+                        * inconsistent results due to being a few seconds before
+                        * or after the cutoff. */
         );
 
         return !$haveSentEmailRecently;

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -443,14 +443,21 @@ class Emailer extends Component
     }
 
     /**
-     * Whether the non-user address has already been sent this type of email in the last X days
+     * Whether the non-user address has already been sent this type of email
+     * recently (where "recent" is defined by the given timeframe).
      *
      * @param string $emailAddress
      * @param string $messageType
+     * @param ?string $timeframe (Optional:) What qualifies as recent. If not
+     *     specified, this will default to `emailRepeatDelayDays` days.
+     *     Example: '11 hours'
      * @return bool
      */
-    public function hasNonUserReceivedMessageRecently(string $emailAddress, string $messageType): bool
-    {
+    public function hasNonUserReceivedMessageRecently(
+        string $emailAddress,
+        string $messageType,
+        ?string $timeframe = null
+    ): bool {
         $latestEmail = EmailLog::find()->where([
             'message_type' => $messageType,
             'non_user_address' => $emailAddress,
@@ -458,11 +465,16 @@ class Emailer extends Component
         ])->orderBy(
             'sent_utc DESC'
         )->one();
+
         if (empty($latestEmail)) {
             return false;
         }
 
-        return MySqlDateTime::dateIsRecent($latestEmail->sent_utc, $this->emailRepeatDelayDays);
+        if (empty($timeframe)) {
+            $timeframe = $this->emailRepeatDelayDays . ' days';
+        }
+
+        return MySqlDateTime::dateTimeIsRecent($latestEmail->sent_utc, $timeframe);
     }
 
     /**
@@ -499,7 +511,10 @@ class Emailer extends Component
 
         $haveSentEmailRecently = $this->hasNonUserReceivedMessageRecently(
             $emailAddress,
-            EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS
+            EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS,
+            '11 hours' /* Use slightly less than the desired interval, to avoid
+                                 * inconsistent results due to being a few seconds before
+                                 * or after the cutoff. */
         );
 
         return !$haveSentEmailRecently;

--- a/application/common/helpers/MySqlDateTime.php
+++ b/application/common/helpers/MySqlDateTime.php
@@ -95,9 +95,9 @@ class MySqlDateTime
     public static function dateTimeIsRecent(string $dbDate, string $timeframe)
     {
         $dtInterval = '-' . $timeframe;
-        $recentDate = self::relativeTime($dtInterval);
+        $recentDateTime = self::relativeTime($dtInterval);
 
-        return strtotime($dbDate) >= strtotime($recentDate);
+        return strtotime($dbDate) >= strtotime($recentDateTime);
     }
 
     /**

--- a/application/common/helpers/MySqlDateTime.php
+++ b/application/common/helpers/MySqlDateTime.php
@@ -85,6 +85,22 @@ class MySqlDateTime
     }
 
     /**
+     * Whether the given date-and-time qualifies as "recent" according to the
+     * given timeframe.
+     *
+     * @param string $dbDate formated datetime from database
+     * @param string $timeframe -- Example: '11 hours'
+     * @return bool
+     */
+    public static function dateTimeIsRecent(string $dbDate, string $timeframe)
+    {
+        $dtInterval = '-' . $timeframe;
+        $recentDate = self::relativeTime($dtInterval);
+
+        return strtotime($dbDate) >= strtotime($recentDate);
+    }
+
+    /**
      * Compare a date or datetime in MySQL format (yyyy-mm-dd or yyyy-mm-dd hh:mm::ss)
      * to an epoch time as returned from time().
      * Returns true if $eventTime is the same day or before $now.

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1367,4 +1367,30 @@ class EmailContext extends YiiContext
         ]);
         $this->tempEmailLog->save();
     }
+
+    /**
+     * @Given I sent an external-groups sync-error email :numberOfHours hour(s) ago
+     */
+    public function iSentAnExternalGroupsSyncErrorEmailHourAgo($numberOfHours)
+    {
+        $this->iSendAnExternalGroupsSyncErrorEmail();
+        $relativeTimeString = sprintf(
+            '-%u hours ago',
+            $numberOfHours
+        );
+
+        /** @var EmailLog[] $emailLogs */
+        $emailLogs = EmailLog::find()->each();
+        foreach ($emailLogs as $emailLog) {
+            $emailLog->sent_utc = MysqlDateTime::relative($relativeTimeString);
+            Assert::true(
+                $emailLog->save(true, ['sent_utc']),
+                sprintf(
+                    'Failed to update email log record to be for %s: %s',
+                    $relativeTimeString,
+                    $emailLog->getFirstError('sent_utc')
+                )
+            );
+        }
+    }
 }

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1379,12 +1379,13 @@ class EmailContext extends YiiContext
             $numberOfHours
         );
 
-        /** @var EmailLog[] $emailLogs */
-        $emailLogs = EmailLog::find()->all();
+        $emailLogs = EmailLog::findAll([
+            'message_type' => EmailLog::MESSAGE_TYPE_EXT_GROUP_SYNC_ERRORS,
+        ]);
 
         Assert::notEmpty(
             $emailLogs,
-            'No email logs found to update the sent_at value for'
+            'No external-group sync-error email logs found to set the sent_at value for'
         );
 
         foreach ($emailLogs as $emailLog) {

--- a/application/features/bootstrap/EmailContext.php
+++ b/application/features/bootstrap/EmailContext.php
@@ -1375,14 +1375,20 @@ class EmailContext extends YiiContext
     {
         $this->iSendAnExternalGroupsSyncErrorEmail();
         $relativeTimeString = sprintf(
-            '-%u hours ago',
+            '-%u hours',
             $numberOfHours
         );
 
         /** @var EmailLog[] $emailLogs */
-        $emailLogs = EmailLog::find()->each();
+        $emailLogs = EmailLog::find()->all();
+
+        Assert::notEmpty(
+            $emailLogs,
+            'No email logs found to update the sent_at value for'
+        );
+
         foreach ($emailLogs as $emailLog) {
-            $emailLog->sent_utc = MysqlDateTime::relative($relativeTimeString);
+            $emailLog->sent_utc = MysqlDateTime::relativeTime($relativeTimeString);
             Assert::true(
                 $emailLog->save(true, ['sent_utc']),
                 sprintf(

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -447,8 +447,8 @@ Feature: Email
     Examples:
       | hoursAgo     | timesSent |
       | 1 hour ago   | 1 time    |
-      | 11 hours ago | 1 time    |
-      | 13 hours ago | 2 times   |
+      | 10 hours ago | 1 time    |
+      | 12 hours ago | 2 times   |
 
   Scenario: Ensure no EmailLog is to both a User and a non-user address
     Given a user already exists

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -438,6 +438,18 @@ Feature: Email
     When I send an external-groups sync-error email again
     Then the external-groups sync-error email has been sent 1 time
 
+  Scenario Outline: Sending external-group sync-error emails up to every 12 hours
+    Given the database has been purged
+      And I sent an external-groups sync-error email <hoursAgo>
+    When I send an external-groups sync-error email again
+    Then the external-groups sync-error email has been sent <timesSent>
+
+    Examples:
+      | hoursAgo     | timesSent |
+      | 1 hour ago   | 1 time    |
+      | 11 hours ago | 1 time    |
+      | 13 hours ago | 2 times   |
+
   Scenario: Ensure no EmailLog is to both a User and a non-user address
     Given a user already exists
     When I try to log an email as sent to that User and to a non-user address


### PR DESCRIPTION
[IDP-1266](https://itse.youtrack.cloud/issue/IDP-1266) Run the external-groups sync every 12 hours

---

### Fixed
- Enable seeing if a specific date-and-time (not just a date) is recent
- Allow sending the external-groups sync-error emails every 12 hours 
  * The other emails consider "31 days" (configurable) the cutoff for "recent", but we want these emails to be able to go out more often than that.

---

### PR Checklist
- [ ] ~~Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)~~
- [ ] ~~Documentation (README, local.env.dist, api.raml, etc.)~~
- [x] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
