### PR TITLE
use cron to send queued email messages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV GITHUB_REF_NAME=$GITHUB_REF_NAME
 ENV REFRESHED_AT 2024-02-27
 
 RUN apt-get update -y && \
-    apt-get install -y make
+    apt-get install -y cron make
 
 WORKDIR /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV GITHUB_REF_NAME=$GITHUB_REF_NAME
 RUN apt-get update && apt-get install -y --no-install-recommends \
   cron \
   make \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /data
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM silintl/php8:8.3
 ARG GITHUB_REF_NAME
 ENV GITHUB_REF_NAME=$GITHUB_REF_NAME
 
-ENV REFRESHED_AT 2024-02-27
-
-RUN apt-get update -y && \
-    apt-get install -y cron make
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  cron \
+  make \
+  && rm -rf /var/lib/apt/lists/* \
 
 WORKDIR /data
 

--- a/application/console/controllers/SendController.php
+++ b/application/console/controllers/SendController.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace console\controllers;
+
+use common\models\Email;
+use yii\console\Controller;
+
+class SendController extends Controller
+{
+    public function actionSendQueuedEmail()
+    {
+        Email::sendQueuedEmail();
+    }
+}

--- a/application/run-cron.sh
+++ b/application/run-cron.sh
@@ -11,5 +11,8 @@ fi
 # Make environment variables available to cron jobs
 $config env >> /etc/environment
 
+echo '* * * * * root /data/yii send/send-queued-email > /proc/1/fd/1 2>&1' > /etc/crontab
+chmod 0644 /etc/crontab
+
 # run cron in foreground so output is logged
 cron -f

--- a/application/run-cron.sh
+++ b/application/run-cron.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+if [[ $PARAMETER_STORE_PATH ]]; then
+  config="config-shim -v --path $PARAMETER_STORE_PATH"
+elif [[ $APP_ID ]]; then
+  config="config-shim --app $APP_ID --config $CONFIG_ID --env $ENV_ID"
+else
+  config=""
+fi
+
+# Make environment variables available to cron jobs
+$config env >> /etc/environment
+
+# run cron in foreground so output is logged
+cron -f


### PR DESCRIPTION
[IDP-1444](https://itse.youtrack.cloud/issue/IDP-1444) integrate email-service into idp-id-broker

---

### Added
- Added cron service and a script to start it
- Added a console action to send queued email
- Added a crontab file that runs the queued email action

---

### PR Checklist
- [x] ~Put version number in PR title (e.g. `Release x.y.z - Summary of changes`)~
- [x] ~Documentation (README, local.env.dist, api.raml, etc.)~
- [x] ~Tests created or updated~
- [x] ~Run `make composershow`~
- [x] Run `make psr2`
