### PR TITLE
Release 7.2.0 -- share one API key and secret for both TOTP and Webauthn

### DIFF
--- a/actions-services.yml
+++ b/actions-services.yml
@@ -41,8 +41,8 @@ services:
             ABANDONED_USER_bestPracticeUrl: http://www.example.com/best-practices.html
             ABANDONED_USER_deactivateInstructionsUrl: http://www.example.com/deactivate-instructions.html
             MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
-            MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
-            MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678
+            MFA_API_KEY: 10345678-1234-1234-1234-123456789012
+            MFA_API_SECRET: 11345678-1234-1234-1234-12345678
             MFA_WEBAUTHN_appId: ourApp99
             MFA_WEBAUTHN_rpDisplayName: Our App
             MFA_WEBAUTHN_rpId: http://app99

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -30,6 +30,18 @@ $mfaTotpConfig['issuer'] = $idpDisplayName;
 
 $mfaWebAuthnConfig = Env::getArrayFromPrefix('MFA_WEBAUTHN_');
 
+$mfaApiKey = Env::get('MFA_API_KEY');
+if (!empty($mfaApiKey)) {
+    $mfaTotpConfig['apiKey'] = $mfaApiKey;
+    $mfaWebAuthnConfig['apiKey'] = $mfaApiKey;
+}
+
+$mfaApiSecret = Env::get('MFA_API_SECRET');
+if (!empty($mfaApiSecret)) {
+    $mfaTotpConfig['apiSecret'] = $mfaApiSecret;
+    $mfaWebAuthnConfig['apiSecret'] = $mfaApiSecret;
+}
+
 $emailerClass = Env::get('EMAILER_CLASS', Emailer::class);
 
 /*

--- a/application/features/bootstrap/AuthenticationContext.php
+++ b/application/features/bootstrap/AuthenticationContext.php
@@ -15,7 +15,7 @@ class AuthenticationContext extends FeatureContext
     public function __destruct()
     {
         // Ensure the (local) WebAuthn MFA API is left with the correct API Secret.
-        $this->setWebAuthnApiSecretTo(Env::get('MFA_WEBAUTHN_apiSecret'));
+        $this->setWebAuthnApiSecretTo(Env::get('MFA_API_SECRET'));
     }
 
     /**
@@ -91,7 +91,7 @@ class AuthenticationContext extends FeatureContext
         $dynamoDbClient->updateItem([
             'Key' => [
                 'value' => [
-                    'S' => Env::get('MFA_WEBAUTHN_apiKey'),
+                    'S' => Env::get('MFA_API_KEY'),
                 ],
             ],
             'UpdateExpression' => 'set hashedApiSecret = :newHashedApiSecret',
@@ -109,6 +109,6 @@ class AuthenticationContext extends FeatureContext
      */
     public function weHaveTheRightPasswordForTheWebauthnMfaApi()
     {
-        $this->setWebAuthnApiSecretTo(Env::get('MFA_WEBAUTHN_apiSecret'));
+        $this->setWebAuthnApiSecretTo(Env::get('MFA_API_SECRET'));
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,8 +48,8 @@ services:
       MYSQL_USER: appfortests
       MYSQL_PASSWORD: appfortests
       MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
-      MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
-      MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678
+      MFA_API_KEY: 10345678-1234-1234-1234-123456789012
+      MFA_API_SECRET: 11345678-1234-1234-1234-12345678
       # the corresponding hash: $2a$10$8Bp9PqqfStjLvh1nQJ67JeY3CO/mEXmF1GKfe8Vk0kue1.i7fa2mC
       MFA_WEBAUTHN_appId: ourApp99
       MFA_WEBAUTHN_rpDisplayName: Our App
@@ -169,8 +169,8 @@ services:
       EMAIL_SERVICE_baseUrl: dummy
       EMAIL_SIGNATURE: Dummy Signature for Test
       MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
-      MFA_WEBAUTHN_apiKey: 10345678-1234-1234-1234-123456789012
-      MFA_WEBAUTHN_apiSecret: 11345678-1234-1234-1234-12345678
+      MFA_API_KEY: 10345678-1234-1234-1234-123456789012
+      MFA_API_SECRET: 11345678-1234-1234-1234-12345678
       # the corresponding hash: $2a$10$8Bp9PqqfStjLvh1nQJ67JeY3CO/mEXmF1GKfe8Vk0kue1.i7fa2mC
       MFA_WEBAUTHN_appId: ourApp99
       MFA_WEBAUTHN_rpDisplayName: Our App

--- a/dynamorestart/DynamoRestart.php
+++ b/dynamorestart/DynamoRestart.php
@@ -70,7 +70,7 @@ class DynamoRestart
                 'value' => [
                     'S' => ApiKeyValue,
                 ],
-                // This assumes the MFA_WEBAUTHN_apiSecret env var is "11345678-1234-1234-1234-12345678"
+                // This assumes the MFA_API_SECRET env var is "11345678-1234-1234-1234-12345678"
                 // The value below comes from using this go code to match what happens in serverless-mfa-api-go
                 // 	a := "11345678-1234-1234-1234-12345678"
                 //	hashedApiSecret, err := bcrypt.GenerateFromPassword([]byte(a), bcrypt.DefaultCost)

--- a/local.env.dist
+++ b/local.env.dist
@@ -215,15 +215,19 @@ HR_NOTIFICATIONS_EMAIL=test@test.com
 # By default does not include a bcc address.
 #MFA_MANAGER_HELP_BCC=
 
-# Required parameters for TOTP service
+# Required parameters for TOTP and WebAuthn service
+#MFA_API_KEY=
+#MFA_API_SECRET=
+
+# Required parameter for TOTP service
 #MFA_TOTP_apiBaseUrl=
-#MFA_TOTP_apiKey=
-#MFA_TOTP_apiSecret=
+#MFA_TOTP_apiKey=        # DEPRECATED: use MFA_API_KEY
+#MFA_TOTP_apiSecret=     # DEPRECATED: use MFA_API_SECRET
 
 # Required parameters for WebAuthn service
 #MFA_WEBAUTHN_apiBaseUrl=
-#MFA_WEBAUTHN_apiKey=
-#MFA_WEBAUTHN_apiSecret=
+#MFA_WEBAUTHN_apiKey=      # DEPRECATED: use MFA_API_KEY
+#MFA_WEBAUTHN_apiSecret=   # DEPRECATED: use MFA_API_SECRET
 #MFA_WEBAUTHN_appId=
 #MFA_WEBAUTHN_rpDisplayName=
 #MFA_WEBAUTHN_rpId=


### PR DESCRIPTION
### Changed (non-breaking)
- Share one API key and secret for TOTP and Webauthn services

### Deprecated
- `MFA_TOTP_apiKey`, `MFA_TOTP_apiSecret`, `MFA_WEBAUTHN_apiKey`, `MFA_WEBAUTHN_apiSecret` environment variables are being deprecated. Use `MFA_API_KEY` and `MFA_API_SECRET`.

---

### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] Documentation (README, local.env.dist, api.raml, etc.)
- [x] ~Tests created or updated~
- [x] ~Run `make composershow`~
- [x] Run `make psr2`
