### PR TITLE
fix password_verify deprecation by checking for null first

### DIFF
--- a/application/common/models/User.php
+++ b/application/common/models/User.php
@@ -292,7 +292,8 @@ class User extends UserBase
     {
         return function ($attributeName) {
             $currentPassword = $this->currentPassword ?? new Password();
-            if ($currentPassword->hash === null || !password_verify($this->password, $currentPassword->hash)) {
+            $hash = $currentPassword->hash ?? null;
+            if ($hash === null || !password_verify($this->password, $currentPassword->hash)) {
                 $this->addError($attributeName, 'Incorrect password.');
             } else {
                 // check the current hash cost and rehash if necessary


### PR DESCRIPTION

### Fixed
- Fix deprecation in `password_verify` by checking for a null first.