### PR TITLE
Release 7.1.2 -- Fix config shim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,5 @@ COPY dockerbuild/vhost.conf /etc/apache2/sites-enabled/
 # ErrorLog inside a VirtualHost block is ineffective for unknown reasons
 RUN sed -i -E 's@ErrorLog .*@ErrorLog /proc/self/fd/2@i' /etc/apache2/apache2.conf
 
-ADD https://github.com/silinternational/config-shim/releases/download/v1.2.1/config-shim.gz config-shim.gz
-RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
-
 EXPOSE 80
 CMD ["/data/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ COPY dockerbuild/vhost.conf /etc/apache2/sites-enabled/
 # ErrorLog inside a VirtualHost block is ineffective for unknown reasons
 RUN sed -i -E 's@ErrorLog .*@ErrorLog /proc/self/fd/2@i' /etc/apache2/apache2.conf
 
-ADD https://github.com/silinternational/config-shim/releases/download/v1.2.0/config-shim.gz config-shim.gz
+ADD https://github.com/silinternational/config-shim/releases/download/v1.2.1/config-shim.gz config-shim.gz
 RUN gzip -d config-shim.gz && chmod 755 config-shim && mv config-shim /usr/local/bin
 
 EXPOSE 80

--- a/application/run.sh
+++ b/application/run.sh
@@ -19,7 +19,7 @@ echo 'sleeping a random number of seconds up to 9 to avoid migration runs clash'
 sleep $[ ( $RANDOM % 10 ) ]s
 
 if [[ $PARAMETER_STORE_PATH ]]; then
-  config="config-shim --path $PARAMETER_STORE_PATH"
+  config="config-shim -v --path $PARAMETER_STORE_PATH"
 elif [[ $APP_ID ]]; then
   config="config-shim --app $APP_ID --config $CONFIG_ID --env $ENV_ID"
 else


### PR DESCRIPTION

### Fixed
- Update config-shim to version 1.2.1, which adds pagination to the AWS `GetParametersByPath` call to get more than 10 parameters.

---

### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] ~Documentation (README, local.env.dist, api.raml, etc.)~
- [x] ~Tests created or updated~
- [x] ~Run `make composershow`~
- [x] ~Run `make psr2`~
