### PR TITLE
Release 8.0.1 -- fix email style

### DIFF
--- a/application/common/mail/layouts/html.php
+++ b/application/common/mail/layouts/html.php
@@ -21,7 +21,11 @@ $maxWidth = Env::get('EMAIL_MAX_WIDTH', '600px');
                 <table style="background-color: <?= $brandColor ?>; width: 100%">
                     <tr>
                         <th>
-                            <img src="<?= $logo ?>" style="max-height: 4em; vertical-align: middle" alt="logo">
+                            <img
+                              src="<?= $logo ?>"
+                              style="max-height: 4em; vertical-align: middle; text-align: left;
+                              alt="logo"
+                            >
                         </th>
                     </tr>
                 </table>


### PR DESCRIPTION
### Fixed
- In email template, add `text-align: left` to compensate for changing `td` to `th`