### PR TITLE
Release 7.0.2 -- reduce memory consumption of password expiry processing

### DIFF
--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -802,6 +802,7 @@ class Emailer extends Component
             /** @var Password $userPassword */
             $userPassword = $user->currentPassword;
             if ($userPassword) {
+                // password expiry still needs to be checked because it can be extended by having an active MFA
                 $passwordExpiry = strtotime($userPassword->getExpiresOn());
                 if ($passwordExpiry < strtotime(self::PASSWORD_EXPIRING_CUTOFF)
                     && !($passwordExpiry < time())
@@ -856,6 +857,7 @@ class Emailer extends Component
             /** @var Password $userPassword */
             $userPassword = $user->currentPassword;
             if ($userPassword) {
+                // password expiry still needs to be checked because it can be extended by having an active MFA
                 $passwordExpiry = strtotime($userPassword->getExpiresOn());
                 if ($passwordExpiry < time()
                     && $passwordExpiry > strtotime(self::PASSWORD_EXPIRED_CUTOFF)

--- a/application/common/components/Emailer.php
+++ b/application/common/components/Emailer.php
@@ -781,14 +781,16 @@ class Emailer extends Component
                 JOIN `password` p ON u.id = p.user_id
                 LEFT JOIN `email_log` e ON u.id = e.user_id
                     AND e.message_type = 'password-expiring'
-                    AND e.sent_utc >= CURRENT_DATE() - INTERVAL 31 DAY # EMAIL_REPEAT_DELAY_DAYS
+                    AND e.sent_utc >= CURRENT_DATE() - INTERVAL ? DAY
             WHERE u.active = 'yes'
                 AND u.locked = 'no'
                 AND p.expires_on < CURRENT_DATE() + INTERVAL 15 DAY
                 AND p.expires_on >= CURRENT_DATE() # send a different message if expired
                 AND e.id IS NULL
             GROUP BY u.id
-            HAVING COUNT(*) = 1;")->queryAll();
+            HAVING COUNT(*) = 1;")
+            ->bindValue(1, $this->emailRepeatDelayDays)
+            ->queryAll();
 
         $this->logger->info(array_merge($logData, [
             'users' => count($users)
@@ -837,13 +839,15 @@ class Emailer extends Component
             JOIN `password` p ON u.id = p.user_id
             LEFT JOIN `email_log` e ON u.id = e.user_id
                 AND e.message_type = 'password-expired'
-                AND e.sent_utc >= CURRENT_DATE() - INTERVAL 31 DAY # EMAIL_REPEAT_DELAY_DAYS
+                AND e.sent_utc >= CURRENT_DATE() - INTERVAL ? DAY
             WHERE u.active = 'yes'
                 AND u.locked = 'no'
                 AND p.expires_on <= CURRENT_DATE()
                 AND e.id IS NULL
             GROUP BY u.id
-            HAVING COUNT(*) = 1;")->queryAll();
+            HAVING COUNT(*) = 1;")
+            ->bindValue(1, $this->emailRepeatDelayDays)
+            ->queryAll();
 
         $this->logger->info(array_merge($logData, [
             'users' => count($users)

--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -1586,7 +1586,7 @@ class User extends UserBase
      * Returns a list of active, unlocked users that haven't recently received a given email message.
      * @param $template Email template name to use as search criteria
      * @param $days Number of days to consider an email sent recently
-     * @returns User[]
+     * @return User[]
      */
     public static function getUsersForEmail(string $template, int $days): array
     {

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -92,7 +92,7 @@ class CronController extends Controller
         if (\Yii::$app->params['google']['enableSheetsExport']) {
             $actions[] = 'actionExportToSheets';
         }
-        
+
         $actions[] = 'actionSendPasswordExpiryEmails';
 
         foreach ($actions as $action) {

--- a/application/console/controllers/CronController.php
+++ b/application/console/controllers/CronController.php
@@ -2,12 +2,12 @@
 
 namespace console\controllers;
 
+use common\components\Emailer;
 use common\components\ExternalGroupsSync;
 use common\models\Invite;
 use common\models\Method;
 use common\models\Mfa;
 use common\models\User;
-use common\components\Emailer;
 use yii\console\Controller;
 
 class CronController extends Controller
@@ -86,13 +86,14 @@ class CronController extends Controller
             'actionSendAbandonedUsersEmail',
             'actionSendDelayedMfaRelatedEmails',
             'actionSendMethodReminderEmails',
-            'actionSendPasswordExpiryEmails',
             'actionSyncExternalGroups',
         ];
 
         if (\Yii::$app->params['google']['enableSheetsExport']) {
             $actions[] = 'actionExportToSheets';
         }
+        
+        $actions[] = 'actionSendPasswordExpiryEmails';
 
         foreach ($actions as $action) {
             try {

--- a/application/features/email.feature
+++ b/application/features/email.feature
@@ -365,6 +365,7 @@ Feature: Email
   Scenario Outline:  When to send password expiring notice email
     Given we are configured <toSendOrNot> password expiring emails
       And I remove records of any emails that have been sent
+      And no mfas exist
       And a user already exists
       And that user has a password that expires in <number> days
       And a "password-expiring" email <hasOrHasNot> been sent to that user
@@ -383,9 +384,30 @@ Feature: Email
       | to send      | 15      | has          | should NOT     |
       | NOT to send  | 15      | has NOT      | should NOT     |
 
+  Scenario Outline:  When to send password expiring notice email for a user with MFA enabled
+    Given we are configured <toSendOrNot> password expiring emails
+    And the database has been purged
+    And a user already exists
+    And that user has a password that expires in <number> days
+    And a totp mfa option does exist
+    And a "password-expiring" email <hasOrHasNot> been sent to that user
+    When I send password expiring emails
+    Then a "password-expiring" email <shouldOrNot> have been sent to them
+
+    Examples:
+      | toSendOrNot | number | hasOrHasNot | shouldOrNot |
+      | to send     | -1462  | has NOT     | should NOT  |
+      | to send     | -1461  | has NOT     | should      |
+      | to send     | -1447  | has NOT     | should      |
+      | to send     | -1446  | has NOT     | should NOT  |
+      | to send     | -1461  | has         | should NOT  |
+      | to send     | -1447  | has         | should NOT  |
+      | NOT to send | -1447  | has NOT     | should NOT  |
+
   Scenario Outline:  When to send password expired notice email
     Given we are configured <toSendOrNot> password expired emails
       And I remove records of any emails that have been sent
+      And no mfas exist
       And a user already exists
       And that user has a password that expires in <number> days
       And a "password-expired" email <hasOrHasNot> been sent to that user


### PR DESCRIPTION
[IDP-1414](https://itse.youtrack.cloud/issue/IDP-1414) IdP Export Sheet

---

### Fixed
- Optimized the database query that retrieves users for sending password expiry messages. This task runs before the Google Sheets export (and the external groups sync). The logs show that the password expiry task is sometimes the last to run and it does not finish.

### Changed
- Changed the order of scheduled task execution. Moved password expiry processing to last in case the fix doesn't work.
- 
---

### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [x] Run `make psr2`
