### PR TITLE
Stop having `cron/all` send MFA metrics to Google Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,12 +66,6 @@ The API is described by [api.raml](api.raml), and an auto-generated [api.html](a
    * `./vendor/bin/behat features/authentication.feature`
    * `./vendor/bin/behat features/authentication.feature:298`
 
-## Google Analytics Calls - DEPRECATED
-Calls are made to Google Analytics regarding users' mfas and whether a password has been pwned.
-
-If you want to have an indication that those calls are likely to succeed, run 
-`$ make callGA`.
-
 ## Adding groups to SAML `member` attribute from a Google Sheet
 
 The `local.env.dist` file shows how to add the necessary environment variables

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -3,15 +3,12 @@
 namespace console\controllers;
 
 use common\components\ExternalGroupsSync;
-use common\helpers\Utils;
 use common\models\Invite;
 use common\models\Method;
 use common\models\Mfa;
 use common\models\User;
 use common\components\Emailer;
 use yii\console\Controller;
-use Br33f\Ga4\MeasurementProtocol\Dto\Event\BaseEvent;
-use TheIconic\Tracking\GoogleAnalytics\Analytics;
 
 class CronController extends Controller
 {
@@ -24,80 +21,6 @@ class CronController extends Controller
         Mfa::removeOldUnverifiedRecords();
 
         Mfa::removeOldManagerMfaRecords();
-    }
-
-    /**
-     * Send events to Google Analytics that give the number of ...
-     *  - active users
-     *  - active users that have a verified Mfa of any type
-     *  - active users with a backup code Mfa
-     *  - active users with a verified totp Mfa
-     *  - active users with a verified u2f/webauthn Mfa
-     *
-     * If you need to debug the Google Analytics call, do this ...
-     *     $response = $analytics->setProtocolVersion('1')
-     *                           ->setDebug(true)
-     *     ...
-     *     ...
-     *     \Yii::warning([
-     *            'results' => $response->getDebugResponse(),
-     *     ]);
-     *
-     *
-     * @throws \Exception
-     */
-    public function actionGoogleAnalytics()
-    {
-        $eventCategory = 'mfa-usage';
-
-        \Yii::warning(
-            'Reporting ID Broker metrics to Google Analytics is deprecated and '
-            . 'will be removed in a future release.'
-        );
-
-        $gaEvents = [
-            'active_users' => User::find()->where(['active' => 'yes'])->count(),
-            'active_users_with_require_mfa' => User::countUsersWithRequireMfa(),
-            'active_users_with_mfas' => User::getQueryOfUsersWithMfa()->count(),
-            'active_users_with_backup_codes' => User::getQueryOfUsersWithMfa(Mfa::TYPE_BACKUPCODE)->count(),
-            'active_users_with_totp' => User::getQueryOfUsersWithMfa(Mfa::TYPE_TOTP)->count(),
-            'active_users_with_u2f' => User::getQueryOfUsersWithMfa(Mfa::TYPE_WEBAUTHN)->count(),
-            'active_users_with_password' => User::countUsersWithPassword(),
-            // Since GA doesn't accept event values as floats, multiply this by 10 and round it
-            'average_mfas_per_user_with_mfas_times_ten' => round(User::getAverageNumberOfMfasPerUserWithMfas() * 10.0),
-            'active_users_personal_email_no_methods' => User::numberWithPersonalEmailButNoMethods(),
-            'active_users_only_2sv_or_u2f' => User::numberWithOneMfaNotBackupCodes()
-        ];
-
-        list($gaService, $gaRequest) = Utils::GoogleAnalyticsServiceAndRequest("cron");
-        if ($gaService === null) {
-            return;
-        }
-
-        foreach ($gaEvents as $label => $value) {
-            $gaEvent = new BaseEvent($label);
-            $gaEvent->setCategory($eventCategory)
-                ->setLabel($label)
-                ->setValue($value);
-
-            $gaRequest->addEvent($gaEvent);
-        }
-
-        $debugResponse = $gaService->sendDebug($gaRequest);
-        $gaMessages = $debugResponse->getValidationMessages();
-        if (empty($gaMessages)) {
-            $gaService->send($gaRequest);
-        } else {
-            \Yii::warning([
-                'google-analytics' => "Aborting GA cron since the request was not accepted: " .
-                    var_export($gaMessages, true)
-            ]);
-            return;
-        }
-
-        $gaEvents['action'] = 'completed posting to Google Analytics';
-
-        \Yii::warning($gaEvents);
     }
 
     public function actionSendDelayedMfaRelatedEmails()
@@ -164,7 +87,6 @@ class CronController extends Controller
             'actionSendDelayedMfaRelatedEmails',
             'actionSendMethodReminderEmails',
             'actionSendPasswordExpiryEmails',
-            'actionGoogleAnalytics',
             'actionSyncExternalGroups',
         ];
 


### PR DESCRIPTION
[IDP-1266](https://itse.youtrack.cloud/issue/IDP-1266) Run the external-groups sync every 12 hours

---

### Changed (BREAKING)
- Stop having `cron/all` send MFA metrics to Google Analytics

### Removed
- Remove "Google Analytics Calls - DEPRECATED" section of README file

---

### PR Checklist
- [ ] ~~Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)~~
- [x] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] ~~Tests created or updated~~
- [x] Run `make composershow`
- [x] Run `make psr2`
