### PR TITLE
use Behat attributes in place of old-style comment annotations

### DIFF
--- a/app/features/bootstrap/AuthenticationContext.php
+++ b/app/features/bootstrap/AuthenticationContext.php
@@ -5,6 +5,7 @@ namespace Sil\SilIdBroker\Behat\Context;
 use Aws\DynamoDb\DynamoDbClient;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Hook\AfterScenario;
+use Behat\Step\Given;
 use common\models\Mfa;
 use common\models\User;
 use FeatureContext;
@@ -23,9 +24,7 @@ class AuthenticationContext extends FeatureContext
         }
     }
 
-    /**
-     * @Given :username has a valid WebAuthn MFA method
-     */
+    #[Given(':username has a valid WebAuthn MFA method')]
     public function userHasAValidWebauthnMfaMethod($username)
     {
         $user = User::findByUsername($username);
@@ -74,9 +73,7 @@ class AuthenticationContext extends FeatureContext
         return $u2fSimResponse;
     }
 
-    /**
-     * @Given we have the wrong password for the WebAuthn MFA API
-     */
+    #[Given('we have the wrong password for the WebAuthn MFA API')]
     public function weHaveTheWrongPasswordForTheWebauthnMfaApi()
     {
         /* This is setting the API secret to something else, so that the one
@@ -109,9 +106,7 @@ class AuthenticationContext extends FeatureContext
         ]);
     }
 
-    /**
-     * @Given we have the right password for the WebAuthn MFA API
-     */
+    #[Given('we have the right password for the WebAuthn MFA API')]
     public function weHaveTheRightPasswordForTheWebauthnMfaApi()
     {
         $this->setWebAuthnApiSecretTo(Env::get('MFA_API_SECRET'));

--- a/app/features/bootstrap/EmailContext.php
+++ b/app/features/bootstrap/EmailContext.php
@@ -12,6 +12,9 @@ use common\models\MfaBackupcode;
 use common\models\MfaWebauthn;
 use common\models\User;
 use Webmozart\Assert\Assert;
+use Behat\Step\Then;
+use Behat\Step\When;
+use Behat\Step\Given;
 
 class EmailContext extends YiiContext
 {
@@ -67,17 +70,13 @@ class EmailContext extends YiiContext
     public const RECOVERY_EMAIL = 'recovery@example.com';
 
 
-    /**
-     * @Then a(n) :messageType email should have been sent to them
-     */
+    #[Then('a(n) :messageType email should have been sent to them')]
     public function aEmailShouldHaveBeenSentToThem($messageType)
     {
         $this->assertEmailSent($messageType, $this->tempUser->email);
     }
 
-    /**
-     * @Then a(n) :messageType email should NOT have been sent to them
-     */
+    #[Then('a(n) :messageType email should NOT have been sent to them')]
     public function aEmailShouldNotHaveBeenSentToThem($messageType)
     {
         $this->matchingFakeEmails = $this->fakeEmailer->getFakeEmailsOfTypeSentToUser(
@@ -88,9 +87,7 @@ class EmailContext extends YiiContext
         Assert::isEmpty($this->matchingFakeEmails);
     }
 
-    /**
-     * @Then a(n) :messageType email to that user should NOT have been logged
-     */
+    #[Then('a(n) :messageType email to that user should NOT have been logged')]
     public function aEmailToThatUserShouldNotHaveBeenLogged($messageType)
     {
         $emailLogs = EmailLog::findAll([
@@ -110,18 +107,14 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @When that user is created
-     */
+    #[When('that user is created')]
     public function thatUserIsCreated()
     {
         Assert::null($this->tempUser, 'The user should not have existed yet.');
         $this->tempUser = $this->createNewUser();
     }
 
-    /**
-     * @When that user is created with a personal email address
-     */
+    #[When('that user is created with a personal email address')]
     public function thatUserIsCreatedWithAPersonalEmailAddress()
     {
         Assert::null($this->tempUser, 'The user should not have existed yet.');
@@ -215,9 +208,7 @@ class EmailContext extends YiiContext
         return null;
     }
 
-    /**
-     * @Then a(n) :messageType email to that user should have been logged
-     */
+    #[Then('a(n) :messageType email to that user should have been logged')]
     public function aEmailToThatUserShouldHaveBeenLogged($messageType)
     {
         $emailLogs = EmailLog::findAll([
@@ -237,49 +228,37 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @Given we are configured to send invite emails
-     */
+    #[Given('we are configured to send invite emails')]
     public function weAreConfiguredToSendInviteEmails()
     {
         $this->fakeEmailer->sendInviteEmails = true;
     }
 
-    /**
-     * @Given we are configured to send password-changed emails
-     */
+    #[Given('we are configured to send password-changed emails')]
     public function weAreConfiguredToSendPasswordChangedEmails()
     {
         $this->fakeEmailer->sendPasswordChangedEmails = true;
     }
 
-    /**
-     * @Given we are configured NOT to send invite emails
-     */
+    #[Given('we are configured NOT to send invite emails')]
     public function weAreConfiguredNotToSendInviteEmails()
     {
         $this->fakeEmailer->sendInviteEmails = false;
     }
 
-    /**
-     * @Given we are configured NOT to send password-changed emails
-     */
+    #[Given('we are configured NOT to send password-changed emails')]
     public function weAreConfiguredNotToSendPasswordChangedEmails()
     {
         $this->fakeEmailer->sendPasswordChangedEmails = false;
     }
 
-    /**
-     * @Given a(nother) (specific) user already exists
-     */
+    #[Given('a(nother) (specific) user already exists')]
     public function aUserAlreadyExists()
     {
         $this->tempUser = $this->createNewUser();
     }
 
-    /**
-     * @Given an(other) inactive user already exists
-     */
+    #[Given('an(other) inactive user already exists')]
     public function anInactiveUserAlreadyExists()
     {
         $this->tempUser = $this->createNewUser();
@@ -293,9 +272,7 @@ class EmailContext extends YiiContext
         $user->save();
     }
 
-    /**
-     * @Given that user does NOT have a password
-     */
+    #[Given('that user does NOT have a password')]
     public function thatUserDoesNotHaveAPassword()
     {
         if ($this->tempUser !== null) {
@@ -307,18 +284,14 @@ class EmailContext extends YiiContext
         }
     }
 
-    /**
-     * @Given a second user exists with a totp mfa option
-     */
+    #[Given('a second user exists with a totp mfa option')]
     public function aSecondUserExistsWithATotpMfaOption()
     {
         $this->tempUser2 = $this->createNewUser();
         $this->createMfa(Mfa::TYPE_TOTP, null, $this->tempUser2);
     }
 
-    /**
-     * @Given a second inactive user exists with a totp mfa option
-     */
+    #[Given('a second inactive user exists with a totp mfa option')]
     public function aSecondInactiveUserExistsWithATotpMfaOption()
     {
         $this->tempUser2 = $this->createNewUser();
@@ -326,9 +299,7 @@ class EmailContext extends YiiContext
         self::deactivateUser($this->tempUser2);
     }
 
-    /**
-     * @Given a :messageType email was sent :daysAgo days ago to that user
-     */
+    #[Given('a :messageType email was sent :daysAgo days ago to that user')]
     public function anEmailWasSentXDaysAgoToThatUser(string $messageType, int $daysAgo)
     {
         if ($daysAgo < 0) {
@@ -350,9 +321,7 @@ class EmailContext extends YiiContext
         Assert::true($emailLog->save(), 'Could not save a new EmailLog for the test');
     }
 
-    /**
-     * @Given a :messageType email has been sent to that user
-     */
+    #[Given('a :messageType email has been sent to that user')]
     public function anEmailHasBeenSentToThatUser(string $messageType)
     {
         $emailLog = new EmailLog([
@@ -363,17 +332,13 @@ class EmailContext extends YiiContext
         Assert::true($emailLog->save(), 'Could not save a new EmailLog for the test');
     }
 
-    /**
-     * @Given a :messageType email has NOT been sent to that user
-     */
+    #[Given('a :messageType email has NOT been sent to that user')]
     public function anEmailHasNotBeenSentToThatUser(string $messageType)
     {
         EmailLog::deleteAll(['user_id' => $this->tempUser->id, 'message_type' => $messageType]);
     }
 
-    /**
-     * @When that user gets a password
-     */
+    #[When('that user gets a password')]
     public function thatUserGetsAPassword()
     {
         $this->setPasswordForUser(
@@ -392,9 +357,7 @@ class EmailContext extends YiiContext
         $user->scenario = $oldScenario;
     }
 
-    /**
-     * @Given that user has a password
-     */
+    #[Given('that user has a password')]
     public function thatUserHasAPassword()
     {
         $this->setPasswordForUser(
@@ -405,9 +368,7 @@ class EmailContext extends YiiContext
         Assert::notNull($this->tempUser->current_password_id);
     }
 
-    /**
-     * @When that user has non-pw changes
-     */
+    #[When('that user has non-pw changes')]
     public function thatUserHasNonPwChanges()
     {
         $this->tempUser->first_name .= ', changed ' . microtime();
@@ -417,154 +378,116 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @Given I remove records of any emails that have been sent
-     */
+    #[Given('I remove records of any emails that have been sent')]
     public function iRemoveRecordsOfAnyEmailsThatHaveBeenSent()
     {
         $this->fakeEmailer->forgetFakeEmailsSent();
         EmailLog::deleteAll();
     }
 
-    /**
-     * @Given a specific user does NOT exist
-     */
+    #[Given('a specific user does NOT exist')]
     public function aSpecificUserDoesNotExist()
     {
         $this->tempUser = null;
     }
 
-    /**
-     * @Given we are configured to send mfa option added emails
-     */
+    #[Given('we are configured to send mfa option added emails')]
     public function weAreConfiguredToSendMfaOptionAddedEmails()
     {
         $this->fakeEmailer->sendMfaOptionAddedEmails = true;
     }
 
-    /**
-     * @Given we are configured NOT to send mfa option added emails
-     */
+    #[Given('we are configured NOT to send mfa option added emails')]
     public function weAreConfiguredNotToSendMfaOptionAddedEmails()
     {
         $this->fakeEmailer->sendMfaOptionAddedEmails = false;
     }
 
-    /**
-     * @Given we are configured to send mfa enabled emails
-     */
+    #[Given('we are configured to send mfa enabled emails')]
     public function weAreConfiguredToSendMfaEnabledEmails()
     {
         $this->fakeEmailer->sendMfaEnabledEmails = true;
     }
 
-    /**
-     * @Given we are configured NOT to send mfa enabled emails
-     */
+    #[Given('we are configured NOT to send mfa enabled emails')]
     public function weAreConfiguredNotToSendMfaEnabledEmails()
     {
         $this->fakeEmailer->sendMfaEnabledEmails = false;
     }
 
-    /**
-     * @Given we are configured to send mfa option removed emails
-     */
+    #[Given('we are configured to send mfa option removed emails')]
     public function weAreConfiguredToSendMfaOptionRemovedEmails()
     {
         $this->fakeEmailer->sendMfaOptionRemovedEmails = true;
     }
 
-    /**
-     * @Given we are configured NOT to send mfa option removed emails
-     */
+    #[Given('we are configured NOT to send mfa option removed emails')]
     public function weAreConfiguredNotToSendMfaOptionRemovedEmails()
     {
         $this->fakeEmailer->sendMfaOptionRemovedEmails = false;
     }
 
-    /**
-     * @Given we are configured to send mfa disabled emails
-     */
+    #[Given('we are configured to send mfa disabled emails')]
     public function weAreConfiguredToSendMfaDisabledEmails()
     {
         $this->fakeEmailer->sendMfaDisabledEmails = true;
     }
 
-    /**
-     * @Given we are configured NOT to send mfa disabled emails
-     */
+    #[Given('we are configured NOT to send mfa disabled emails')]
     public function weAreConfiguredNotToSendMfaDisabledEmails()
     {
         $this->fakeEmailer->sendMfaDisabledEmails = false;
     }
 
-    /**
-     * @Given we are configured to send welcome emails
-     */
+    #[Given('we are configured to send welcome emails')]
     public function weAreConfiguredToSendWelcomeEmails()
     {
         $this->fakeEmailer->sendWelcomeEmails = true;
     }
 
-    /**
-     * @Given we are configured NOT to send welcome emails
-     */
+    #[Given('we are configured NOT to send welcome emails')]
     public function weAreConfiguredNotToSendWelcomeEmails()
     {
         $this->fakeEmailer->sendWelcomeEmails = false;
     }
 
-    /**
-     * @Given we are configured to send lost key emails
-     */
+    #[Given('we are configured to send lost key emails')]
     public function weAreConfiguredToSendLostKeyEmails()
     {
         $this->fakeEmailer->sendLostSecurityKeyEmails = true;
     }
 
-    /**
-     * @Given we are configured NOT to send lost key emails
-     */
+    #[Given('we are configured NOT to send lost key emails')]
     public function weAreConfiguredNotToSendLostKeyEmails()
     {
         $this->fakeEmailer->sendLostSecurityKeyEmails = false;
     }
 
-    /**
-     * @Given we are configured to send get backup codes emails
-     */
+    #[Given('we are configured to send get backup codes emails')]
     public function weAreConfiguredToSendGetBackupCodesEmails()
     {
         $this->fakeEmailer->sendGetBackupCodesEmails = true;
     }
 
-    /**
-     * @Given we are configured NOT to send get backup codes emails
-     */
+    #[Given('we are configured NOT to send get backup codes emails')]
     public function weAreConfiguredNotToSendGetBackupCodesEmails()
     {
         $this->fakeEmailer->sendGetBackupCodesEmails = false;
     }
 
-    /**
-     * @Given we are configured to send refresh backup codes emails
-     */
+    #[Given('we are configured to send refresh backup codes emails')]
     public function weAreConfiguredToSendRefreshBackupCodesEmails()
     {
         $this->fakeEmailer->sendRefreshBackupCodesEmails = true;
     }
 
-    /**
-     * @Given we are configured NOT to send refresh backup codes emails
-     */
+    #[Given('we are configured NOT to send refresh backup codes emails')]
     public function weAreConfiguredNotToSendRefreshBackupCodesEmails()
     {
         $this->fakeEmailer->sendRefreshBackupCodesEmails = false;
     }
 
-    /**
-     * @Given no mfas exist
-     */
+    #[Given('no mfas exist')]
     public function noMfasExist()
     {
         MfaBackupcode::deleteAll();
@@ -572,9 +495,7 @@ class EmailContext extends YiiContext
         Mfa::deleteAll();
     }
 
-    /**
-     * @Given :count verified webauthn mfa option does exist
-     */
+    #[Given(':count verified webauthn mfa option does exist')]
     public function aVerifiedWebAuthnMfaOptionDoesExist($count)
     {
         $this->createMfa(Mfa::TYPE_WEBAUTHN);
@@ -589,75 +510,57 @@ class EmailContext extends YiiContext
     }
 
 
-    /**
-     * @Given a verified webauthn mfa option was just deleted
-     */
+    #[Given('a verified webauthn mfa option was just deleted')]
     public function aVerifiedWebAuthnMfaOptionWasJustDeleted()
     {
         $this->testMfaOption = $this->createTempMfa(Mfa::TYPE_WEBAUTHN, 1);
         $this->mfaEventType = 'delete_mfa';
     }
 
-    /**
-     * @Given an unverified webauthn mfa option was just deleted
-     */
+    #[Given('an unverified webauthn mfa option was just deleted')]
     public function anUnverifiedWebAuthnMfaOptionWasJustDeleted()
     {
         $this->testMfaOption = $this->createTempMfa(Mfa::TYPE_WEBAUTHN, 0);
         $this->mfaEventType = 'delete_mfa';
     }
 
-    /**
-     * @Given an unverified webauthn mfa option does exist
-     */
+    #[Given('an unverified webauthn mfa option does exist')]
     public function anUnverifiedWebAuthnMfaOptionDoesExist()
     {
         $this->createMfa(Mfa::TYPE_WEBAUTHN, null, null, 0);
     }
 
-    /**
-     * @Given a (verified) webauthn mfa option does NOT Exist
-     */
+    #[Given('a (verified) webauthn mfa option does NOT Exist')]
     public function aWebAuthnMfaOptionDoesNotExist()
     {
         $this->deleteMfaOfType(Mfa::TYPE_WEBAUTHN);
     }
 
-    /**
-     * @Given a webauthn mfa option was used :arg1 days ago
-     */
+    #[Given('a webauthn mfa option was used :arg1 days ago')]
     public function aWebAuthnMfaOptionWasXUsedDaysAgo($lastUsedDaysAgo)
     {
         $this->createMfa(Mfa::TYPE_WEBAUTHN, $lastUsedDaysAgo);
     }
 
-    /**
-     * @Given a totp mfa option does exist
-     */
+    #[Given('a totp mfa option does exist')]
     public function aTotpMfaOptionDoesExist()
     {
         $this->createMfa(Mfa::TYPE_TOTP);
     }
 
-    /**
-     * @Given a totp mfa option does NOT exist
-     */
+    #[Given('a totp mfa option does NOT exist')]
     public function aTotpMfaOptionDoesNotExist()
     {
         $this->deleteMfaOfType(Mfa::TYPE_TOTP);
     }
 
-    /**
-     * @Given a totp mfa option was used :arg1 days ago
-     */
+    #[Given('a totp mfa option was used :arg1 days ago')]
     public function aTotpMfaOptionWasUsedDaysAgo($lastUsedDaysAgo)
     {
         $this->createMfa(Mfa::TYPE_TOTP, $lastUsedDaysAgo);
     }
 
-    /**
-     * @Given a backup code mfa option does exist
-     */
+    #[Given('a backup code mfa option does exist')]
     public function aBackupCodeMfaOptionDoesExist()
     {
         $results = Mfa::create($this->tempUser->id, Mfa::TYPE_BACKUPCODE);
@@ -666,17 +569,13 @@ class EmailContext extends YiiContext
         $this->tempUser->refresh();
     }
 
-    /**
-     * @Given a backup code mfa option does NOT exist
-     */
+    #[Given('a backup code mfa option does NOT exist')]
     public function aBackupCodeMfaOptionDoesNotExist()
     {
         $this->deleteMfaOfType(Mfa::TYPE_BACKUPCODE);
     }
 
-    /**
-     * @Given there are :arg1 backup codes
-     */
+    #[Given('there are :arg1 backup codes')]
     public function thereAreXBackupCodes($desiredCount)
     {
         $backupMfa = $this->getMfa(Mfa::TYPE_BACKUPCODE);
@@ -703,26 +602,20 @@ class EmailContext extends YiiContext
         Assert::eq(count($remainingCodes), $desiredCount, 'Could not ensure the desired count of backup codes.');
     }
 
-    /**
-     * @Given the latest mfa event type was :arg1
-     */
+    #[Given('the latest mfa event type was :arg1')]
     public function theLatestMfaEventTypeWas($eventType)
     {
         $this->mfaEventType = $eventType;
     }
 
 
-    /**
-     * @Given a backup code mfa option was used :arg1 days ago
-     */
+    #[Given('a backup code mfa option was used :arg1 days ago')]
     public function aBackupCodeMfaOptionWasXUsedDaysAgo($lastUsedDaysAgo)
     {
         $this->createMfa(Mfa::TYPE_BACKUPCODE, $lastUsedDaysAgo);
     }
 
-    /**
-     * @When a backup code is used up by that user
-     */
+    #[When('a backup code is used up by that user')]
     public function aBackupCodeIsUsedUpByThatUser()
     {
         $backupMfa = $this->getMfa(Mfa::TYPE_BACKUPCODE);
@@ -735,9 +628,7 @@ class EmailContext extends YiiContext
         MfaBackupcode::sendRefreshCodesMessage($backupMfa->id);
     }
 
-    /**
-     * @When I check if a mfa option added email should be sent
-     */
+    #[When('I check if a mfa option added email should be sent')]
     public function iCheckIfAMfaOptionAddedEmailShouldBeSent()
     {
         $this->tempUser->refresh();
@@ -747,9 +638,7 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @When I check if a mfa enabled email should be sent
-     */
+    #[When('I check if a mfa enabled email should be sent')]
     public function iCheckIfAMfaEnabledEmailShouldBeSent()
     {
         $this->mfaEnabledEmailShouldBeSent = $this->fakeEmailer->shouldSendMfaEnabledMessageTo(
@@ -758,9 +647,7 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @When I check if a mfa option removed email should be sent
-     */
+    #[When('I check if a mfa option removed email should be sent')]
     public function iCheckIfAMfaOptionRemovedEmailShouldBeSent()
     {
         $this->mfaOptionRemovedEmailShouldBeSent = $this->fakeEmailer->shouldSendMfaOptionRemovedMessageTo(
@@ -770,9 +657,7 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @When I check if a mfa disabled email should be sent
-     */
+    #[When('I check if a mfa disabled email should be sent')]
     public function iCheckIfAMfaDisabledEmailShouldBeSent()
     {
         $this->mfaDisabledEmailShouldBeSent = $this->fakeEmailer->shouldSendMfaDisabledMessageTo(
@@ -782,9 +667,7 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @When I check if a get backup codes email has been sent recently
-     */
+    #[When('I check if a get backup codes email has been sent recently')]
     public function iCheckIfAGetBackupCodesEmailHasBeenSentRecently()
     {
         $messageType = EmailLog::MESSAGE_TYPE_GET_BACKUP_CODES;
@@ -794,170 +677,128 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @When I check if a lost security key email should be sent
-     */
+    #[When('I check if a lost security key email should be sent')]
     public function iCheckIfALostSecurityKeyEmailShouldBeSent()
     {
         $this->lostKeyEmailShouldBeSent = $this->fakeEmailer->shouldSendLostSecurityKeyMessageTo($this->tempUser);
     }
 
-    /**
-     * @When I check if a get backup codes email should be sent
-     */
+    #[When('I check if a get backup codes email should be sent')]
     public function iCheckIfAGetBackupCodesEmailShouldBeSent()
     {
         $this->getBackupCodesEmailShouldBeSent = $this->fakeEmailer->shouldSendGetBackupCodesMessageTo($this->tempUser);
     }
 
 
-    /**
-     * @When I check if a refresh backup codes email should be sent
-     */
+    #[When('I check if a refresh backup codes email should be sent')]
     public function iCheckIfARefreshBackupCodesEmailShouldBeSent()
     {
         $this->refreshBackupCodesEmailShouldBeSent = $this->fakeEmailer->shouldSendRefreshBackupCodesMessage(count($this->tempBackupCodes));
     }
 
-    /**
-     * @When I send delayed mfa related emails
-     */
+    #[When('I send delayed mfa related emails')]
     public function iSendDelayedMfaRelatedEmails()
     {
         $this->fakeEmailer->sendDelayedMfaRelatedEmails();
     }
 
-    /**
-     * @Then I see that a mfa option added email should NOT be sent
-     */
+    #[Then('I see that a mfa option added email should NOT be sent')]
     public function iSeeThatAMfaOptionAddedEmailShouldNotBeSent()
     {
         Assert::false($this->mfaOptionAddedEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a mfa option added email should be sent
-     */
+    #[Then('I see that a mfa option added email should be sent')]
     public function iSeeThatAMfaOptionAddedEmailShouldBeSent()
     {
         Assert::true($this->mfaOptionAddedEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a mfa enabled email should NOT be sent
-     */
+    #[Then('I see that a mfa enabled email should NOT be sent')]
     public function iSeeThatAMfaEnabledEmailShouldNotBeSent()
     {
         Assert::false($this->mfaEnabledEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a mfa enabled email should be sent
-     */
+    #[Then('I see that a mfa enabled email should be sent')]
     public function iSeeThatAMfaEnabledEmailShouldBeSent()
     {
         Assert::true($this->mfaEnabledEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a mfa option removed email should NOT be sent
-     */
+    #[Then('I see that a mfa option removed email should NOT be sent')]
     public function iSeeThatAMfaOptionRemovedEmailShouldNotBeSent()
     {
         Assert::false($this->mfaOptionRemovedEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a mfa option removed email should be sent
-     */
+    #[Then('I see that a mfa option removed email should be sent')]
     public function iSeeThatAMfaOptionRemovedEmailShouldBeSent()
     {
         Assert::true($this->mfaOptionRemovedEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a mfa disabled email should NOT be sent
-     */
+    #[Then('I see that a mfa disabled email should NOT be sent')]
     public function iSeeThatAMfaDisabledEmailShouldNotBeSent()
     {
         Assert::false($this->mfaDisabledEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a mfa disabled email should be sent
-     */
+    #[Then('I see that a mfa disabled email should be sent')]
     public function iSeeThatAMfaDisabledEmailShouldBeSent()
     {
         Assert::true($this->mfaDisabledEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a get backup codes email has NOT been sent recently
-     */
+    #[Then('I see that a get backup codes email has NOT been sent recently')]
     public function iSeeThatAGetBackupCodesEmailHasNotBeSent()
     {
         Assert::false($this->getBackupCodesEmailHasBeenSent);
     }
 
-    /**
-     * @Then I see that a get backup codes email has been sent recently
-     */
+    #[Then('I see that a get backup codes email has been sent recently')]
     public function iSeeThatAGetBackupCodesEmailHasBeenSent()
     {
         Assert::true($this->getBackupCodesEmailHasBeenSent);
     }
 
-    /**
-     * @Then I see that a lost security key email should NOT be sent
-     */
+    #[Then('I see that a lost security key email should NOT be sent')]
     public function iSeeThatALostSecurityKeyEmailShouldNotBeSent()
     {
         Assert::false($this->lostKeyEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a lost security key email should be sent
-     */
+    #[Then('I see that a lost security key email should be sent')]
     public function iSeeThatALostSecurityKeyEmailShouldBeSent()
     {
         Assert::true($this->lostKeyEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a get backup codes email should NOT be sent
-     */
+    #[Then('I see that a get backup codes email should NOT be sent')]
     public function iSeeThatAGetBackupCodesEmailShouldNotBeSent()
     {
         Assert::false($this->getBackupCodesEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a get backup codes email should be sent
-     */
+    #[Then('I see that a get backup codes email should be sent')]
     public function iSeeThatAGetBackupCodesEmailShouldBeSent()
     {
         Assert::true($this->getBackupCodesEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a refresh backup codes email should NOT be sent
-     */
+    #[Then('I see that a refresh backup codes email should NOT be sent')]
     public function iSeeThatARefreshBackupCodesEmailShouldNotBeSent()
     {
         Assert::false($this->refreshBackupCodesEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that a refresh backup codes email should be sent
-     */
+    #[Then('I see that a refresh backup codes email should be sent')]
     public function iSeeThatARefreshBackupCodesEmailShouldBeSent()
     {
         Assert::true($this->refreshBackupCodesEmailShouldBeSent);
     }
 
-    /**
-     * @Then I see that the first user has received a lost-security-key email
-     */
+    #[Then('I see that the first user has received a lost-security-key email')]
     public function iSeeThatTheFirstUserHasReceivedALostSecurityKeyEmail()
     {
         Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently(
@@ -966,9 +807,7 @@ class EmailContext extends YiiContext
         ));
     }
 
-    /**
-     * @Then I see that the second user has received a get-backup-codes email
-     */
+    #[Then('I see that the second user has received a get-backup-codes email')]
     public function iSeeThatTheSecondUserHasReceivedAGetBackupCodesEmail()
     {
         Assert::true($this->fakeEmailer->hasUserReceivedMessageRecently(
@@ -977,9 +816,7 @@ class EmailContext extends YiiContext
         ));
     }
 
-    /**
-     * @Then I see that the first user has NOT received a lost-security-key email
-     */
+    #[Then('I see that the first user has NOT received a lost-security-key email')]
     public function iSeeThatTheFirstUserHasNotReceivedALostSecurityKeyEmail()
     {
         Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently(
@@ -988,9 +825,7 @@ class EmailContext extends YiiContext
         ));
     }
 
-    /**
-     * @Then I see that the second user has NOT received a get-backup-codes email
-     */
+    #[Then('I see that the second user has NOT received a get-backup-codes email')]
     public function iSeeThatTheSecondUserHasNotReceivedAGetBackupCodesEmail()
     {
         Assert::false($this->fakeEmailer->hasUserReceivedMessageRecently(
@@ -999,9 +834,7 @@ class EmailContext extends YiiContext
         ));
     }
 
-    /**
-     * @Given no methods exist
-     */
+    #[Given('no methods exist')]
     public function noMethodsExist()
     {
         Method::deleteAll();
@@ -1020,9 +853,7 @@ class EmailContext extends YiiContext
         Assert::true($method->save(), "Could not create new method.");
     }
 
-    /**
-     * @When I create a new recovery method
-     */
+    #[When('I create a new recovery method')]
     public function iCreateANewRecoveryMethod()
     {
         $this->createMethod(self::METHOD_EMAIL_ADDRESS);
@@ -1045,81 +876,61 @@ class EmailContext extends YiiContext
         Assert::contains(current($this->matchingFakeEmails)['bcc_address'], $address, 'address not on bcc line');
     }
 
-    /**
-     * @Then a Method Verify email is sent to that method
-     */
+    #[Then('a Method Verify email is sent to that method')]
     public function aMethodVerifyEmailIsSentToThatMethod()
     {
         $this->assertEmailSent(EmailLog::MESSAGE_TYPE_METHOD_VERIFY, self::METHOD_EMAIL_ADDRESS);
     }
 
-    /**
-     * @Then a Manager Rescue email is sent to the manager
-     */
+    #[Then('a Manager Rescue email is sent to the manager')]
     public function aManagerRescueEmailIsSentToTheManager()
     {
         $this->assertEmailSent(EmailLog::MESSAGE_TYPE_MFA_RECOVERY, self::MANAGER_EMAIL);
     }
 
-    /**
-     * @Then a Recovery Rescue email is sent to the recovery contact
-     */
+    #[Then('a Recovery Rescue email is sent to the recovery contact')]
     public function aRecoveryRescueEmailIsSentToTheRecoveryContact()
     {
         $this->assertEmailSent(EmailLog::MESSAGE_TYPE_MFA_RECOVERY, self::RECOVERY_EMAIL);
     }
 
-    /**
-     * @Given an unverified method exists
-     */
+    #[Given('an unverified method exists')]
     public function anUnverifiedMethodExists()
     {
         $this->createMethod(self::METHOD_EMAIL_ADDRESS);
     }
 
-    /**
-     * @When I request that the verify email is resent
-     */
+    #[When('I request that the verify email is resent')]
     public function iRequestThatTheVerifyEmailIsResent()
     {
         $this->testMethod->sendVerification();
     }
 
-    /**
-     * @When I request a new manager mfa
-     */
+    #[When('I request a new manager mfa')]
     public function iRequestANewManagerMfa()
     {
         Mfa::create($this->tempUser->id, Mfa::TYPE_MANAGER, label: 'label');
     }
 
-    /**
-     * @When I request a new recovery mfa
-     */
+    #[When('I request a new recovery mfa')]
     public function iRequestANewRecoveryMfa()
     {
         Mfa::create($this->tempUser->id, Mfa::TYPE_RECOVERY, 'label', '', self::RECOVERY_EMAIL);
     }
 
-    /**
-     * @Then that email should have been copied to the personal email address
-     */
+    #[Then('that email should have been copied to the personal email address')]
     public function thatEmailShouldHaveBeenCopiedToThePersonalEmailAddress()
     {
         Assert::eq($this->matchingFakeEmails[0]['cc_address'], $this->tempUser->personal_email);
     }
 
-    /**
-     * @Given /^we are configured (NOT to|to) send recovery method reminder emails$/
-     */
+    #[Given('/^we are configured (NOT to|to) send recovery method reminder emails$/')]
     public function weAreConfiguredToSendRecoveryMethodReminderEmails($sendOrNot)
     {
         $this->fakeEmailer->sendMethodReminderEmails = ($sendOrNot === 'to');
     }
 
-    /**
-     * @Given a recovery method was created :n days ago
-     */
+    #[Given('a recovery method was created :n days ago')]
     public function aRecoveryMethodWasCreatedDaysAgo($n)
     {
         $method = Method::findOrCreate($this->tempUser->id, 'email@example.com');
@@ -1131,17 +942,13 @@ class EmailContext extends YiiContext
         Assert::true($method->save(), "Could not create new method.");
     }
 
-    /**
-     * @When I send recovery method reminder emails
-     */
+    #[When('I send recovery method reminder emails')]
     public function iSendRecoveryMethodReminderEmails()
     {
         $this->fakeEmailer->sendMethodReminderEmails();
     }
 
-    /**
-     * @Then /^I see that a recovery method reminder (has|has NOT) been sent$/
-     */
+    #[Then('/^I see that a recovery method reminder (has|has NOT) been sent$/')]
     public function iSeeThatARecoveryMethodReminderHasNotBeenSent($hasOrHasNot)
     {
         $hasBeenSent = $this->fakeEmailer->hasUserReceivedMessageRecently(
@@ -1156,25 +963,19 @@ class EmailContext extends YiiContext
         }
     }
 
-    /**
-     * @Given /^we are configured (NOT to|to) send password expiring emails$/
-     */
+    #[Given('/^we are configured (NOT to|to) send password expiring emails$/')]
     public function weAreConfiguredToSendPasswordExpiringEmails($sendOrNot)
     {
         $this->fakeEmailer->sendPasswordExpiringEmails = ($sendOrNot === 'to');
     }
 
-    /**
-     * @When I send password expiring emails
-     */
+    #[When('I send password expiring emails')]
     public function iSendPasswordExpiringEmails()
     {
         $this->fakeEmailer->sendPasswordExpiringEmails();
     }
 
-    /**
-     * @Given that user has a password that expires in :n days
-     */
+    #[Given('that user has a password that expires in :n days')]
     public function thatUserHasAPasswordThatExpiresInDays($n)
     {
         $this->setPasswordForUser(
@@ -1194,49 +995,37 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @Given /^we are configured (NOT to|to) send password expired emails$/
-     */
+    #[Given('/^we are configured (NOT to|to) send password expired emails$/')]
     public function weAreConfiguredToSendPasswordExpiredEmails($sendOrNot)
     {
         $this->fakeEmailer->sendPasswordExpiredEmails = ($sendOrNot === 'to');
     }
 
-    /**
-     * @When I send password expired emails
-     */
+    #[When('I send password expired emails')]
     public function iSendPasswordExpiredEmails()
     {
         $this->fakeEmailer->sendPasswordExpiredEmails();
     }
 
-    /**
-     * @Given a :param email address is configured
-     */
+    #[Given('a :param email address is configured')]
     public function aParamEmailAddressIsConfigured(string $param)
     {
         \Yii::$app->params[$param] = 'email@example.com';
     }
 
-    /**
-     * @Then the :param email address is on the bcc line
-     */
+    #[Then('the :param email address is on the bcc line')]
     public function theParamEmailAddressIsOnTheBccLine(string $param)
     {
         $this->assertEmailBcc(\Yii::$app->params[$param]);
     }
 
-    /**
-     * @Given /^hr notification email (is|is NOT) set$/
-     */
+    #[Given('/^hr notification email (is|is NOT) set$/')]
     public function hrNotificationEmailIsOrIsNotSet($isOrIsNot)
     {
         $this->fakeEmailer->hrNotificationsEmail = ($isOrIsNot === 'is') ? "hr@example.com" : "";
     }
 
-    /**
-     * @Given the user has not logged in for :months
-     */
+    #[Given('the user has not logged in for :months')]
     public function theUserHasNotLoggedInFor($months)
     {
         $date = MySqlDateTime::relative("-" . $months);
@@ -1247,17 +1036,13 @@ class EmailContext extends YiiContext
         $this->tempUser->save();
     }
 
-    /**
-     * @When I send abandoned user email (again)
-     */
+    #[When('I send abandoned user email (again)')]
     public function iSendAbandonedUserEmail()
     {
         $this->fakeEmailer->sendAbandonedUsersEmail();
     }
 
-    /**
-     * @Then /^the abandoned user email (has|has NOT) been sent$/
-     */
+    #[Then('/^the abandoned user email (has|has NOT) been sent$/')]
     public function theAbandonedUserEmailHasOrHasNotBeenSent($hasOrHasNot)
     {
         $numberSent = $this->countEmailsSent(EmailLog::MESSAGE_TYPE_ABANDONED_USERS);
@@ -1284,9 +1069,7 @@ class EmailContext extends YiiContext
         return $actualCount;
     }
 
-    /**
-     * @Given the database has been purged
-     */
+    #[Given('the database has been purged')]
     public function theDatabaseHasBeenPurged()
     {
         MfaBackupcode::deleteAll();
@@ -1298,18 +1081,14 @@ class EmailContext extends YiiContext
         $this->fakeEmailer->forgetFakeEmailsSent();
     }
 
-    /**
-     * @Then the abandoned user email has been sent :expectedCount time(s)
-     */
+    #[Then('the abandoned user email has been sent :expectedCount time(s)')]
     public function theAbandonedUserEmailHasBeenSentTime($expectedCount)
     {
         $actualCount = $this->countEmailsSent(EmailLog::MESSAGE_TYPE_ABANDONED_USERS);
         Assert::eq($actualCount, $expectedCount);
     }
 
-    /**
-     * @Given I send an external-groups sync-error email (again)
-     */
+    #[Given('I send an external-groups sync-error email (again)')]
     public function iSendAnExternalGroupsSyncErrorEmail()
     {
         $this->fakeEmailer->sendExternalGroupSyncErrorsEmail(
@@ -1320,9 +1099,7 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @Then the external-groups sync-error email has been sent :expectedCount time(s)
-     */
+    #[Then('the external-groups sync-error email has been sent :expectedCount time(s)')]
     public function theExternalGroupsSyncErrorEmailHasBeenSentTime($expectedCount)
     {
         // The $appPrefix is needed by the FakeEmailer, to find the appropriate
@@ -1335,9 +1112,7 @@ class EmailContext extends YiiContext
         Assert::eq($actualCount, $expectedCount);
     }
 
-    /**
-     * @When I try to log an email as sent to that User and to a non-user address
-     */
+    #[When('I try to log an email as sent to that User and to a non-user address')]
     public function iTryToLogAnEmailAsSentToThatUserAndToANonUserAddress()
     {
         $this->tempEmailLog = new EmailLog([
@@ -1348,9 +1123,7 @@ class EmailContext extends YiiContext
         $this->tempEmailLog->save();
     }
 
-    /**
-     * @Then an email log validation error should have occurred
-     */
+    #[Then('an email log validation error should have occurred')]
     public function anEmailLogValidationErrorShouldHaveOccurred()
     {
         Assert::notEmpty(
@@ -1359,9 +1132,7 @@ class EmailContext extends YiiContext
         );
     }
 
-    /**
-     * @When I try to log an email as sent to neither a User nor a non-user address
-     */
+    #[When('I try to log an email as sent to neither a User nor a non-user address')]
     public function iTryToLogAnEmailAsSentToNeitherAUserNorANonUserAddress()
     {
         $this->tempEmailLog = new EmailLog([
@@ -1370,9 +1141,7 @@ class EmailContext extends YiiContext
         $this->tempEmailLog->save();
     }
 
-    /**
-     * @Given I sent an external-groups sync-error email :numberOfHours hour(s) ago
-     */
+    #[Given('I sent an external-groups sync-error email :numberOfHours hour(s) ago')]
     public function iSentAnExternalGroupsSyncErrorEmailHourAgo($numberOfHours)
     {
         $this->iSendAnExternalGroupsSyncErrorEmail();

--- a/app/features/bootstrap/FeatureContext.php
+++ b/app/features/bootstrap/FeatureContext.php
@@ -1,6 +1,11 @@
 <?php
 
 use Behat\Gherkin\Node\TableNode;
+use Behat\Hook\AfterSuite;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+use Behat\Transformation\Transform;
 use common\helpers\MySqlDateTime;
 use common\models\EmailLog;
 use common\models\Invite;
@@ -49,9 +54,7 @@ class FeatureContext extends YiiContext
     public const RETRIEVED = 'retrieved';
     public const UPDATED = 'updated';
 
-    /**
-     * @Given I add a user with a(n) :property of :value
-     */
+    #[Given('I add a user with a(n) :property of :value')]
     public function iAddAUserWithAnOf($property, $value)
     {
         $sampleUserData = [
@@ -77,17 +80,13 @@ class FeatureContext extends YiiContext
         $this->theResponseStatusCodeShouldBe(200);
     }
 
-    /**
-     * @Then I should receive :numRecords record(s)
-     */
+    #[Then('I should receive :numRecords record(s)')]
     public function iShouldReceiveRecords($numRecords)
     {
         $this->iShouldReceiveUsers($numRecords);
     }
 
-    /**
-     * @Then that record should have a data item with the following elements:
-     */
+    #[Then('that record should have a data item with the following elements:')]
     public function thatRecordShouldHaveADataItemWithTheFollowingElements(TableNode $table)
     {
         Assert::minCount($this->resBody, 1);
@@ -107,18 +106,14 @@ class FeatureContext extends YiiContext
         }
     }
 
-    /**
-     * @Given the requester is not authorized
-     */
+    #[Given('the requester is not authorized')]
     public function theRequesterIsNotAuthorized()
     {
         unset($this->reqHeaders['Authorization']);
     }
 
-    /**
-     * @Given the user store is empty
-     * @AfterSuite @database
-     */
+    #[Given('the user store is empty')]
+    #[AfterSuite('@database')]
     public static function theUserStoreIsEmpty()
     {
         // To avoid calls to try to remove TOTP/WebAuthn entries from their
@@ -135,9 +130,7 @@ class FeatureContext extends YiiContext
         User::deleteAll();
     }
 
-    /**
-     * @When /^I request "(.*)" be <?(created|updated|deleted|retrieved|headed|patched)>?$/
-     */
+    #[When('/^I request "(.*)" be <?(created|updated|deleted|retrieved|headed|patched)>?$/')]
     public function iRequestTheResourceBe($resource, $action)
     {
         $client = $this->buildClient();
@@ -165,7 +158,7 @@ class FeatureContext extends YiiContext
 
     public function callU2fSimulator($resource, $action, User $user, string $externalId)
     {
-        $webConfig = Yii::$app->components['webauthn'];
+        $webConfig = \Yii::$app->components['webauthn'];
 
         $this->reqHeaders = array_merge($this->reqHeaders, [
             'x-mfa-RPID' => $webConfig['rpId'],
@@ -212,9 +205,7 @@ class FeatureContext extends YiiContext
         }
     }
 
-    /**
-     * @When I send a :verb to :resource with a valid uid
-     */
+    #[When('I send a :verb to :resource with a valid uid')]
     public function iSendAToWithAValidUid($verb, $resource)
     {
         $client = $this->buildClient();
@@ -236,9 +227,7 @@ class FeatureContext extends YiiContext
         return Json::decode($jsonBlob) ?? [];
     }
 
-    /**
-     * @Then the response status code should be :statusCode
-     */
+    #[Then('the response status code should be :statusCode')]
     public function theResponseStatusCodeShouldBe($statusCode)
     {
         Assert::eq(
@@ -252,9 +241,7 @@ class FeatureContext extends YiiContext
         );
     }
 
-    /**
-     * @Then the response body should contain :containsText
-     */
+    #[Then('the response body should contain :containsText')]
     public function theResponseBodyShouldContain($containsText)
     {
         Assert::contains(
@@ -268,9 +255,7 @@ class FeatureContext extends YiiContext
         );
     }
 
-    /**
-     * @Then the response body should not contain :notContainsText
-     */
+    #[Then('the response body should not contain :notContainsText')]
     public function theResponseBodyShouldNotContain($notContainsText)
     {
         Assert::notContains(
@@ -284,26 +269,20 @@ class FeatureContext extends YiiContext
         );
     }
 
-    /**
-     * @Then /^the property (\w+) should contain "(.*)"$/
-     */
+    #[Then('/^the property (\w+) should contain "(.*)"$/')]
     public function thePropertyShouldContain($property, $contents)
     {
         empty($contents) ? Assert::eq($this->resBody[$property], "")
                          : Assert::contains($this->resBody[$property], $contents);
     }
 
-    /**
-     * @Then the user store is still empty
-     */
+    #[Then('the user store is still empty')]
     public function thereAreStillNoUsers()
     {
         Assert::isEmpty(User::find()->all());
     }
 
-    /**
-     * @Given the requester is authorized
-     */
+    #[Given('the requester is authorized')]
     public function theRequesterIsAuthorized()
     {
         $keys = Env::requireArray('API_ACCESS_KEYS');
@@ -311,57 +290,43 @@ class FeatureContext extends YiiContext
         $this->reqHeaders['Authorization'] = 'Bearer ' . $keys[0];
     }
 
-    /**
-     * @Given /^then I remove the (.*)$/
-     */
+    #[Given('/^then I remove the (.*)$/')]
     public function thenIRemoveThe($property)
     {
         unset($this->reqBody[$property]);
     }
 
-    /**
-     * @Given /^I provide an invalid (.*) of "?([^"]*)"?$/
-     */
+    #[Given('/^I provide an invalid (.*) of "?([^"]*)"?$/')]
     public function iProvideAnInvalidPropertyValue($property, $value)
     {
         $this->reqBody[$property] = $value;
     }
 
-    /**
-     * @Transform /^(true|false)$/
-     */
+    #[Transform('/^(true|false)$/')]
     public function transformBool($string)
     {
         return boolval($string);
     }
 
-    /**
-     * @Transform /^null$/
-     */
+    #[Transform('/^null$/')]
     public function transformNull()
     {
         return null;
     }
 
-    /**
-     * @Given /^I provide (?:a|an) (.*) that is too long$/
-     */
+    #[Given('/^I provide (?:a|an) (.*) that is too long$/')]
     public function iProvideAPropertyThatIsTooLong($property)
     {
         $this->reqBody[$property] = str_repeat("z", 256);
     }
 
-    /**
-     * @Given /^a record does not exist with (?:a|an) (.*) of "?([^"]*)"?$/
-     */
+    #[Given('/^a record does not exist with (?:a|an) (.*) of "?([^"]*)"?$/')]
     public function aUserDoesNotExist($property, $value)
     {
         User::deleteAll([$property => $value]);
     }
 
-    /**
-     * @Given I provide the following (valid) data:
-     */
+    #[Given('I provide the following (valid) data:')]
     public function iProvideTheFollowingValidData(TableNode $data)
     {
         foreach ($data as $row) {
@@ -369,9 +334,7 @@ class FeatureContext extends YiiContext
         }
     }
 
-    /**
-     * @Then the following data is returned:
-     */
+    #[Then('the following data is returned:')]
     public function theFollowingDataIsReturned(TableNode $data)
     {
         foreach ($data as $row) {
@@ -399,9 +362,7 @@ class FeatureContext extends YiiContext
     }
 
 
-    /**
-     * @Given the following data is not returned:
-     */
+    #[Given('the following data is not returned:')]
     public function theFollowingDataIsNotReturned(TableNode $data)
     {
         foreach ($data as $row) {
@@ -409,9 +370,7 @@ class FeatureContext extends YiiContext
         }
     }
 
-    /**
-     * @Then /^a record exists with (?:a|an) (.*) of "?([^"]*)"?$/
-     */
+    #[Then('/^a record exists with (?:a|an) (.*) of "?([^"]*)"?$/')]
     public function aRecordExistsForThisKey($lookupKey, $lookupValue)
     {
         $this->userFromDbBefore = $this->userFromDb;
@@ -425,9 +384,7 @@ class FeatureContext extends YiiContext
         ));
     }
 
-    /**
-     * @Then the following data should be stored:
-     */
+    #[Then('the following data should be stored:')]
     public function theFollowingDataIsStored(TableNode $data)
     {
         foreach ($data as $row) {
@@ -445,12 +402,11 @@ class FeatureContext extends YiiContext
     }
 
     /**
-     * @Then :property should be stored as now UTC
-     *
      * The time between the request being made and that data being stored might have
      * some latency so "now" may not be the same in every circumstance, therefore a
      * range of acceptable time will be used to determine accuracy.
      */
+    #[Then(':property should be stored as now UTC')]
     public function shouldBeStoredAsNowUTC($property)
     {
         $expectedNow = strtotime($this->now);
@@ -463,10 +419,7 @@ class FeatureContext extends YiiContext
         Assert::range($storedNow, $minAcceptable, $maxAcceptable, "Stored time $storedNow is not within acceptable range of $minAcceptable to $maxAcceptable");
     }
 
-    /**
-     * @Then :property should not change
-     *
-     */
+    #[Then(':property should not change')]
     public function shouldNotChange($property)
     {
         $valueBefore = $this->userFromDbBefore->$property;
@@ -475,9 +428,7 @@ class FeatureContext extends YiiContext
         Assert::eq($valueBefore, $valueNow);
     }
 
-    /**
-     * @When I request :resource be created again
-     */
+    #[When('I request :resource be created again')]
     public function iRequestTheResourceBeCreatedAgain($resource)
     {
         $this->userFromDbBefore = $this->userFromDb;
@@ -487,9 +438,7 @@ class FeatureContext extends YiiContext
         $this->iRequestTheResourceBe($resource, self::CREATED);
     }
 
-    /**
-     * @Then the only property to change should be :property
-     */
+    #[Then('the only property to change should be :property')]
     public function theOnlyPropertyToChangeShouldBe($property)
     {
         foreach ($this->userFromDbBefore->attributes as $name => $value) {
@@ -501,25 +450,19 @@ class FeatureContext extends YiiContext
         }
     }
 
-    /**
-     * @Given /^I change the (\w*) to (.*)$/
-     */
+    #[Given('/^I change the (\w*) to (.*)$/')]
     public function iChangeThe($property, $value)
     {
         $this->reqBody[$property] = $value;
     }
 
-    /**
-     * @Given :property1 and :property2 are the same
-     */
+    #[Given(':property1 and :property2 are the same')]
     public function propertiesAreTheSame($property1, $property2)
     {
         Assert::eq($this->userFromDb->$property1, $this->userFromDb->$property2);
     }
 
-    /**
-     * @Given the user has a password of :password
-     */
+    #[Given('the user has a password of :password')]
     public function theUserHasAPasswordOf($password)
     {
         $this->userFromDb->scenario = User::SCENARIO_UPDATE_PASSWORD;
@@ -529,9 +472,7 @@ class FeatureContext extends YiiContext
         Assert::true($this->userFromDb->save());
     }
 
-    /**
-     * @Then /^a record still exists with (?:a|an) (.*) of "?([^"]*)"?$/
-     */
+    #[Then('/^a record still exists with (?:a|an) (.*) of "?([^"]*)"?$/')]
     public function aRecordStillExistsForThisKey($lookupKey, $lookupValue)
     {
         $this->userFromDbBefore = $this->userFromDb;
@@ -539,9 +480,7 @@ class FeatureContext extends YiiContext
         $this->aRecordExistsForThisKey($lookupKey, $lookupValue);
     }
 
-    /**
-     * @Then none of the data has changed
-     */
+    #[Then('none of the data has changed')]
     public function noneOfTheDataHasChanged()
     {
         foreach ($this->userFromDbBefore->attributes as $name => $value) {
@@ -552,18 +491,14 @@ class FeatureContext extends YiiContext
         }
     }
 
-    /**
-     * @Then the authentication is not successful
-     */
+    #[Then('the authentication is not successful')]
     public function theAuthenticationIsNotSuccessful()
     {
         $this->theResponseStatusCodeShouldBe(400);
         $this->thePropertyShouldContain("message", "");
     }
 
-    /**
-     * @Given /^the (.*) is stored as (.*)$/
-     */
+    #[Given('/^the (.*) is stored as (.*)$/')]
     public function thePropertyIsStoredAs($property, $value)
     {
         $this->userFromDb->$property = $value;
@@ -572,17 +507,13 @@ class FeatureContext extends YiiContext
         Assert::true($this->userFromDb->save());
     }
 
-    /**
-     * @Given /^I should receive (\d+) users$/
-     */
+    #[Given('/^I should receive (\d+) users$/')]
     public function iShouldReceiveUsers($numOfUsers)
     {
         Assert::count($this->resBody, $numOfUsers);
     }
 
-    /**
-     * @Given the user :username has no password in the database
-     */
+    #[Given('the user :username has no password in the database')]
     public function theUserHasNoPasswordInTheDatabase($username)
     {
         $user = User::findByUsername($username);
@@ -594,9 +525,7 @@ class FeatureContext extends YiiContext
         Password::deleteAll(['user_id' => $user->id]);
     }
 
-    /**
-     * @Given the user :username does have a password in the database
-     */
+    #[Given('the user :username does have a password in the database')]
     public function theUserDoesHaveAPasswordInTheDatabase($username)
     {
         $user = User::findByUsername($username);
@@ -616,9 +545,7 @@ class FeatureContext extends YiiContext
         );
     }
 
-    /**
-     * @Given the user :username has an expired invite code :code
-     */
+    #[Given('the user :username has an expired invite code :code')]
     public function theUserHasAnExpiredInviteCode($username, $code)
     {
         $user = User::findByUsername($username);
@@ -627,9 +554,7 @@ class FeatureContext extends YiiContext
         $this->createInviteCode($user, $code, true);
     }
 
-    /**
-     * @Given the user :username has a non-expired invite code :code
-     */
+    #[Given('the user :username has a non-expired invite code :code')]
     public function theUserHasANonExpiredInviteCode($username, $code)
     {
         $user = User::findByUsername($username);
@@ -638,17 +563,13 @@ class FeatureContext extends YiiContext
         $this->createInviteCode($user, $code);
     }
 
-    /**
-     * @Given I do not provide an employee_id
-     */
+    #[Given('I do not provide an employee_id')]
     public function iDoNotProvideAnEmployeeId()
     {
         unset($this->reqBody['employee_id']);
     }
 
-    /**
-     * @Given the response should contain a :key array with :num items
-     */
+    #[Given('the response should contain a :key array with :num items')]
     public function theResponseShouldContainAArrayWithItems($key, $num)
     {
         Assert::keyExists($this->resBody, $key);
@@ -691,9 +612,7 @@ class FeatureContext extends YiiContext
         return $this->resBody;
     }
 
-    /**
-     * @Then /^a method record exists with (?:a|an) (.*) of "?([^"]*)"?$/
-     */
+    #[Then('/^a method record exists with (?:a|an) (.*) of "?([^"]*)"?$/')]
     public function aMethodRecordExistsForThisKey($lookupKey, $lookupValue)
     {
         $this->methodFromDb = Method::findOne([$lookupKey => $lookupValue]);
@@ -705,9 +624,7 @@ class FeatureContext extends YiiContext
         ));
     }
 
-    /**
-     * @Then a method record exists with a value of :address text to change signature
-     */
+    #[Then('a method record exists with a value of :address text to change signature')]
     public function aMethodRecordExistsForEmployeeIdWithAValueOf($address)
     {
         $this->methodFromDb = Method::findOne(['value' => $address, 'user_id' => $this->userFromDb->id]);
@@ -719,17 +636,13 @@ class FeatureContext extends YiiContext
     }
 
 
-    /**
-     * @Then the method record is marked as verified
-     */
+    #[Then('the method record is marked as verified')]
     public function theMethodRecordIsMarkedAsVerified()
     {
         Assert::eq(1, $this->methodFromDb->verified, 'method is not marked as verified');
     }
 
-    /**
-     * @Then a method record does not exist with a value of :address
-     */
+    #[Then('a method record does not exist with a value of :address')]
     public function aMethodRecordDoesNotExistForEmployeeIdWithAValueOf($address)
     {
         Assert::null(
@@ -738,18 +651,14 @@ class FeatureContext extends YiiContext
         );
     }
 
-    /**
-     * @Then the profile review date should be past
-     */
+    #[Then('the profile review date should be past')]
     public function theProfileReviewDateShouldBePast()
     {
         $this->userFromDb->refresh();
         Assert::true(MySqlDateTime::isBefore($this->userFromDb->review_profile_after, time()));
     }
 
-    /**
-     * @Given the user record for :username has expired
-     */
+    #[Given('the user record for :username has expired')]
     public function theUserRecordForHasExpired($username)
     {
         $user = User::findByUsername($username);
@@ -758,17 +667,13 @@ class FeatureContext extends YiiContext
         Assert::true($user->save());
     }
 
-    /**
-     * @Given there is a :username user in the database
-     */
+    #[Given('there is a :username user in the database')]
     public function thereIsAUserInTheDatabase($username)
     {
         $this->userFromDb = User::findOne(['username' => $username]);
     }
 
-    /**
-     * @Given that user has a :field in the :tense
-     */
+    #[Given('that user has a :field in the :tense')]
     public function thatUserHasAFieldInTheTense($field, $tense)
     {
         $relativeTimes = [
@@ -781,9 +686,7 @@ class FeatureContext extends YiiContext
         Assert::true($this->userFromDb->save());
     }
 
-    /**
-     * @Given I create the following users:
-     */
+    #[Given('I create the following users:')]
     public function iCreateTheFollowingUsers(TableNode $data)
     {
         $dataArray = $data->getColumnsHash();
@@ -792,26 +695,20 @@ class FeatureContext extends YiiContext
             $this->iRequestTheResourceBe('/user', self::CREATED);
         }
     }
-    /**
-     * @Given I provide a(n) :field query property of :value
-     */
+    #[Given('I provide a(n) :field query property of :value')]
     public function iProvideAFieldQueryPropertyOfValue($field, $value)
     {
         $this->queryParams[$field] = $value;
     }
 
-    /**
-     * @When I search by :field
-     */
+    #[When('I search by :field')]
     public function iSearchByField($field)
     {
         $request = '/user?' . $field . '=' . $this->queryParams[$field];
         $this->iRequestTheResourceBe($request, self::RETRIEVED);
     }
 
-    /**
-     * @Then user :employeeId is returned
-     */
+    #[Then('user :employeeId is returned')]
     public function userIsReturned($employeeId)
     {
         $found = false;
@@ -824,17 +721,13 @@ class FeatureContext extends YiiContext
         Assert::true($found, 'user ' . $employeeId . ' was not returned');
     }
 
-    /**
-     * @Then no users are returned
-     */
+    #[Then('no users are returned')]
     public function noUsersAreReturned()
     {
         Assert::eq(count($this->resBody), 0, 'response is not empty');
     }
 
-    /**
-     * @Given the response should contain a :key array with only these elements:
-     */
+    #[Given('the response should contain a :key array with only these elements:')]
     public function theResponseShouldContainAMemberArrayWithOnlyTheseElements($key, TableNode $data)
     {
         $property = $this->resBody[$key];
@@ -853,9 +746,7 @@ class FeatureContext extends YiiContext
     }
 
 
-    /**
-     * @Then the uuid property should be a valid UUID
-     */
+    #[Then('the uuid property should be a valid UUID')]
     public function theUuidPropertyShouldBeAValidUuid()
     {
         Assert::regex(
@@ -864,9 +755,7 @@ class FeatureContext extends YiiContext
         );
     }
 
-    /**
-     * @Given I wait until after the user :username expiration date
-     */
+    #[Given('I wait until after the user :username expiration date')]
     public function iWaitUntilAfterTheUserExpirationDate($username)
     {
         $this->userFromDb = User::findOne(['username' => $username]);
@@ -876,36 +765,28 @@ class FeatureContext extends YiiContext
         $this->userFromDb->save();
     }
 
-    /**
-     * @Given The user's current password should not be marked as pwned
-     */
+    #[Given("The user's current password should not be marked as pwned")]
     public function theUserSCurrentPasswordShouldNotBeMarkedAsPwned()
     {
         $user = User::findOne(['username' => $this->reqBody['username']]);
         Assert::eq($user->currentPassword->hibp_is_pwned, "no");
     }
 
-    /**
-     * @Given The user's current password should be marked as pwned
-     */
+    #[Given("The user's current password should be marked as pwned")]
     public function theUserSCurrentPasswordShouldBeMarkedAsPwned()
     {
         $user = User::findOne(['username' => $this->reqBody['username']]);
         Assert::eq($user->currentPassword->hibp_is_pwned, "yes");
     }
 
-    /**
-     * @Given The user's password is not expired
-     */
+    #[Given("The user's password is not expired")]
     public function theUserSPasswordIsNotExpired()
     {
         $user = User::findOne(['username' => $this->reqBody['username']]);
         Assert::greaterThanEq(strtotime($user->currentPassword->expires_on), time());
     }
 
-    /**
-     * @Given The user's password is expired
-     */
+    #[Given("The user's password is expired")]
     public function theUserSPasswordIsExpired()
     {
         $user = User::findOne(['username' => $this->reqBody['username']]);

--- a/app/features/bootstrap/GroupsExternalContext.php
+++ b/app/features/bootstrap/GroupsExternalContext.php
@@ -3,6 +3,8 @@
 namespace Sil\SilIdBroker\Behat\Context;
 
 use Behat\Gherkin\Node\TableNode;
+use Behat\Step\Given;
+use Behat\Step\When;
 use common\models\User;
 use FeatureContext;
 use Webmozart\Assert\Assert;
@@ -13,9 +15,7 @@ class GroupsExternalContext extends FeatureContext
     private string $userEmailAddress = 'john_smith@example.org';
     private string $userPassword = 'dummy-password-#1';
 
-    /**
-     * @Given a user exists
-     */
+    #[Given('a user exists')]
     public function aUserExists()
     {
         $this->deleteTestUser($this->userEmailAddress);
@@ -88,9 +88,7 @@ class GroupsExternalContext extends FeatureContext
         return $this->userEmailAddress;
     }
 
-    /**
-     * @Given that user's list of groups is :commaSeparatedGroups
-     */
+    #[Given("that user's list of groups is :commaSeparatedGroups")]
     public function thatUsersListOfGroupsIs($commaSeparatedGroups)
     {
         $this->user->groups = $commaSeparatedGroups;
@@ -103,9 +101,7 @@ class GroupsExternalContext extends FeatureContext
         ));
     }
 
-    /**
-     * @Given that user's list of external groups is :commaSeparatedExternalGroups
-     */
+    #[Given("that user's list of external groups is :commaSeparatedExternalGroups")]
     public function thatUsersListOfExternalGroupsIs($commaSeparatedExternalGroups)
     {
         $this->user->groups_external = $commaSeparatedExternalGroups;
@@ -118,9 +114,7 @@ class GroupsExternalContext extends FeatureContext
         ));
     }
 
-    /**
-     * @When I sign in as that user
-     */
+    #[When('I sign in as that user')]
     public function iSignInAsThatUser()
     {
         $dataForTableNode = [

--- a/app/features/bootstrap/GroupsExternalSyncContext.php
+++ b/app/features/bootstrap/GroupsExternalSyncContext.php
@@ -8,6 +8,9 @@ use common\models\EmailLog;
 use common\models\User;
 use Sil\PhpEnv\Env;
 use Webmozart\Assert\Assert;
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 
 class GroupsExternalSyncContext extends GroupsExternalContext
 {
@@ -29,9 +32,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
     /** @var string[] */
     private array $syncErrors;
 
-    /**
-     * @Given the following users exist, with these external groups:
-     */
+    #[Given('the following users exist, with these external groups:')]
     public function theFollowingUsersExistWithTheseExternalGroups(TableNode $table)
     {
         $dummyEmployeeId = 11110;
@@ -49,9 +50,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         }
     }
 
-    /**
-     * @Given the :appPrefix external groups list is the following:
-     */
+    #[Given('the :appPrefix external groups list is the following:')]
     public function theExternalGroupsListIsTheFollowing(string $appPrefix, TableNode $table)
     {
         $userGroupsMap = [];
@@ -63,9 +62,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         $this->externalGroupsLists[$appPrefix] = $userGroupsMap;
     }
 
-    /**
-     * @When I sync the list of :appPrefix external groups
-     */
+    #[When('I sync the list of :appPrefix external groups')]
     public function iSyncTheListOfExternalGroups($appPrefix)
     {
         $this->syncErrors = ExternalGroupsSync::processUpdates(
@@ -76,9 +73,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         );
     }
 
-    /**
-     * @Then there should not have been any sync errors
-     */
+    #[Then('there should not have been any sync errors')]
     public function thereShouldNotHaveBeenAnySyncErrors()
     {
         Assert::isEmpty($this->syncErrors, sprintf(
@@ -87,9 +82,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         ));
     }
 
-    /**
-     * @Then the following users should have the following external groups:
-     */
+    #[Then('the following users should have the following external groups:')]
     public function theFollowingUsersShouldHaveTheFollowingExternalGroups(TableNode $table)
     {
         foreach ($table as $row) {
@@ -110,9 +103,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         }
     }
 
-    /**
-     * @Then there should have been a sync error
-     */
+    #[Then('there should have been a sync error')]
     public function thereShouldHaveBeenASyncError()
     {
         Assert::notEmpty(
@@ -124,9 +115,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         }
     }
 
-    /**
-     * @Then there should have been a sync error that mentions :text
-     */
+    #[Then('there should have been a sync error that mentions :text')]
     public function thereShouldHaveBeenASyncErrorThatMentions($text)
     {
         $foundMatch = false;
@@ -142,9 +131,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         ));
     }
 
-    /**
-     * @Given only the following users exist, with these external groups:
-     */
+    #[Given('only the following users exist, with these external groups:')]
     public function onlyTheFollowingUsersExistWithTheseExternalGroups(TableNode $table)
     {
         Assert::inArray(
@@ -166,9 +153,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         }
     }
 
-    /**
-     * @Then we should have sent exactly :expectedCount :appPrefix sync-error notification email
-     */
+    #[Then('we should have sent exactly :expectedCount :appPrefix sync-error notification email')]
     public function weShouldHaveSentExactlySyncErrorNotificationEmail($expectedCount, $appPrefix)
     {
         $fakeEmailer = $this->fakeEmailer;
@@ -190,9 +175,7 @@ class GroupsExternalSyncContext extends GroupsExternalContext
         ));
     }
 
-    /**
-     * @Given we have provided an error-notifications email address
-     */
+    #[Given('we have provided an error-notifications email address')]
     public function weHaveProvidedAnErrorNotificationsEmailAddress()
     {
         $this->errorsEmailRecipient = 'sync-errors@example.com';

--- a/app/features/bootstrap/HibpUnitTestsContext.php
+++ b/app/features/bootstrap/HibpUnitTestsContext.php
@@ -2,6 +2,9 @@
 
 namespace Sil\SilIdBroker\Behat\Context;
 
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 use common\components\HIBP;
 use Webmozart\Assert\Assert;
 
@@ -11,66 +14,50 @@ class HibpUnitTestsContext extends UnitTestsContext
     public $hashes;
     public $isPwned;
 
-    /**
-     * @Given I have a :password
-     */
+    #[Given('I have a :password')]
     public function iHaveAPass($password)
     {
         $this->password = $password;
     }
 
-    /**
-     * @When I ask for it as hashes
-     */
+    #[When('I ask for it as hashes')]
     public function iAskForItAsHashes()
     {
         $this->hashes = HIBP::asHashes($this->password);
     }
 
-    /**
-     * @Then I'll get a :hashPrefix and :hashSuffix
-     */
+    #[Then("I'll get a :hashPrefix and :hashSuffix")]
     public function illGetAHashPrefixAndHashSuffix($hashPrefix, $hashSuffix)
     {
         Assert::eq($this->hashes['Prefix'], $hashPrefix);
         Assert::eq($this->hashes['Suffix'], $hashSuffix);
     }
 
-    /**
-     * @Given I have a pwned password
-     */
+    #[Given('I have a pwned password')]
     public function iHaveAPwnedPassword()
     {
         $this->password = 'pass123';
     }
 
-    /**
-     * @When I ask if it is pwned
-     */
+    #[When('I ask if it is pwned')]
     public function iAskIfItIsPwned()
     {
         $this->isPwned = HIBP::isPwned($this->password);
     }
 
-    /**
-     * @Then I'll get a true response
-     */
+    #[Then("I'll get a true response")]
     public function illGetATrueResponse()
     {
         Assert::true($this->isPwned);
     }
 
-    /**
-     * @Given I have a random password that has not been pwned
-     */
+    #[Given('I have a random password that has not been pwned')]
     public function iHaveARandomPasswordThatHasNotBeenPwned()
     {
         $this->password = random_bytes(128);
     }
 
-    /**
-     * @Then I'll get a false response
-     */
+    #[Then("I'll get a false response")]
     public function illGetAFalseResponse()
     {
         Assert::false($this->isPwned);

--- a/app/features/bootstrap/MethodContext.php
+++ b/app/features/bootstrap/MethodContext.php
@@ -7,6 +7,9 @@ use common\helpers\MySqlDateTime;
 use common\models\Method;
 use common\models\User;
 use Webmozart\Assert\Assert;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 
 class MethodContext extends \FeatureContext
 {
@@ -15,9 +18,7 @@ class MethodContext extends \FeatureContext
      */
     protected $tempMethod;
 
-    /**
-     * @Given /^user with employee id (.*) has (?:a|an) (verified|unverified) Method "(.*)"$/
-     */
+    #[Given('/^user with employee id (.*) has (?:a|an) (verified|unverified) Method "(.*)"$/')]
     public function userHasAMethod($employeeId, $verified, $value)
     {
         $user = User::findOne(['employee_id' => $employeeId]);
@@ -37,9 +38,7 @@ class MethodContext extends \FeatureContext
         $this->tempUid = $method->uid;
     }
 
-    /**
-     * @Then the following method data should be stored:
-     */
+    #[Then('the following method data should be stored:')]
     public function theFollowingMethodDataIsStored(TableNode $data)
     {
         foreach ($data as $row) {
@@ -50,9 +49,7 @@ class MethodContext extends \FeatureContext
         }
     }
 
-    /**
-     * @When I send the correct code to verify that Method
-     */
+    #[When('I send the correct code to verify that Method')]
     public function iSendTheCorrectCodeToVerifyThatMethod()
     {
         $method = Method::findOne(['uid' => $this->tempUid]);
@@ -60,67 +57,51 @@ class MethodContext extends \FeatureContext
         $this->iSendAToWithAValidUid('PUT', '/method/{uid}/verify');
     }
 
-    /**
-     * @When I send an incorrect code to verify that Method
-     */
+    #[When('I send an incorrect code to verify that Method')]
     public function iSendAnIncorrectCodeToVerifyThatMethod()
     {
         $this->iChangeThe('code', 'abcdef');
         $this->iSendAToWithAValidUid('PUT', '/method/{uid}/verify');
     }
 
-    /**
-     * @Given the verification expiration time has passed
-     */
+    #[Given('the verification expiration time has passed')]
     public function theVerificationExpirationTimeHasPassed()
     {
         $this->tempMethod->verification_expires = MySqlDateTime::relativeTime('-1 hour');
         $this->tempMethod->save();
     }
 
-    /**
-     * @Then the method should remain unverified
-     */
+    #[Then('the method should remain unverified')]
     public function theMethodShouldRemainUnverified()
     {
         Assert::false($this->methodFromDb->isVerified(), 'Method is verified but should not be.');
     }
 
-    /**
-     * @Then the verification should not be expired
-     */
+    #[Then('the verification should not be expired')]
     public function theVerificationShouldNotBeExpired()
     {
         Assert::false($this->methodFromDb->isVerificationExpired(), 'Verification is expired but should not be.');
     }
 
-    /**
-     * @Then the verification should be expired
-     */
+    #[Then('the verification should be expired')]
     public function theVerificationShouldBeExpired()
     {
         Assert::true($this->methodFromDb->isVerificationExpired(), 'Verification is not expired but should be.');
     }
 
-    /**
-     * @Then the verification attempts counter should be :arg1
-     */
+    #[Then('the verification attempts counter should be :arg1')]
     public function theVerificationAttemptsCounterShouldBe($arg1)
     {
         Assert::eq($this->methodFromDb->verification_attempts, $arg1);
     }
 
-    /**
-     * @Then the verification code should have changed
-     */
+    #[Then('the verification code should have changed')]
     public function theVerificationCodeShouldHaveChanged()
     {
         Assert::notEq($this->methodFromDb->verification_code, $this->tempMethod->verification_code);
     }
 
-    /**
-     * @Then the verification code should not have changed
-     */
+    #[Then('the verification code should not have changed')]
     public function theVerificationCodeShouldNotHaveChanged()
     {
         Assert::eq($this->methodFromDb->verification_code, $this->tempMethod->verification_code);

--- a/app/features/bootstrap/MfaContext.php
+++ b/app/features/bootstrap/MfaContext.php
@@ -12,6 +12,7 @@ use common\models\MfaWebauthn;
 use common\models\User;
 use OTPHP\TOTP;
 use Webmozart\Assert\Assert;
+use Behat\Step\Then;
 
 class MfaContext extends \FeatureContext
 {
@@ -42,9 +43,7 @@ class MfaContext extends \FeatureContext
      */
     private $totpSecret;
 
-    /**
-     * @Given the user has a verified :mfaType MFA
-     */
+    #[Given('the user has a verified :mfaType MFA')]
     public function iGiveThatUserAVerifiedMfa($mfaType)
     {
         Assert::notEq($mfaType, mfa::TYPE_WEBAUTHN, "should have called iGiveThatUserAVerifiedWebauthnMfa");
@@ -72,9 +71,7 @@ class MfaContext extends \FeatureContext
         }
     }
 
-    /**
-     * @Given the user has a mfaWebauthn with a key_handle_hash of :keyHandleHash
-     */
+    #[Given('the user has a mfaWebauthn with a key_handle_hash of :keyHandleHash')]
     public function iGiveThatUserAMfaWebauthnMfaWithAKeyHandleHashOf($keyHandleHash)
     {
         $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
@@ -95,9 +92,7 @@ class MfaContext extends \FeatureContext
         $this->mfaWebauthnIds[] = $webauthn->id;
     }
 
-    /**
-     * @Then an MFA record exists for an employee_id of :employeeId
-     */
+    #[Then('an MFA record exists for an employee_id of :employeeId')]
     public function anMfaRecordExistsForAnEmployeeIdOf($employeeId)
     {
         $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
@@ -107,9 +102,7 @@ class MfaContext extends \FeatureContext
         Assert::notEmpty($this->mfa, 'No MFA record found for that user.');
     }
 
-    /**
-     * @Then the following MFA data should be stored:
-     */
+    #[Then('the following MFA data should be stored:')]
     public function theFollowingMfaDataShouldBeStored(TableNode $table)
     {
         foreach ($table as $row) {
@@ -121,9 +114,7 @@ class MfaContext extends \FeatureContext
     }
 
 
-    /**
-     * @Then the following mfaWebauthn data should be stored:
-     */
+    #[Then('the following mfaWebauthn data should be stored:')]
     public function theFollowingMfaWebauthnDataShouldBeStored(TableNode $table)
     {
         $this->mfaWebauthn = MfaWebauthn::findOne(['id' => $this->mfaWebauthn->id]);
@@ -137,9 +128,7 @@ class MfaContext extends \FeatureContext
         }
     }
 
-    /**
-     * @Given the user has a manager email address
-     */
+    #[Given('the user has a manager email address')]
     public function theUserHasAManagerEmailAddress()
     {
         $dataForTableNode = [
@@ -151,9 +140,7 @@ class MfaContext extends \FeatureContext
         $this->theResponseStatusCodeShouldBe(200);
     }
 
-    /**
-     * @Given the user does not have a manager email address
-     */
+    #[Given('the user does not have a manager email address')]
     public function theUserDoesNotHaveAManagerEmailAddress()
     {
         $dataForTableNode = [
@@ -165,9 +152,7 @@ class MfaContext extends \FeatureContext
         $this->theResponseStatusCodeShouldBe(200);
     }
 
-    /**
-     * @Given the user has requested a new webauthn MFA
-     */
+    #[Given('the user has requested a new webauthn MFA')]
     public function theUserHasRequestedANewWebauthnMfa()
     {
         $rpId = getenv('MFA_WEBAUTHN_rpId');
@@ -228,18 +213,14 @@ class MfaContext extends \FeatureContext
     }
 
 
-    /**
-     * @When I update the MFA
-     */
+    #[When('I update the MFA')]
     public function iUpdateTheMfa()
     {
         $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id, self::UPDATED);
     }
 
 
-    /**
-     * @When I update the mfaWebauthn
-     */
+    #[When('I update the mfaWebauthn')]
     public function iUpdateTheMfaWebauthn()
     {
         $rpId = getenv('MFA_WEBAUTHN_rpId');
@@ -247,9 +228,7 @@ class MfaContext extends \FeatureContext
         $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id . '/webauthn/' . $this->mfaWebauthn->id, self::UPDATED);
     }
 
-    /**
-     * @When I request to verify (one of) the code(s)
-     */
+    #[When('I request to verify (one of) the code(s)')]
     public function iRequestToVerifyOneOfTheCodes()
     {
         $dataForTableNode = [
@@ -262,9 +241,7 @@ class MfaContext extends \FeatureContext
         $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id . '/verify', self::CREATED);
     }
 
-    /**
-     * @When I request to verify the webauthn Mfa registration
-     */
+    #[When('I request to verify the webauthn Mfa registration')]
     public function iRequestToVerifyTheWebauthnMfaRegistration()
     {
         $rpId = getenv('MFA_WEBAUTHN_rpId');
@@ -272,9 +249,7 @@ class MfaContext extends \FeatureContext
         $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id . '/verify/registration', self::CREATED);
     }
 
-    /**
-     * @When I request to verify the webauthn Mfa registration with a label of :label
-     */
+    #[When('I request to verify the webauthn Mfa registration with a label of :label')]
     public function iRequestToVerifyTheWebauthnMfaRegistrationWithALabelOf($label)
     {
         $rpId = getenv('MFA_WEBAUTHN_rpId');
@@ -283,17 +258,13 @@ class MfaContext extends \FeatureContext
         $this->iRequestTheResourceBe('/mfa/' . $this->mfa->id . '/verify/registration', self::CREATED);
     }
 
-    /**
-     * @Then :num codes should be stored
-     */
+    #[Then(':num codes should be stored')]
     public function codesShouldBeStored($num)
     {
         Assert::eq(count($this->mfa->mfaBackupcodes), $num);
     }
 
-    /**
-     * @When I request to delete the MFA
-     */
+    #[When('I request to delete the MFA')]
     public function iRequestToDeleteTheMfa()
     {
         $dataForTableNode = [
@@ -308,9 +279,7 @@ class MfaContext extends \FeatureContext
     }
 
 
-    /**
-     * @When I request to delete the webauthn entry of the MFA with a webauthn_id of :webauthnId
-     */
+    #[When('I request to delete the webauthn entry of the MFA with a webauthn_id of :webauthnId')]
     public function iRequestToDeleteTheWebauthnEntryOfTheMfaWithAWebauthnIDOf($webauthnId)
     {
         $dataForTableNode = [
@@ -326,9 +295,7 @@ class MfaContext extends \FeatureContext
     }
 
 
-    /**
-     * @When I request to delete the webauthn entry of the MFA
-     */
+    #[When('I request to delete the webauthn entry of the MFA')]
     public function iRequestToDeleteTheWebauthnEntryOfTheMfa()
     {
         $webauthnId = $this->mfaWebauthnIds[0];
@@ -336,9 +303,7 @@ class MfaContext extends \FeatureContext
     }
 
 
-    /**
-     * @When the user requests a new webauthn MFA
-     */
+    #[When('the user requests a new webauthn MFA')]
     public function theUserRequestsANewWebauthnMfa()
     {
         $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
@@ -347,18 +312,14 @@ class MfaContext extends \FeatureContext
         $this->iRequestTheResourceBe('/mfa', self::CREATED);
     }
 
-    /**
-     * @Then the MFA record is not stored
-     */
+    #[Then('the MFA record is not stored')]
     public function theMfaRecordIsNotStored()
     {
         $this->mfa = Mfa::findOne(['id' => $this->mfa->id]);
         Assert::null($this->mfa, 'A matching record was found in the database');
     }
 
-    /**
-     * @Then the MFA record is still stored
-     */
+    #[Then('the MFA record is still stored')]
     public function theMfaRecordIsStillStored()
     {
         $this->mfa = Mfa::findOne(['id' => $this->mfa->id]);

--- a/app/features/bootstrap/MfaRateLimitContext.php
+++ b/app/features/bootstrap/MfaRateLimitContext.php
@@ -11,6 +11,9 @@ use common\models\User;
 use Webmozart\Assert\Assert;
 use Yii;
 use yii\web\TooManyRequestsHttpException;
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 
 class MfaRateLimitContext extends YiiContext
 {
@@ -79,9 +82,7 @@ class MfaRateLimitContext extends YiiContext
         }
     }
 
-    /**
-     * @Given I have a user with backup codes available
-     */
+    #[Given('I have a user with backup codes available')]
     public function iHaveAUserWithBackupCodesAvailable()
     {
         $user = $this->createNewUserInDatabase('has_backupcodes');
@@ -92,17 +93,13 @@ class MfaRateLimitContext extends YiiContext
         $this->validBackupCodes = $mfaCreateResult['data'];
     }
 
-    /**
-     * @Given that MFA method has no recent failures
-     */
+    #[Given('that MFA method has no recent failures')]
     public function thatMfaMethodHasNoRecentFailures()
     {
         $this->thatMfaMethodShouldHaveRecentFailure(0);
     }
 
-    /**
-     * @When I submit a correct backup code
-     */
+    #[When('I submit a correct backup code')]
     public function iSubmitACorrectBackupCode()
     {
         Assert::notEmpty($this->validBackupCodes);
@@ -110,17 +107,13 @@ class MfaRateLimitContext extends YiiContext
         $this->submitBackupCode($this->mfaId, $correctBackupCode);
     }
 
-    /**
-     * @Then the backup code should be accepted
-     */
+    #[Then('the backup code should be accepted')]
     public function theBackupCodeShouldBeAccepted()
     {
         Assert::true($this->mfaVerifyResult);
     }
 
-    /**
-     * @When I submit an incorrect backup code
-     */
+    #[When('I submit an incorrect backup code')]
     public function iSubmitAnIncorrectBackupCode()
     {
         $incorrectBackupCode = $this->generateBackupCodeNotIn(
@@ -129,9 +122,7 @@ class MfaRateLimitContext extends YiiContext
         $this->submitBackupCode($this->mfaId, $incorrectBackupCode);
     }
 
-    /**
-     * @Then that MFA method should have :number recent failure(s)
-     */
+    #[Then('that MFA method should have :number recent failure(s)')]
     public function thatMfaMethodShouldHaveRecentFailure(int $number)
     {
         $mfa = Mfa::findOne($this->mfaId);
@@ -142,9 +133,7 @@ class MfaRateLimitContext extends YiiContext
         );
     }
 
-    /**
-     * @Given that MFA method has nearly too many recent failures
-     */
+    #[Given('that MFA method has nearly too many recent failures')]
     public function thatMfaMethodHasNearlyTooManyRecentFailures()
     {
         $mfa = Mfa::findOne($this->mfaId);
@@ -166,9 +155,7 @@ class MfaRateLimitContext extends YiiContext
         Assert::same($mfa->countRecentFailures(), $desiredCount);
     }
 
-    /**
-     * @Given that MFA method has too many recent failures
-     */
+    #[Given('that MFA method has too many recent failures')]
     public function thatMfaMethodHasTooManyRecentFailures()
     {
         $this->thatMfaMethodHasNearlyTooManyRecentFailures();
@@ -183,9 +170,7 @@ class MfaRateLimitContext extends YiiContext
         );
     }
 
-    /**
-     * @Then I should be told to wait and try later
-     */
+    #[Then('I should be told to wait and try later')]
     public function iShouldBeToldToWaitAndTryLater()
     {
         Assert::isInstanceOf(
@@ -194,9 +179,7 @@ class MfaRateLimitContext extends YiiContext
         );
     }
 
-    /**
-     * @Then an MFA rate-limit email should have been sent to that user
-     */
+    #[Then('an MFA rate-limit email should have been sent to that user')]
     public function anEmailShouldHaveBeenSentToThatUser()
     {
         $mfa = Mfa::findOne($this->mfaId);
@@ -213,9 +196,7 @@ class MfaRateLimitContext extends YiiContext
         ));
     }
 
-    /**
-     * @Then that MFA rate-limit activation should have been logged
-     */
+    #[Then('that MFA rate-limit activation should have been logged')]
     public function thatMfaRateLimitActivationShouldHaveBeenLogged()
     {
         Yii::getLogger()->flush();
@@ -224,9 +205,7 @@ class MfaRateLimitContext extends YiiContext
         Assert::contains($loggedMessagesJson, 'MFA rate limit triggered');
     }
 
-    /**
-     * @Given that MFA method had too many failures, but they are not recent
-     */
+    #[Given('that MFA method had too many failures, but they are not recent')]
     public function thatMfaMethodHadTooManyFailuresButTheyAreNotRecent()
     {
         $mfa = Mfa::findOne($this->mfaId);

--- a/app/features/bootstrap/MfaUnitTestsContext.php
+++ b/app/features/bootstrap/MfaUnitTestsContext.php
@@ -5,6 +5,9 @@ namespace Sil\SilIdBroker\Behat\Context;
 use common\models\Mfa;
 use common\models\MfaBackupcode;
 use Webmozart\Assert\Assert;
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 
 class MfaUnitTestsContext extends UnitTestsContext
 {
@@ -12,9 +15,7 @@ class MfaUnitTestsContext extends UnitTestsContext
 
     protected $inputBackupCode;
 
-    /**
-     * @Given I have a user with a backup codes mfa option
-     */
+    #[Given('I have a user with a backup codes mfa option')]
     public function iHaveAUserWithABackupCodesMfaOption()
     {
         $this->tempUser = $this->createNewUserInDatabase('mfa_tester');
@@ -22,9 +23,7 @@ class MfaUnitTestsContext extends UnitTestsContext
         MfaBackupcode::deleteAll();
     }
 
-    /**
-     * @Given I have a user with a manager rescue mfa option
-     */
+    #[Given('I have a user with a manager rescue mfa option')]
     public function iHaveAUserWithAManagerRescueMfaOption()
     {
         $this->tempUser = $this->createNewUserInDatabase('mfa_tester');
@@ -32,9 +31,7 @@ class MfaUnitTestsContext extends UnitTestsContext
         MfaBackupcode::deleteAll();
     }
 
-    /**
-     * @Given I have a user with an unverified totp mfa option
-     */
+    #[Given('I have a user with an unverified totp mfa option')]
     public function iHaveAUserWithAnUnverifiedTotpMfaOption()
     {
         Mfa::deleteAll();
@@ -46,9 +43,7 @@ class MfaUnitTestsContext extends UnitTestsContext
         );
     }
 
-    /**
-     * @Given I have a user with a verified totp mfa option
-     */
+    #[Given('I have a user with a verified totp mfa option')]
     public function iHaveAUserWithAVerifiedTotpMfaOption()
     {
         Mfa::deleteAll([]);
@@ -60,33 +55,25 @@ class MfaUnitTestsContext extends UnitTestsContext
         );
     }
 
-    /**
-     * @Given the totp mfa option is new
-     */
+    #[Given('the totp mfa option is new')]
     public function theTotpMfaOptionIsNew()
     {
         $this->mfaIsNew = true;
     }
 
-    /**
-     * @Given the totp mfa option is old
-     */
+    #[Given('the totp mfa option is old')]
     public function theTotpMfaOptionIsOld()
     {
         $this->mfaIsNew = false;
     }
 
-    /**
-     * @Given the totp mfa option has just been verified
-     */
+    #[Given('the totp mfa option has just been verified')]
     public function theTotpMfaOptionHasJustBeenVerified()
     {
         $this->mfaChangedAttrs['verified'] = 0;
     }
 
-    /**
-     * @Given a backup code with a leading zero was saved and was shortened
-     */
+    #[Given('a backup code with a leading zero was saved and was shortened')]
     public function aBackupCodeWithALeadingZeroWasSavedAndWasShortened()
     {
         $fullBackupCode = '01234567';
@@ -95,9 +82,7 @@ class MfaUnitTestsContext extends UnitTestsContext
         MfaBackupcode::insertBackupCode($this->mfaId, substr($fullBackupCode, 1));
     }
 
-    /**
-     * @Given a backup code with a leading zero was saved and was not shortened
-     */
+    #[Given('a backup code with a leading zero was saved and was not shortened')]
     public function aBackupCodeWithALeadingZeroWasSavedAndWasNotShortened()
     {
         $fullBackupCode = '01234567';
@@ -106,9 +91,7 @@ class MfaUnitTestsContext extends UnitTestsContext
         MfaBackupcode::insertBackupCode($this->mfaId, $fullBackupCode);
     }
 
-    /**
-     * @Given a backup code without a leading zero was saved and was not shortened
-     */
+    #[Given('a backup code without a leading zero was saved and was not shortened')]
     public function aBackupCodeWithoutALeadingZeroWasSavedAndWasNotShortened()
     {
         $fullBackupCode = '81234567';
@@ -117,9 +100,7 @@ class MfaUnitTestsContext extends UnitTestsContext
         MfaBackupcode::insertBackupCode($this->mfaId, $fullBackupCode);
     }
 
-    /**
-     * @When a matching backup code is provided for validation
-     */
+    #[When('a matching backup code is provided for validation')]
     public function aMatchingBackupCodeIsProvidedForValidation()
     {
         $this->backupCodeWasValid = MfaBackupcode::validateAndRemove(
@@ -128,9 +109,7 @@ class MfaUnitTestsContext extends UnitTestsContext
         );
     }
 
-    /**
-     * @When a not matching backup code is provided for validation
-     */
+    #[When('a not matching backup code is provided for validation')]
     public function aNOTMatchingBackupCodeIsProvidedForValidation()
     {
         $this->backupCodeWasValid = MfaBackupcode::validateAndRemove(
@@ -139,17 +118,13 @@ class MfaUnitTestsContext extends UnitTestsContext
         );
     }
 
-    /**
-     * @When I check if the new mfa option is newly verified
-     */
+    #[When('I check if the new mfa option is newly verified')]
     public function iCheckIfTheNewMfaOptionIsNewlyVerified()
     {
         $this->mfaIsNewlyVerified = $this->mfa->isNewlyVerified(true, []);
     }
 
-    /**
-     * @When I check if the mfa option is newly verified
-     */
+    #[When('I check if the mfa option is newly verified')]
     public function iCheckIfTheMfaOptionIsNewlyVerified()
     {
         $this->mfaIsNewlyVerified = $this->mfa->isNewlyVerified(
@@ -158,49 +133,37 @@ class MfaUnitTestsContext extends UnitTestsContext
         );
     }
 
-    /**
-     * @Then a backup code match should be detected
-     */
+    #[Then('a backup code match should be detected')]
     public function aBackupCodeMatchShouldBeDetected()
     {
         Assert::true($this->backupCodeWasValid);
     }
 
-    /**
-     * @Then a backup code match should not be detected
-     */
+    #[Then('a backup code match should not be detected')]
     public function aBackupCodeMatchShouldNotBeDetected()
     {
         Assert::false($this->backupCodeWasValid);
     }
 
-    /**
-     * @Then :number backup codes should exist
-     */
+    #[Then(':number backup codes should exist')]
     public function xBackupCodesShouldExist($number)
     {
         Assert::eq($number, MfaBackupcode::find()->count());
     }
 
-    /**
-     * @Then I see that the mfa option is newly verified
-     */
+    #[Then('I see that the mfa option is newly verified')]
     public function iSeeThatTheMfaOptionIsNewlyVerified()
     {
         Assert::true($this->mfaIsNewlyVerified);
     }
 
-    /**
-     * @Then I see that the mfa option is NOT newly verified
-     */
+    #[Then('I see that the mfa option is NOT newly verified')]
     public function iSeeThatTheMfaOptionIsNotNewlyVerified()
     {
         Assert::false($this->mfaIsNewlyVerified);
     }
 
-    /**
-     * @Given that user also has a manager rescue mfa option
-     */
+    #[Given('that user also has a manager rescue mfa option')]
     public function thatUserAlsoHasAManagerRescueMfaOption()
     {
         $code = 'manager';
@@ -208,9 +171,7 @@ class MfaUnitTestsContext extends UnitTestsContext
         MfaBackupcode::insertBackupCode($this->mfaId, $code);
     }
 
-    /**
-     * @When I verify a backup code
-     */
+    #[When('I verify a backup code')]
     public function iVerifyABackupCode()
     {
         $code = 'backup';
@@ -219,9 +180,7 @@ class MfaUnitTestsContext extends UnitTestsContext
         Assert::true($mfa->verify($code));
     }
 
-    /**
-     * @Then I see that the user no longer has a manager rescue mfa option
-     */
+    #[Then('I see that the user no longer has a manager rescue mfa option')]
     public function iSeeThatTheUserNoLongerHasAManagerRescueMfaOption()
     {
         $mfa = Mfa::findOne(['user_id' => $this->tempUser->id, 'type' => Mfa::TYPE_MANAGER]);

--- a/app/features/bootstrap/MySqlDateTimeContext.php
+++ b/app/features/bootstrap/MySqlDateTimeContext.php
@@ -5,6 +5,9 @@ namespace Sil\SilIdBroker\Behat\Context;
 use Behat\Behat\Context\Context;
 use common\helpers\MySqlDateTime;
 use Webmozart\Assert\Assert;
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 
 class MySqlDateTimeContext implements Context
 {
@@ -14,17 +17,13 @@ class MySqlDateTimeContext implements Context
     /** @var  int */
     protected $recentDays;
 
-    /**
-     * @Given I say that recent is in the last :arg1 days
-     */
+    #[Given('I say that recent is in the last :arg1 days')]
     public function iSayThatRecentIsInTheLastXDays($recentDays)
     {
         $this->recentDays = $recentDays;
     }
 
-    /**
-     * @When  I ask if :arg1 days ago is recent
-     */
+    #[When('I ask if :arg1 days ago is recent')]
     public function iAskIfXDaysAgoIsRecent($daysAgo)
     {
         $diffConfig = "-" . $daysAgo . " days";
@@ -34,18 +33,14 @@ class MySqlDateTimeContext implements Context
     }
 
 
-    /**
-     * @Then I see that that date is recent
-     */
+    #[Then('I see that that date is recent')]
     public function iSeeThatThatDateIsRecent()
     {
         Assert::true($this->dateIsRecent);
     }
 
 
-    /**
-     * @Then I see that that date is not recent
-     */
+    #[Then('I see that that date is not recent')]
     public function iSeeThatThatDateIsNotRecent()
     {
         Assert::false($this->dateIsRecent);

--- a/app/features/bootstrap/SheetsUnitTestsContext.php
+++ b/app/features/bootstrap/SheetsUnitTestsContext.php
@@ -5,6 +5,9 @@ namespace Sil\SilIdBroker\Behat\Context;
 use Behat\Behat\Tester\Exception\PendingException;
 use common\components\Sheets;
 use Webmozart\Assert\Assert;
+use Behat\Step\Given;
+use Behat\Step\When;
+use Behat\Step\Then;
 
 class SheetsUnitTestsContext extends UnitTestsContext
 {
@@ -12,9 +15,7 @@ class SheetsUnitTestsContext extends UnitTestsContext
     private $header;
     private $table;
 
-    /**
-     * @Given I have a list of users
-     */
+    #[Given('I have a list of users')]
     public function iHaveAListOfUsers()
     {
         $this->users = [
@@ -29,9 +30,7 @@ class SheetsUnitTestsContext extends UnitTestsContext
         ];
     }
 
-    /**
-     * @Given I have an array of table headers
-     */
+    #[Given('I have an array of table headers')]
     public function iHaveAnArrayOfTableHeaders()
     {
         $this->header = [
@@ -43,17 +42,13 @@ class SheetsUnitTestsContext extends UnitTestsContext
         ];
     }
 
-    /**
-     * @When I generate a table
-     */
+    #[When('I generate a table')]
     public function iGenerateATable()
     {
         $this->table = Sheets::makeTable($this->header, $this->users);
     }
 
-    /**
-     * @Then I see that the table was generated correctly
-     */
+    #[Then('I see that the table was generated correctly')]
     public function iSeeThatTheTableWasGeneratedCorrectly()
     {
         $table = $this->table;

--- a/app/features/bootstrap/UnitTestsContext.php
+++ b/app/features/bootstrap/UnitTestsContext.php
@@ -2,6 +2,10 @@
 
 namespace Sil\SilIdBroker\Behat\Context;
 
+use Behat\Hook\AfterScenario;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
 use common\helpers\MySqlDateTime;
 use common\models\EmailLog;
 use common\models\Invite;
@@ -167,25 +171,19 @@ class UnitTestsContext extends YiiContext
         $user->refresh();
     }
 
-    /**
-     * @When I request a list of verified methods
-     */
+    #[When('I request a list of verified methods')]
     public function iRequestAListOfVerifiedMethods()
     {
         $this->methodList = $this->tempUser->getVerifiedMethodOptions();
     }
 
-    /**
-     * @Then I see a list containing :num method
-     */
+    #[Then('I see a list containing :num method')]
     public function iSeeAListContainingMethod($num)
     {
         Assert::count($this->methodList, $num);
     }
 
-    /**
-     * @Given the database contains a user with no invite codes
-     */
+    #[Given('the database contains a user with no invite codes')]
     public function theDatabaseContainsAUserWithNoInviteCodes()
     {
         $this->tempUser = $this->createNewUserInDatabase('unit_test');
@@ -199,9 +197,7 @@ class UnitTestsContext extends YiiContext
         }
     }
 
-    /**
-     * @Given /^the database contains a user with a (non-expired|expired) invite code$/
-     */
+    #[Given('/^the database contains a user with a (non-expired|expired) invite code$/')]
     public function theDatabaseContainsAUserWithANonExpiredInviteCode($expiredOrNot)
     {
         $this->theDatabaseContainsAUserWithNoInviteCodes();
@@ -216,27 +212,21 @@ class UnitTestsContext extends YiiContext
         $this->tempUser->refresh();
     }
 
-    /**
-     * @When I request an invite code
-     */
+    #[When('I request an invite code')]
     public function iRequestAnInviteCode()
     {
         $this->oldInviteCode = $this->tempUser->invites[0] ?? null;
         $this->inviteCode = Invite::findOrCreate($this->tempUser->id);
     }
 
-    /**
-     * @Then I receive a code that is not expired
-     */
+    #[Then('I receive a code that is not expired')]
     public function iReceiveACodeThatIsNotExpired()
     {
         Assert::notNull($this->inviteCode);
         Assert::false($this->inviteCode->isExpired());
     }
 
-    /**
-     * @Then the code should be in UUID format
-     */
+    #[Then('the code should be in UUID format')]
     public function theCodeShouldBeInUuidFormat()
     {
         Assert::notNull($this->inviteCode);
@@ -244,9 +234,7 @@ class UnitTestsContext extends YiiContext
     }
 
 
-    /**
-     * @Then I receive a new code
-     */
+    #[Then('I receive a new code')]
     public function iReceiveANewCode()
     {
         Assert::notNull($this->inviteCode, 'inviteCode is null');
@@ -254,17 +242,13 @@ class UnitTestsContext extends YiiContext
         Assert::notEq($this->inviteCode->uuid, $this->oldInviteCode->uuid);
     }
 
-    /**
-     * @Then the new code is not expired
-     */
+    #[Then('the new code is not expired')]
     public function theNewCodeIsNotExpired()
     {
         $this->iReceiveACodeThatIsNotExpired();
     }
 
-    /**
-     * @Given the nag dates are in the past
-     */
+    #[Given('the nag dates are in the past')]
     public function theNagDatesAreInThePast()
     {
         $this->tempUser->review_profile_after = MySqlDateTime::relative('-1 day');
@@ -272,33 +256,25 @@ class UnitTestsContext extends YiiContext
         $this->tempUser->nag_for_mfa_after = MySqlDateTime::relative('-1 day');
     }
 
-    /**
-     * @When I request the nag state
-     */
+    #[When('I request the nag state')]
     public function iRequestTheNagState()
     {
         $this->nagState = $this->tempUser->getNagState();
     }
 
-    /**
-     * @Then I see that the nag state is :state
-     */
+    #[Then('I see that the nag state is :state')]
     public function iSeeThatTheNagStateIs($state)
     {
         Assert::eq($this->nagState, $state);
     }
 
-    /**
-     * @Given there is a user in the database
-     */
+    #[Given('there is a user in the database')]
     public function thereIsAUserInTheDatabase()
     {
         $this->tempUser = $this->createNewUserInDatabase('unit_test');
     }
 
-    /**
-     * @Given /^that user has (\d+) (verified|unverified) methods?$/i
-     */
+    #[Given('/^that user has (\d+) (verified|unverified) methods?$/i')]
     public function thatUserHasVerifiedMethods($n, $verifiedOrUnverified)
     {
         for ($i = 0; $i < $n; $i++) {
@@ -309,9 +285,7 @@ class UnitTestsContext extends YiiContext
         }
     }
 
-    /**
-     * @Given /^that user has (\d+) (verified|unverified) mfas?/i
-     */
+    #[Given('/^that user has (\d+) (verified|unverified) mfas?/i')]
     public function thatUserHasVerifiedMfas($n, $verifiedOrUnverified)
     {
         for ($i = 0; $i < $n; $i++) {
@@ -322,49 +296,37 @@ class UnitTestsContext extends YiiContext
         }
     }
 
-    /**
-     * @Given that user has a verified backup code mfa
-     */
+    #[Given('that user has a verified backup code mfa')]
     public function thatUserHasAVerifiedBackupCodeMfa()
     {
         $this->createMfaBackupCodes();
     }
 
-    /**
-     * @Given that user has a verified webauthn mfa
-     */
+    #[Given('that user has a verified webauthn mfa')]
     public function thatUserHasAVerifiedWebauthnMfa()
     {
         $this->createMfaWebauthn();
     }
 
-    /**
-     * @When I create a new user with a :property property of :value
-     */
+    #[When('I create a new user with a :property property of :value')]
     public function iCreateANewUserWithAPropertyOf($property, $value)
     {
         $this->tempUser = $this->createNewUserInDatabase('test_user', [$property => $value]);
     }
 
-    /**
-     * @Given the database contains a user (with no MFA options)
-     */
+    #[Given('the database contains a user (with no MFA options)')]
     public function theDatabaseContainsAUser()
     {
         $this->tempUser = $this->createNewUserInDatabase('test_user');
     }
 
-    /**
-     * @Given that user has a :property property value of :value
-     */
+    #[Given('that user has a :property property value of :value')]
     public function thatUserHasAPropertyValueOf($property, $value)
     {
         $this->iChangeTheUsersPropertyTo($property, $value);
     }
 
-    /**
-     * @When I change the user's :property property to :value
-     */
+    #[When("I change the user's :property property to :value")]
     public function iChangeTheUsersPropertyTo($property, $value)
     {
         $this->tempUser->scenario = User::SCENARIO_UPDATE_USER;
@@ -372,26 +334,22 @@ class UnitTestsContext extends YiiContext
         Assert::eq(true, $this->tempUser->save());
     }
 
-    /**
-     * @Then I see the user's :property property is :value
-     */
+    #[Then("I see the user's :property property is :value")]
     public function iSeeTheUsersPropertyIs($property, $value)
     {
         $this->tempUser->refresh();
         Assert::eq($this->tempUser->$property, $value);
     }
 
-    /**
-     * @Given the :param config parameter is true
-     */
+    #[Given('the :param config parameter is true')]
     public function theConfigParameterIsTrue($param)
     {
         $this->originalParams[$param] = \Yii::$app->params[$param];
         \Yii::$app->params[$param] = true;
     }
 
+    #[Given("the :param config parameter is false")]
     /**
-     * @Given the :param config parameter is false
      * Behat can't seem to pass a false boolean correctly as an argument
      */
     public function theConfigParameterIsFalse($param)
@@ -400,10 +358,7 @@ class UnitTestsContext extends YiiContext
         \Yii::$app->params[$param] = false;
     }
 
-
-    /**
-     * @AfterScenario
-     */
+    #[AfterScenario]
     public function resetParams()
     {
         foreach ($this->originalParams as $param => $value) {
@@ -411,17 +366,13 @@ class UnitTestsContext extends YiiContext
         }
     }
 
-    /**
-     * @When I add backup codes for that user
-     */
+    #[When('I add backup codes for that user')]
     public function iAddBackupCodesForThatUser()
     {
         $this->createMfa(Mfa::TYPE_BACKUPCODE);
     }
 
-    /**
-     * @Given the user has not logged in for :months
-     */
+    #[Given('the user has not logged in for :months')]
     public function theUserHasNotLoggedInFor($months)
     {
         $date = MySqlDateTime::relative("-{$months}");
@@ -429,17 +380,13 @@ class UnitTestsContext extends YiiContext
         $this->iChangeTheUsersPropertyTo("created_utc", $date);
     }
 
-    /**
-     * @When I get users for HR notification
-     */
+    #[When('I get users for HR notification')]
     public function iGetUsersForHrNotification()
     {
         $this->dataToVerify = User::getAbandonedUsers();
     }
 
-    /**
-     * @Then /^the user (is|is NOT) included in the data$/
-     */
+    #[Then('/^the user (is|is NOT) included in the data$/')]
     public function isUserIncludedInTheData($option)
     {
         $isIncluded = false;
@@ -457,9 +404,7 @@ class UnitTestsContext extends YiiContext
         }
     }
 
-    /**
-     * @When I delete inactive users
-     */
+    #[When('I delete inactive users')]
     public function iDeleteInactiveUsers()
     {
         // Temporarily set the configs to something that will allow
@@ -474,17 +419,13 @@ class UnitTestsContext extends YiiContext
         \Yii::$app->params['inactiveUserPeriod'] = $originalPeriod;
     }
 
-    /**
-     * @When I retrieve the remaining users
-     */
+    #[When('I retrieve the remaining users')]
     public function IRetrieveTheRemainingUsers()
     {
         $this->dataToVerify = User::find()->all();
     }
 
-    /**
-     * @When the user submits a new password
-     */
+    #[When('the user submits a new password')]
     public function theUserSubmitsANewPassword()
     {
         $this->tempUser->password = 'k23@U$%235u25@I2$o';
@@ -492,18 +433,14 @@ class UnitTestsContext extends YiiContext
         $this->tempUser->save();
     }
 
-    /**
-     * @Then a new password hash should be stored
-     */
+    #[Then('a new password hash should be stored')]
     public function aNewPasswordHashShouldBeStored()
     {
         $hash = $this->tempUser->currentPassword->hash;
         Assert::notEmpty($hash);
     }
 
-    /**
-     * @Given that user has a password with a low hash cost
-     */
+    #[Given('that user has a password with a low hash cost')]
     public function thatUserHasAPasswordWithALowHashCost()
     {
         $this->password = 'k23@U24urchr,@I2$o';
@@ -520,9 +457,7 @@ class UnitTestsContext extends YiiContext
         Assert::true($this->tempUser->save(), var_export($passwordObject->errors, true));
     }
 
-    /**
-     * @When the user uses their password
-     */
+    #[When('the user uses their password')]
     public function theUserUsesTheirPassword()
     {
         $this->tempUser->scenario = User::SCENARIO_AUTHENTICATE;
@@ -530,9 +465,7 @@ class UnitTestsContext extends YiiContext
         Assert::true($this->tempUser->validate(), var_export($this->tempUser->errors, true));
     }
 
-    /**
-     * @Then the password hash should be updated
-     */
+    #[Then('the password hash should be updated')]
     public function thePasswordHashShouldBeUpdated()
     {
         $currentPassword = $this->tempUser->getCurrentPassword()->one();

--- a/app/features/bootstrap/YiiContext.php
+++ b/app/features/bootstrap/YiiContext.php
@@ -4,6 +4,7 @@ namespace Sil\SilIdBroker\Behat\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Hook\BeforeScenario;
+use Behat\Hook\BeforeSuite;
 use Sil\Psr3Adapters\Psr3StdOutLogger;
 use Sil\SilIdBroker\Behat\Context\fakes\FakeEmailer;
 use Sil\SilIdBroker\Behat\Context\fakes\FakeLogTarget;
@@ -51,9 +52,7 @@ class YiiContext implements Context
         Yii::$app->log->targets[] = $this->fakeLogTarget;
     }
 
-    /**
-     * @BeforeSuite
-     */
+    #[BeforeSuite]
     public static function loadYiiApp()
     {
         if (empty(self::$application)) {


### PR DESCRIPTION

### Changed (non-breaking)
- Use PHP Attributes for Behat and remove old-style comment annotations.


---

### PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [x] Tests created or updated
- [ ] Run `make composershow`
- [x] Run `make psr2`
