### PR TITLE
Fix the cc and bcc headers in emails sent. The SES driver was incomplete

### DIFF
--- a/app/common/components/EmailClient.php
+++ b/app/common/components/EmailClient.php
@@ -15,6 +15,8 @@ use yii\db\Exception;
  */
 class EmailClient extends Component
 {
+    public const string NONE = '(none)';
+
     /**
      * @throws Exception
      * @throws InvalidConfigException
@@ -62,8 +64,9 @@ class EmailClient extends Component
             'action' => 'email/queue',
             'status' => 'queued',
             'id' => $email->id,
-            'toAddress' => $email->to_address ?? '(null)',
-            'subject' => $email->subject ?? '(null)',
+            'toAddress' => $email->to_address ?? self::NONE,
+            'ccAddress' => $email->cc_address ?? self::NONE,
+            'subject' => $email->subject ?? self::NONE,
             'send_after' => date('c', $email->send_after),
             'delay_seconds' => $email->delay_seconds,
         ]);

--- a/app/common/components/SesMailer.php
+++ b/app/common/components/SesMailer.php
@@ -50,12 +50,12 @@ class SesMailer extends BaseMailer
         ];
 
         $cc = $message->getCc();
-        if (!empty($cc)) {
+        if (!empty($cc) && !empty($cc[0])) {
             $destination['CcAddresses'] = $cc;
         }
 
         $bcc = $message->getBcc();
-        if (!empty($bcc)) {
+        if (!empty($bcc) && !empty($bcc[0])) {
             $destination['BccAddresses'] = $bcc;
         }
 

--- a/app/common/components/SesMailer.php
+++ b/app/common/components/SesMailer.php
@@ -86,6 +86,7 @@ class SesMailer extends BaseMailer
                 'action' => 'sendMessage',
                 'type' => get_class($e),
                 'message' => $e->getMessage(),
+                'destination' => $destination,
             ]);
             return false;
         }

--- a/app/common/components/SesMailer.php
+++ b/app/common/components/SesMailer.php
@@ -49,6 +49,8 @@ class SesMailer extends BaseMailer
             $result = $this->client->sendEmail([
                 'Destination' => [
                     'ToAddresses' => $message->getTo(),
+                    'CcAddresses' => $message->getCc(),
+                    'BccAddresses' => $message->getBcc(),
                 ],
                 'ReplyToAddresses' => $message->getReplyTo(),
                 'Source' => $message->getFrom(),

--- a/app/common/components/SesMailer.php
+++ b/app/common/components/SesMailer.php
@@ -45,13 +45,23 @@ class SesMailer extends BaseMailer
      */
     protected function sendMessage($message)
     {
+        $destination = [
+            'ToAddresses' => $message->getTo(),
+        ];
+
+        $cc = $message->getCc();
+        if (!empty($cc)) {
+            $destination['CcAddresses'] = $cc;
+        }
+
+        $bcc = $message->getBcc();
+        if (!empty($bcc)) {
+            $destination['BccAddresses'] = $bcc;
+        }
+
         try {
             $result = $this->client->sendEmail([
-                'Destination' => [
-                    'ToAddresses' => $message->getTo(),
-                    'CcAddresses' => $message->getCc(),
-                    'BccAddresses' => $message->getBcc(),
-                ],
+                'Destination' => $destination,
                 'ReplyToAddresses' => $message->getReplyTo(),
                 'Source' => $message->getFrom(),
                 'Message' => [

--- a/app/common/components/SesMessage.php
+++ b/app/common/components/SesMessage.php
@@ -99,7 +99,10 @@ class SesMessage extends BaseMessage
 
     public function getCc()
     {
-        return $this->cc ?? [];
+        if (empty($this->cc)) {
+            return [];
+        }
+        return $this->cc;
     }
 
     public function setCc($cc)
@@ -113,7 +116,10 @@ class SesMessage extends BaseMessage
 
     public function getBcc()
     {
-        return $this->bcc ?? [];
+        if (empty($this->bcc)) {
+            return [];
+        }
+        return $this->bcc;
     }
 
     public function setBcc($bcc)

--- a/app/common/models/Email.php
+++ b/app/common/models/Email.php
@@ -163,6 +163,8 @@ class Email extends EmailBase
             $mailer->setFrom([$from => $name]);
         }
         $mailer->setTo($this->to_address);
+        $mailer->setCc($this->cc_address);
+        $mailer->setBcc($this->bcc_address);
         $mailer->setSubject($this->subject);
 
         /*

--- a/app/common/models/User.php
+++ b/app/common/models/User.php
@@ -3,6 +3,7 @@
 namespace common\models;
 
 use Closure;
+use common\components\Emailer;
 use common\components\HIBP;
 use common\components\Sheets;
 use common\helpers\MySqlDateTime;


### PR DESCRIPTION
[IDP-1949](https://support.gtis.sil.org/issue/IDP-1949) Add cc option to invite email

---

### Fixed
- Fixed a bug that left the cc and bcc headers empty when sending through AWS SES.


---

### PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [x] Run `make psr2`
