### PR TITLE
Release 7.2.1 -- deprecate MFA_WEBAUTHN_rpDisplayName and MFA_WEBAUTHN_appId

### DIFF
--- a/actions-services.yml
+++ b/actions-services.yml
@@ -43,8 +43,6 @@ services:
             MFA_WEBAUTHN_apiBaseUrl: mfaapi:8080/
             MFA_API_KEY: 10345678-1234-1234-1234-123456789012
             MFA_API_SECRET: 11345678-1234-1234-1234-12345678
-            MFA_WEBAUTHN_appId: ourApp99
-            MFA_WEBAUTHN_rpDisplayName: Our App
             MFA_WEBAUTHN_rpId: http://app99
             U2F_SIM_HOST_AND_PORT: u2fsim:8080
 

--- a/application/common/config/main.php
+++ b/application/common/config/main.php
@@ -25,10 +25,18 @@ $notificationEmail = Env::get('NOTIFICATION_EMAIL');
 
 $mfaNumBackupCodes = Env::get('MFA_NUM_BACKUPCODES', 10);
 
+$passwordProfileUrl = Env::get('PASSWORD_PROFILE_URL');
+
 $mfaTotpConfig = Env::getArrayFromPrefix('MFA_TOTP_');
 $mfaTotpConfig['issuer'] = $idpDisplayName;
 
 $mfaWebAuthnConfig = Env::getArrayFromPrefix('MFA_WEBAUTHN_');
+if (empty($mfaWebAuthnConfig['rpDisplayName'])) {
+    $mfaWebAuthnConfig['rpDisplayName'] = $idpDisplayName;
+}
+if (empty($mfaWebAuthnConfig['appId'])) {
+    $mfaWebAuthnConfig['appId'] = $passwordProfileUrl . '/app-id.json';
+}
 
 $mfaApiKey = Env::get('MFA_API_KEY');
 if (!empty($mfaApiKey)) {
@@ -55,8 +63,6 @@ $emailServiceConfig = Env::getArrayFromPrefix('EMAIL_SERVICE_');
 
 // Re-retrieve the validIpRanges as an array.
 $emailServiceConfig['validIpRanges'] = Env::getArray('EMAIL_SERVICE_validIpRanges');
-
-$passwordProfileUrl = Env::get('PASSWORD_PROFILE_URL');
 
 $logPrefix = function () {
     $request = Yii::$app->request;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,6 @@ services:
       MFA_API_KEY: 10345678-1234-1234-1234-123456789012
       MFA_API_SECRET: 11345678-1234-1234-1234-12345678
       # the corresponding hash: $2a$10$8Bp9PqqfStjLvh1nQJ67JeY3CO/mEXmF1GKfe8Vk0kue1.i7fa2mC
-      MFA_WEBAUTHN_appId: ourApp99
-      MFA_WEBAUTHN_rpDisplayName: Our App
       MFA_WEBAUTHN_rpId: http://app99
       SUPPORT_EMAIL: support@example.com
 
@@ -172,8 +170,6 @@ services:
       MFA_API_KEY: 10345678-1234-1234-1234-123456789012
       MFA_API_SECRET: 11345678-1234-1234-1234-12345678
       # the corresponding hash: $2a$10$8Bp9PqqfStjLvh1nQJ67JeY3CO/mEXmF1GKfe8Vk0kue1.i7fa2mC
-      MFA_WEBAUTHN_appId: ourApp99
-      MFA_WEBAUTHN_rpDisplayName: Our App
       MFA_WEBAUTHN_rpId: http://app99
       HELP_CENTER_URL: https://www.example.com/help
       IDP_DISPLAY_NAME: Test

--- a/local.env.dist
+++ b/local.env.dist
@@ -226,10 +226,10 @@ HR_NOTIFICATIONS_EMAIL=test@test.com
 
 # Required parameters for WebAuthn service
 #MFA_WEBAUTHN_apiBaseUrl=
-#MFA_WEBAUTHN_apiKey=      # DEPRECATED: use MFA_API_KEY
-#MFA_WEBAUTHN_apiSecret=   # DEPRECATED: use MFA_API_SECRET
-#MFA_WEBAUTHN_appId=
-#MFA_WEBAUTHN_rpDisplayName=
+#MFA_WEBAUTHN_apiKey=          # DEPRECATED: use MFA_API_KEY
+#MFA_WEBAUTHN_apiSecret=       # DEPRECATED: use MFA_API_SECRET
+#MFA_WEBAUTHN_rpDisplayName=   # DEPRECATED: will use IDP_DISPLAY_NAME in future versions
+#MFA_WEBAUTHN_appId=           # DEPRECATED: will be derived from PASSWORD_PROFILE_URL in future versions
 #MFA_WEBAUTHN_rpId=
 # Array of origins allowed as relying parties (with scheme, without port or path)
 #RP_ORIGINS=

--- a/local.env.dist
+++ b/local.env.dist
@@ -228,8 +228,8 @@ HR_NOTIFICATIONS_EMAIL=test@test.com
 #MFA_WEBAUTHN_apiBaseUrl=
 #MFA_WEBAUTHN_apiKey=          # DEPRECATED: use MFA_API_KEY
 #MFA_WEBAUTHN_apiSecret=       # DEPRECATED: use MFA_API_SECRET
-#MFA_WEBAUTHN_rpDisplayName=   # DEPRECATED: will use IDP_DISPLAY_NAME in future versions
-#MFA_WEBAUTHN_appId=           # DEPRECATED: will be derived from PASSWORD_PROFILE_URL in future versions
+#MFA_WEBAUTHN_rpDisplayName=   # DEPRECATED: The value of `IDP_DISPLAY_NAME` will be used instead.
+#MFA_WEBAUTHN_appId=           # DEPRECATED: The value of `PASSWORD_PROFILE_URL` + "/app-id.json" will be used instead.
 #MFA_WEBAUTHN_rpId=
 # Array of origins allowed as relying parties (with scheme, without port or path)
 #RP_ORIGINS=


### PR DESCRIPTION

### Deprecated
- Deprecated `MFA_WEBAUTHN_rpDisplayName`. The value of `IDP_DISPLAY_NAME` will be used instead.
- Deprecated `MFA_WEBAUTHN_appId`. The value of `PASSWORD_PROFILE_URL` + "/app-id.json" will be used instead.

---

### PR Checklist
- [x] Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)
- [x] Documentation (README, local.env.dist, api.raml, etc.)
- [x] ~Tests created or updated~
- [x] ~Run `make composershow`~
- [x] Run `make psr2`
