### PR TITLE
Release 7.1.0 -- add Parameter Store as an alternative to AppConfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY dockerbuild/vhost.conf /etc/apache2/sites-enabled/
 # ErrorLog inside a VirtualHost block is ineffective for unknown reasons
 RUN sed -i -E 's@ErrorLog .*@ErrorLog /proc/self/fd/2@i' /etc/apache2/apache2.conf
 
-ADD https://github.com/silinternational/config-shim/releases/download/v1.0.0/config-shim.gz config-shim.gz
+ADD https://github.com/silinternational/config-shim/releases/download/v1.2.0/config-shim.gz config-shim.gz
 RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
 
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -10,24 +10,30 @@
 3. Run `make start`
 
 ## Configuration
+
 By default, configuration is read from environment variables. These are documented
-in the `local.env.dist` file. Optionally, you can define configuration in AWS AppConfig.
+in the `local.env.dist` file. Optionally, you can define configuration in AWS Systems Manager.
 To do this, set the following environment variables to point to the configuration in
 AWS:
 
 * `AWS_REGION` - the AWS region in use
-* `APP_ID` - the application ID or name
-* `CONFIG_ID` - the configuration profile ID or name
-* `ENV_ID` - the environment ID or name
+* `APP_ID` - AppConfig application ID or name
+* `CONFIG_ID` - AppConfig configuration profile ID or name
+* `ENV_ID` - AppConfig environment ID or name
+* `PARAMETER_STORE_PATH` - Parameter Store base path for this app, e.g. "/idp-pw-api/idp-name/prod"
 
 In addition, the AWS API requires authentication. It is best to use an access role
 such as an [ECS Task Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).
 If that is not an option, you can specify an access token using the `AWS_ACCESS_KEY_ID` and
 `AWS_SECRET_ACCESS_KEY` variables.
 
-The content of the configuration profile takes the form of a typical .env file, using
-`#` for comments and `=` for variable assignment. Any variables read from AppConfig 
-will overwrite variables set in the execution environment.
+If `PARAMETER_STORE_PATH` is given, AWS Parameter Store will be used. Each parameter in AWS Parameter
+Store is set as an environment variable in the execution environment.
+
+If `PARAMETER_STORE_PATH` is not given but the AppConfig variables are, AWS AppConfig will be used.
+The content of the AppConfig configuration profile takes the form of a typical .env file, using `#`
+for comments and `=` for variable assignment. Any variables read from AppConfig will overwrite variables
+set in the execution environment.
 
 ## Composer / GitHub rate limit
 If you hit problems of composer unable to pull the necessary dependencies

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ AWS:
 * `APP_ID` - AppConfig application ID or name
 * `CONFIG_ID` - AppConfig configuration profile ID or name
 * `ENV_ID` - AppConfig environment ID or name
-* `PARAMETER_STORE_PATH` - Parameter Store base path for this app, e.g. "/idp-pw-api/idp-name/prod"
+* `PARAMETER_STORE_PATH` - Parameter Store base path for this app, e.g. "/idp-name/"
 
 In addition, the AWS API requires authentication. It is best to use an access role
 such as an [ECS Task Role](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).

--- a/application/run.sh
+++ b/application/run.sh
@@ -18,9 +18,9 @@ chown -R www-data:www-data \
 echo 'sleeping a random number of seconds up to 9 to avoid migration runs clash'
 sleep $[ ( $RANDOM % 10 ) ]s
 
-if [[ ${PARAMETER_STORE_PATH} ]]; then
+if [[ $PARAMETER_STORE_PATH ]]; then
   config="config-shim --path $PARAMETER_STORE_PATH"
-elif [[ ${APP_ID} ]]; then
+elif [[ $APP_ID ]]; then
   config="config-shim --app $APP_ID --config $CONFIG_ID --env $ENV_ID"
 else
   config=""
@@ -28,7 +28,7 @@ fi
 
 $config /data/yii migrate --interactive=0
 
-if [[ ! -z $RUN_TASK ]]; then
+if [[ $RUN_TASK ]]; then
   $config ./yii $RUN_TASK
   exit $?
 fi


### PR DESCRIPTION

### Added
- Added Parameter Store as an alternative to AppConfig

---

### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] Documentation (README, local.env.dist, api.raml, etc.)
- [x] ~Tests created or updated~
- [x] ~Run `make composershow`~
- [x] ~Run `make psr2`~
