### PR TITLE
Update the SES mail driver to more correctly match the Yii2 interface.

### DIFF
--- a/app/behat.yml
+++ b/app/behat.yml
@@ -63,3 +63,11 @@ default:
             paths:
                 - "features/sheets-unit-tests.feature"
             contexts: [ Sil\SilIdBroker\Behat\Context\SheetsUnitTestsContext ]
+        ses_message_unit_tests_features:
+            paths:
+                - "features/ses-message-unit-tests.feature"
+            contexts: [ Sil\SilIdBroker\Behat\Context\SesMessageUnitTestsContext ]
+        ses_mailer_unit_tests_features:
+            paths:
+                - "features/ses-mailer-unit-tests.feature"
+            contexts: [ Sil\SilIdBroker\Behat\Context\SesMailerUnitTestsContext ]

--- a/app/common/components/SesMailer.php
+++ b/app/common/components/SesMailer.php
@@ -45,6 +45,25 @@ class SesMailer extends BaseMailer
      */
     protected function sendMessage($message)
     {
+        $emailArgs = $this->buildEmailArgs($message);
+
+        try {
+            $result = $this->client->sendEmail($emailArgs);
+        } catch (\Throwable $e) {
+            \Yii::error([
+                'action' => 'sendMessage',
+                'type' => get_class($e),
+                'message' => $e->getMessage(),
+                'destination' => $emailArgs['Destination'],
+            ]);
+            return false;
+        }
+        \Yii::info('message sent, id: ' . $result['MessageId']);
+        return true;
+    }
+
+    protected function buildEmailArgs($message): array
+    {
         $destination = [
             'ToAddresses' => $message->getTo(),
         ];
@@ -59,38 +78,26 @@ class SesMailer extends BaseMailer
             $destination['BccAddresses'] = $bcc;
         }
 
-        try {
-            $result = $this->client->sendEmail([
-                'Destination' => $destination,
-                'ReplyToAddresses' => $message->getReplyTo(),
-                'Source' => $message->getFrom(),
-                'Message' => [
-                    'Body' => [
-                        'Html' => [
-                            'Charset' => $message->getCharset(),
-                            'Data' => $message->getHtmlBody(),
-                        ],
-                        'Text' => [
-                            'Charset' => $message->getCharset(),
-                            'Data' => $message->getTextBody(),
-                        ],
-                    ],
-                    'Subject' => [
+        return [
+            'Destination' => $destination,
+            'ReplyToAddresses' => $message->getReplyTo(),
+            'Source' => $message->getFrom(),
+            'Message' => [
+                'Body' => [
+                    'Html' => [
                         'Charset' => $message->getCharset(),
-                        'Data' => $message->getSubject(),
+                        'Data' => $message->getHtmlBody(),
+                    ],
+                    'Text' => [
+                        'Charset' => $message->getCharset(),
+                        'Data' => $message->getTextBody(),
                     ],
                 ],
-            ]);
-        } catch (\Throwable $e) {
-            \Yii::error([
-                'action' => 'sendMessage',
-                'type' => get_class($e),
-                'message' => $e->getMessage(),
-                'destination' => $destination,
-            ]);
-            return false;
-        }
-        \Yii::info('message sent, id: ' . $result['MessageId']);
-        return true;
+                'Subject' => [
+                    'Charset' => $message->getCharset(),
+                    'Data' => $message->getSubject(),
+                ],
+            ],
+        ];
     }
 }

--- a/app/common/components/SesMessage.php
+++ b/app/common/components/SesMessage.php
@@ -108,10 +108,7 @@ class SesMessage extends BaseMessage
      */
     public function getReplyTo(): string|array
     {
-        if ($this->replyTo) {
-            return $this->replyTo;
-        }
-        return $this->getFrom();
+        return $this->replyTo;
     }
 
     /**

--- a/app/common/components/SesMessage.php
+++ b/app/common/components/SesMessage.php
@@ -4,6 +4,7 @@ namespace common\components;
 
 use yii\base\NotSupportedException;
 use yii\mail\BaseMessage;
+use yii\mail\MessageInterface;
 
 /*
  * SesMessage is a Yii2 message component to send email messages using AWS Simple Email Service
@@ -13,48 +14,61 @@ use yii\mail\BaseMessage;
 class SesMessage extends BaseMessage
 {
     /** @var string */
-    private $charset;
+    private string $charset = '';
 
     /** @var string */
-    private $from;
+    private string $from = '';
 
     /** @var string[] */
-    private $to;
+    private array $to = [];
 
     /** @var string[] */
-    private $replyTo;
+    private array $replyTo = [];
 
     /** @var string[] */
-    private $cc;
+    private array $cc = [];
 
     /** @var string[] */
-    private $bcc;
+    private array $bcc = [];
 
     /** @var string */
-    private $subject;
+    private string $subject = '';
 
     /** @var string */
-    private $textBody;
+    private string $textBody = '';
 
     /** @var string */
-    private $htmlBody;
+    private string $htmlBody = '';
 
-    public function getCharset()
+    /**
+     * @inheritdoc
+     */
+    public function getCharset(): string
     {
         return $this->charset ?? 'UTF-8';
     }
 
-    public function setCharset($charset)
+    /**
+     * @inheritdoc
+     */
+    public function setCharset($charset): SesMessage|static
     {
         $this->charset = $charset;
+        return $this;
     }
 
-    public function getFrom()
+    /**
+     * @inheritdoc
+     */
+    public function getFrom(): string
     {
         return $this->from;
     }
 
-    public function setFrom($from)
+    /**
+     * @inheritdoc
+     */
+    public function setFrom($from): SesMessage|static
     {
         if (is_array($from)) {
             if (isset($from[0])) {
@@ -67,84 +81,101 @@ class SesMessage extends BaseMessage
         } else {
             $this->from = $from;
         }
+        return $this;
     }
 
-    public function getTo()
+    /**
+     * @inheritdoc
+     */
+    public function getTo(): string|array
     {
         return $this->to;
     }
 
-    public function setTo($to)
+    /**
+     * @inheritdoc
+     */
+    public function setTo($to): SesMessage|static
     {
-        if (is_array($to)) {
-            $this->to = $to;
-        } else {
-            $this->to = explode(",", $to);
-        }
+        $this->to = static::formatAddresses($to);
+        return $this;
     }
 
-    public function getReplyTo()
+    /**
+     * @inheritdoc
+     */
+    public function getReplyTo(): string|array
     {
-        return $this->replyTo ?? [$this->getFrom()];
+        if ($this->replyTo) {
+            return $this->replyTo;
+        }
+        return $this->getFrom();
     }
 
-    public function setReplyTo($replyTo)
+    /**
+     * @inheritdoc
+     */
+    public function setReplyTo($replyTo): SesMessage|static
     {
-        if (is_array($replyTo)) {
-            $this->replyTo = $replyTo;
-        } else {
-            $this->replyTo = explode(",", $replyTo);
-        }
+        $this->replyTo = static::formatAddresses($replyTo);
+        return $this;
     }
 
-    public function getCc()
+    /**
+     * @inheritdoc
+     */
+    public function getCc(): string|array
     {
-        if (empty($this->cc)) {
-            return [];
-        }
         return $this->cc;
     }
 
-    public function setCc($cc)
+    /**
+     * @inheritdoc
+     */
+    public function setCc($cc): SesMessage|static
     {
-        if (is_array($cc)) {
-            $this->cc = $cc;
-        } else {
-            $this->cc = explode(",", $cc);
-        }
+        $this->cc = static::formatAddresses($cc);
+        return $this;
     }
 
-    public function getBcc()
+    /**
+     * @inheritdoc
+     */
+    public function getBcc(): string|array
     {
-        if (empty($this->bcc)) {
-            return [];
-        }
         return $this->bcc;
     }
 
-    public function setBcc($bcc)
+    /**
+     * @inheritdoc
+     */
+    public function setBcc($bcc): SesMessage|static
     {
-        if (is_array($bcc)) {
-            $this->bcc = $bcc;
-        } else {
-            $this->bcc = explode(",", $bcc);
-        }
+        $this->bcc = static::formatAddresses($bcc);
+        return $this;
     }
 
-    public function getSubject()
+    /**
+     * @inheritdoc
+     */
+    public function getSubject(): string
     {
         return $this->subject;
     }
 
-    public function setSubject($subject)
+    /**
+     * @inheritdoc
+     */
+    public function setSubject($subject): SesMessage|static
     {
         $this->subject = $subject;
+        return $this;
     }
 
     /**
      * @return string
      */
-    public function getTextBody()
+    public function getTextBody(): string
     {
         if (empty($this->textBody)) {
             return strip_tags($this->htmlBody);
@@ -152,15 +183,19 @@ class SesMessage extends BaseMessage
         return $this->textBody;
     }
 
-    public function setTextBody($text)
+    /**
+     * @inheritdoc
+     */
+    public function setTextBody($text): SesMessage|static
     {
         $this->textBody = $text;
+        return $this;
     }
 
     /**
      * @return string
      */
-    public function getHtmlBody()
+    public function getHtmlBody(): string
     {
         if (empty($this->htmlBody)) {
             return htmlspecialchars($this->textBody);
@@ -168,33 +203,76 @@ class SesMessage extends BaseMessage
         return $this->htmlBody;
     }
 
-    public function setHtmlBody($html)
+    /**
+     * @inheritdoc
+     */
+    public function setHtmlBody($html): SesMessage|static
     {
         $this->htmlBody = $html;
+        return $this;
     }
 
-    public function attach($fileName, array $options = [])
+    /**
+     * @inheritdoc
+     * @throws NotSupportedException
+     */
+    public function attach($fileName, array $options = []): MessageInterface
     {
         throw new NotSupportedException('attach is not implemented');
     }
 
-    public function attachContent($content, array $options = [])
+    /**
+     * @inheritdoc
+     * @throws NotSupportedException
+     */
+    public function attachContent($content, array $options = []): MessageInterface
     {
-        throw new NotSupportedException('attacheContent is not implemented');
+        throw new NotSupportedException('attachContent is not implemented');
     }
 
-    public function embed($fileName, array $options = [])
+    /**
+     * @inheritdoc
+     * @throws NotSupportedException
+     */
+    public function embed($fileName, array $options = []): string
     {
         throw new NotSupportedException('embed is not implemented');
     }
 
-    public function embedContent($content, array $options = [])
+    /**
+     * @inheritdoc
+     * @throws NotSupportedException
+     */
+    public function embedContent($content, array $options = []): string
     {
         throw new NotSupportedException('embedContent is not implemented');
     }
 
-    public function toString()
+    /**
+     * @inheritdoc
+     */
+    public function toString(): string
     {
         return $this->textBody;
+    }
+
+    /**
+     * Format addresses as an array of strings, given a string or array as defined by Yii's MailInterface.
+     * @param $email string|array
+     * @return array
+     */
+    private static function formatAddresses(string|array $email): array
+    {
+        $email = is_array($email) ? $email : [$email];
+
+        if (array_is_list($email)) {
+            return $email;
+        }
+
+        $out = [];
+        foreach ($email as $addr => $name) {
+            $out[] = sprintf('%s <%s>', $name, $addr);
+        }
+        return $out;
     }
 }

--- a/app/common/components/SesMessage.php
+++ b/app/common/components/SesMessage.php
@@ -97,7 +97,9 @@ class SesMessage extends BaseMessage
      */
     public function setTo($to): SesMessage|static
     {
-        $this->to = static::formatAddresses($to);
+        if ($to) {
+            $this->to = static::formatAddresses($to);
+        }
         return $this;
     }
 
@@ -117,7 +119,9 @@ class SesMessage extends BaseMessage
      */
     public function setReplyTo($replyTo): SesMessage|static
     {
-        $this->replyTo = static::formatAddresses($replyTo);
+        if ($replyTo) {
+            $this->replyTo = static::formatAddresses($replyTo);
+        }
         return $this;
     }
 
@@ -134,7 +138,9 @@ class SesMessage extends BaseMessage
      */
     public function setCc($cc): SesMessage|static
     {
-        $this->cc = static::formatAddresses($cc);
+        if ($cc) {
+            $this->cc = static::formatAddresses($cc);
+        }
         return $this;
     }
 
@@ -151,7 +157,9 @@ class SesMessage extends BaseMessage
      */
     public function setBcc($bcc): SesMessage|static
     {
-        $this->bcc = static::formatAddresses($bcc);
+        if ($bcc) {
+            $this->bcc = static::formatAddresses($bcc);
+        }
         return $this;
     }
 

--- a/app/common/models/Email.php
+++ b/app/common/models/Email.php
@@ -163,22 +163,20 @@ class Email extends EmailBase
             $mailer->setFrom([$from => $name]);
         }
         $mailer->setTo($this->to_address);
-        $mailer->setCc($this->cc_address);
-        $mailer->setBcc($this->bcc_address);
         $mailer->setSubject($this->subject);
 
         /*
          * Conditionally set optional fields
          */
-        $setMethods = [
-            'setCc' => $this->cc_address,
-            'setBcc' => $this->bcc_address,
-        ];
-        foreach ($setMethods as $method => $value) {
-            if ($value) {
-                $mailer->$method($value);
-            }
+
+        if ($this->cc_address) {
+            $mailer->setCc($this->cc_address);
         }
+
+        if ($this->bcc_address) {
+            $mailer->setBcc($this->bcc_address);
+        }
+
 
         return $mailer;
     }

--- a/app/features/bootstrap/SesMailerUnitTestsContext.php
+++ b/app/features/bootstrap/SesMailerUnitTestsContext.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Sil\SilIdBroker\Behat\Context;
+
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+use common\components\SesMailer;
+use common\components\SesMessage;
+use Webmozart\Assert\Assert;
+
+class SesMailerUnitTestsContext extends YiiContext
+{
+    /** @var SesMailer */
+    protected $mailer;
+
+    /** @var SesMessage */
+    protected $message;
+
+    /** @var array */
+    protected $emailArgs;
+
+    #[Given('I have a new SesMailer')]
+    public function iHaveANewSesMailer()
+    {
+        $this->mailer = new class extends SesMailer {
+            public function getEmailArgs($message): array
+            {
+                return $this->buildEmailArgs($message);
+            }
+        };
+    }
+
+    #[Given('I have a new SesMessage')]
+    public function iHaveANewSesMessage()
+    {
+        $this->message = new SesMessage();
+    }
+
+    #[When('I initialize the SesMailer')]
+    public function iInitializeTheSesMailer()
+    {
+        $this->mailer->init();
+    }
+
+    #[When('I set the AWS region to :region')]
+    public function iSetTheAwsRegionTo($region)
+    {
+        $this->mailer->awsRegion = $region;
+    }
+
+    #[Then('the AWS region should be :region')]
+    public function theAwsRegionShouldBe($region)
+    {
+        Assert::eq($this->mailer->awsRegion, $region);
+    }
+
+    #[When('I set the from address to :from')]
+    public function iSetTheFromAddressTo($from)
+    {
+        $this->message->setFrom($from);
+    }
+
+    #[When('I set the to address to :to')]
+    public function iSetTheToAddressTo($to)
+    {
+        $this->message->setTo($to);
+    }
+
+    #[When('I set the cc address to :cc')]
+    public function iSetTheCcAddressTo($cc)
+    {
+        $this->message->setCc($cc);
+    }
+
+    #[When('I set the bcc address to :bcc')]
+    public function iSetTheBccAddressTo($bcc)
+    {
+        $this->message->setBcc($bcc);
+    }
+
+    #[When('I set the subject to :subject')]
+    public function iSetTheSubjectTo($subject)
+    {
+        $this->message->setSubject($subject);
+    }
+
+    #[When('I set the text body to :text')]
+    public function iSetTheTextBodyTo($text)
+    {
+        $this->message->setTextBody($text);
+    }
+
+    #[When('I set the html body to :html')]
+    public function iSetTheHtmlBodyTo($html)
+    {
+        $this->message->setHtmlBody($html);
+    }
+
+    #[When('I set the cc address to an array with :cc1 and :cc2')]
+    public function iSetTheCcAddressToAnArrayWithAnd($cc1, $cc2)
+    {
+        $this->message->setCc([$cc1, $cc2]);
+    }
+
+    #[Then('the email arguments should be correctly built')]
+    public function theEmailArgumentsShouldBeCorrectlyBuilt()
+    {
+        $this->emailArgs = $this->mailer->getEmailArgs($this->message);
+
+        Assert::eq($this->emailArgs['Source'], $this->message->getFrom());
+        Assert::eq($this->emailArgs['Destination']['ToAddresses'], $this->message->getTo());
+        Assert::eq($this->emailArgs['Message']['Subject']['Data'], $this->message->getSubject());
+        Assert::eq($this->emailArgs['Message']['Body']['Text']['Data'], $this->message->getTextBody());
+        Assert::eq($this->emailArgs['Message']['Body']['Html']['Data'], $this->message->getHtmlBody());
+    }
+
+    #[Then('the email arguments should contain CC address :cc')]
+    public function theEmailArgumentsShouldContainCcAddress($cc)
+    {
+        Assert::keyExists($this->emailArgs['Destination'], 'CcAddresses');
+        Assert::inArray($cc, $this->emailArgs['Destination']['CcAddresses']);
+    }
+
+    #[Then('the email arguments should contain BCC address :bcc')]
+    public function theEmailArgumentsShouldContainBccAddress($bcc)
+    {
+        Assert::keyExists($this->emailArgs['Destination'], 'BccAddresses');
+        Assert::inArray($bcc, $this->emailArgs['Destination']['BccAddresses']);
+    }
+
+    #[Then('the email arguments should not contain CC addresses')]
+    public function theEmailArgumentsShouldNotContainCcAddresses()
+    {
+        Assert::keyNotExists($this->emailArgs['Destination'], 'CcAddresses');
+    }
+
+    #[Then('the email arguments should not contain BCC addresses')]
+    public function theEmailArgumentsShouldNotContainBccAddresses()
+    {
+        Assert::keyNotExists($this->emailArgs['Destination'], 'BccAddresses');
+    }
+}

--- a/app/features/bootstrap/SesMessageUnitTestsContext.php
+++ b/app/features/bootstrap/SesMessageUnitTestsContext.php
@@ -109,10 +109,10 @@ class SesMessageUnitTestsContext extends YiiContext
         }
     }
 
-    #[Then('the reply-to address should be :replyTo')]
-    public function theReplyToAddressShouldBe($replyTo)
+    #[Then('the reply-to address should be empty')]
+    public function theReplyToAddressShouldBeEmpty()
     {
-        Assert::eq($this->message->getReplyTo(), $replyTo);
+        Assert::isEmpty($this->message->getReplyTo());
     }
 
     #[When('I set the cc address to :cc')]

--- a/app/features/bootstrap/SesMessageUnitTestsContext.php
+++ b/app/features/bootstrap/SesMessageUnitTestsContext.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace Sil\SilIdBroker\Behat\Context;
+
+use Behat\Hook\BeforeScenario;
+use Behat\Step\Given;
+use Behat\Step\Then;
+use Behat\Step\When;
+use common\components\SesMessage;
+use Webmozart\Assert\Assert;
+use yii\base\NotSupportedException;
+
+class SesMessageUnitTestsContext extends YiiContext
+{
+    /** @var SesMessage */
+    protected $message;
+
+    protected $exceptionThrown;
+
+    #[BeforeScenario]
+    public function beforeScenario()
+    {
+        $this->exceptionThrown = null;
+    }
+
+    #[Given('I have a new SesMessage')]
+    public function iHaveANewSesMessage()
+    {
+        $this->message = new SesMessage();
+    }
+
+    #[When('I set the charset to :charset')]
+    public function iSetTheCharsetTo($charset)
+    {
+        $this->message->setCharset($charset);
+    }
+
+    #[Then('the charset should be :charset')]
+    public function theCharsetShouldBe($charset)
+    {
+        Assert::eq($this->message->getCharset(), $charset);
+    }
+
+    #[When('I set the from address to :from')]
+    public function iSetTheFromAddressTo($from)
+    {
+        $this->message->setFrom($from);
+    }
+
+    #[Then('the from address should be :from')]
+    public function theFromAddressShouldBe($from)
+    {
+        Assert::eq($this->message->getFrom(), $from);
+    }
+
+    #[When('I set the from address to an array with :email as key and :name as value')]
+    public function iSetTheFromAddressToAnArrayWithEmailAsKeyAndNameAsValue($email, $name)
+    {
+        $this->message->setFrom([$email => $name]);
+    }
+
+    #[When('I set the to address to :to')]
+    public function iSetTheToAddressTo($to)
+    {
+        $this->message->setTo($to);
+    }
+
+    #[Then('the to address should contain :to')]
+    public function theToAddressShouldContain($to)
+    {
+        $addresses = $this->message->getTo();
+        if (is_array($addresses)) {
+            Assert::inArray($to, $addresses);
+        } else {
+            Assert::eq($addresses, $to);
+        }
+    }
+
+    #[When('I set the to address to an array with :r1 and :r2')]
+    public function iSetTheToAddressToAnArrayWithAnd($r1, $r2)
+    {
+        $this->message->setTo([$r1, $r2]);
+    }
+
+    #[When('I set the to address to the following:')]
+    public function iSetTheToAddressToTheFollowing(\Behat\Gherkin\Node\TableNode $table)
+    {
+        $addresses = [];
+        foreach ($table as $row) {
+            $addresses[$row['email']] = $row['name'];
+        }
+        $this->message->setTo($addresses);
+    }
+
+    #[When('I set the reply-to address to :replyTo')]
+    public function iSetTheReplyToAddressTo($replyTo)
+    {
+        $this->message->setReplyTo($replyTo);
+    }
+
+    #[Then('the reply-to address should contain :replyTo')]
+    public function theReplyToAddressShouldContain($replyTo)
+    {
+        $addresses = $this->message->getReplyTo();
+        if (is_array($addresses)) {
+            Assert::inArray($replyTo, $addresses);
+        } else {
+            Assert::eq($addresses, $replyTo);
+        }
+    }
+
+    #[Then('the reply-to address should be :replyTo')]
+    public function theReplyToAddressShouldBe($replyTo)
+    {
+        Assert::eq($this->message->getReplyTo(), $replyTo);
+    }
+
+    #[When('I set the cc address to :cc')]
+    public function iSetTheCcAddressTo($cc)
+    {
+        $this->message->setCc($cc);
+    }
+
+    #[Then('the cc address should contain :cc')]
+    public function theCcAddressShouldContain($cc)
+    {
+        $addresses = $this->message->getCc();
+        if (is_array($addresses)) {
+            Assert::inArray($cc, $addresses);
+        } else {
+            Assert::eq($addresses, $cc);
+        }
+    }
+
+    #[When('I set the bcc address to :bcc')]
+    public function iSetTheBccAddressTo($bcc)
+    {
+        $this->message->setBcc($bcc);
+    }
+
+    #[Then('the bcc address should contain :bcc')]
+    public function theBccAddressShouldContain($bcc)
+    {
+        $addresses = $this->message->getBcc();
+        if (is_array($addresses)) {
+            Assert::inArray($bcc, $addresses);
+        } else {
+            Assert::eq($addresses, $bcc);
+        }
+    }
+
+    #[When('I set the subject to :subject')]
+    public function iSetTheSubjectTo($subject)
+    {
+        $this->message->setSubject($subject);
+    }
+
+    #[Then('the subject should be :subject')]
+    public function theSubjectShouldBe($subject)
+    {
+        Assert::eq($this->message->getSubject(), $subject);
+    }
+
+    #[When('I set the text body to :text')]
+    public function iSetTheTextBodyTo($text)
+    {
+        $this->message->setTextBody($text);
+    }
+
+    #[Then('the text body should be :text')]
+    public function theTextBodyShouldBe($text)
+    {
+        Assert::eq($this->message->getTextBody(), $text);
+    }
+
+    #[When('I set the html body to :html')]
+    public function iSetTheHtmlBodyTo($html)
+    {
+        $this->message->setHtmlBody($html);
+    }
+
+    #[Then('the html body should be :html')]
+    public function theHtmlBodyShouldBe($html)
+    {
+        Assert::eq($this->message->getHtmlBody(), $html);
+    }
+
+    #[Then('toString should return :expected')]
+    public function tostringShouldReturn($expected)
+    {
+        Assert::eq($this->message->toString(), $expected);
+    }
+
+    #[When('I try to attach a file')]
+    public function iTryToAttachAFile()
+    {
+        try {
+            $this->message->attach('test.txt');
+        } catch (NotSupportedException $e) {
+            $this->exceptionThrown = $e;
+        }
+    }
+
+    #[When('I try to attach content')]
+    public function iTryToAttachContent()
+    {
+        try {
+            $this->message->attachContent('content');
+        } catch (NotSupportedException $e) {
+            $this->exceptionThrown = $e;
+        }
+    }
+
+    #[When('I try to embed a file')]
+    public function iTryToEmbedAFile()
+    {
+        try {
+            $this->message->embed('test.txt');
+        } catch (NotSupportedException $e) {
+            $this->exceptionThrown = $e;
+        }
+    }
+
+    #[When('I try to embed content')]
+    public function iTryToEmbedContent()
+    {
+        try {
+            $this->message->embedContent('content');
+        } catch (NotSupportedException $e) {
+            $this->exceptionThrown = $e;
+        }
+    }
+
+    #[Then('it should throw a NotSupportedException')]
+    public function itShouldThrowANotSupportedException()
+    {
+        Assert::isInstanceOf($this->exceptionThrown, NotSupportedException::class);
+    }
+}

--- a/app/features/ses-mailer-unit-tests.feature
+++ b/app/features/ses-mailer-unit-tests.feature
@@ -1,0 +1,50 @@
+Feature: SesMailer Unit Tests
+  As a developer
+  I want to be able to use the SesMailer component
+  So that I can send emails via AWS SES
+
+  Scenario: Testing default region
+    Given I have a new SesMailer
+    When I initialize the SesMailer
+    Then the AWS region should be "us-east-1"
+
+  Scenario: Testing custom region
+    Given I have a new SesMailer
+    When I set the AWS region to "us-west-2"
+    And I initialize the SesMailer
+    Then the AWS region should be "us-west-2"
+
+  Scenario: Testing email arguments building with CC and BCC
+    Given I have a new SesMailer
+    And I have a new SesMessage
+    When I set the from address to "from@example.com"
+    And I set the to address to "to@example.com"
+    And I set the cc address to "cc@example.com"
+    And I set the bcc address to "bcc@example.com"
+    And I set the subject to "Test Subject"
+    And I set the text body to "Test Text Body"
+    And I set the html body to "<b>Test HTML Body</b>"
+    Then the email arguments should be correctly built
+    And the email arguments should contain CC address "cc@example.com"
+    And the email arguments should contain BCC address "bcc@example.com"
+
+  Scenario: Testing email arguments building without CC and BCC
+    Given I have a new SesMailer
+    And I have a new SesMessage
+    When I set the from address to "from@example.com"
+    And I set the to address to "to@example.com"
+    And I set the subject to "Test Subject"
+    Then the email arguments should be correctly built
+    And the email arguments should not contain CC addresses
+    And the email arguments should not contain BCC addresses
+
+  Scenario: Testing email arguments building with multiple CC addresses
+    Given I have a new SesMailer
+    And I have a new SesMessage
+    When I set the from address to "from@example.com"
+    And I set the to address to "to@example.com"
+    And I set the cc address to an array with "cc1@example.com" and "cc2@example.com"
+    And I set the subject to "Test Subject"
+    Then the email arguments should be correctly built
+    And the email arguments should contain CC address "cc1@example.com"
+    And the email arguments should contain CC address "cc2@example.com"

--- a/app/features/ses-message-unit-tests.feature
+++ b/app/features/ses-message-unit-tests.feature
@@ -1,0 +1,116 @@
+Feature: SesMessage Unit Tests
+  As a developer
+  I want to be able to use the SesMessage component
+  So that I can send emails via AWS SES
+
+  Scenario: Testing charset
+    Given I have a new SesMessage
+    When I set the charset to "UTF-16"
+    Then the charset should be "UTF-16"
+
+  Scenario: Testing From address with a string
+    Given I have a new SesMessage
+    When I set the from address to "tester@example.com"
+    Then the from address should be "tester@example.com"
+
+  Scenario: Testing From address with an array (email as key)
+    Given I have a new SesMessage
+    When I set the from address to an array with "tester@example.com" as key and "Tester" as value
+    Then the from address should be "Tester <tester@example.com>"
+
+  Scenario: Testing To address
+    Given I have a new SesMessage
+    When I set the to address to "recipient@example.com"
+    Then the to address should contain "recipient@example.com"
+
+  Scenario: Testing multiple To addresses
+    Given I have a new SesMessage
+    When I set the to address to an array with "r1@example.com" and "r2@example.com"
+    Then the to address should contain "r1@example.com"
+    And the to address should contain "r2@example.com"
+
+  Scenario: Testing To address with names
+    Given I have a new SesMessage
+    When I set the to address to the following:
+      | email | name |
+      | r1@example.com | Recipient One |
+    Then the to address should contain "Recipient One <r1@example.com>"
+
+  Scenario: Testing To address with multiple names
+    Given I have a new SesMessage
+    When I set the to address to the following:
+      | email | name |
+      | r1@example.com | Recipient One |
+      | r2@example.com | Recipient Two |
+    Then the to address should contain "Recipient One <r1@example.com>"
+    And the to address should contain "Recipient Two <r2@example.com>"
+
+  Scenario: Testing Reply-To address
+    Given I have a new SesMessage
+    When I set the reply-to address to "reply@example.com"
+    Then the reply-to address should contain "reply@example.com"
+
+  Scenario: Testing Reply-To default (should be From address)
+    Given I have a new SesMessage
+    And I set the from address to "tester@example.com"
+    Then the reply-to address should be "tester@example.com"
+
+  Scenario: Testing CC address
+    Given I have a new SesMessage
+    When I set the cc address to "cc@example.com"
+    Then the cc address should contain "cc@example.com"
+
+  Scenario: Testing BCC address
+    Given I have a new SesMessage
+    When I set the bcc address to "bcc@example.com"
+    Then the bcc address should contain "bcc@example.com"
+
+  Scenario: Testing Subject
+    Given I have a new SesMessage
+    When I set the subject to "Test Subject"
+    Then the subject should be "Test Subject"
+
+  Scenario: Testing Text Body
+    Given I have a new SesMessage
+    When I set the text body to "Hello World"
+    Then the text body should be "Hello World"
+
+  Scenario: Testing HTML Body
+    Given I have a new SesMessage
+    When I set the html body to "<b>Hello World</b>"
+    Then the html body should be "<b>Hello World</b>"
+
+  Scenario: Testing Text Body generation from HTML Body
+    Given I have a new SesMessage
+    When I set the html body to "<b>Hello World</b>"
+    Then the text body should be "Hello World"
+
+  Scenario: Testing HTML Body generation from Text Body
+    Given I have a new SesMessage
+    When I set the text body to "Hello < World"
+    Then the html body should be "Hello &lt; World"
+
+  Scenario: Testing toString
+    Given I have a new SesMessage
+    When I set the text body to "Hello World"
+    Then toString should return "Hello World"
+
+  Scenario: Testing not supported attach
+    Given I have a new SesMessage
+    When I try to attach a file
+    Then it should throw a NotSupportedException
+
+  Scenario: Testing not supported attachContent
+    Given I have a new SesMessage
+    When I try to attach content
+    Then it should throw a NotSupportedException
+
+  Scenario: Testing not supported embed
+    Given I have a new SesMessage
+    When I try to embed a file
+    Then it should throw a NotSupportedException
+
+  Scenario: Testing not supported embedContent
+    Given I have a new SesMessage
+    When I try to embed content
+    Then it should throw a NotSupportedException

--- a/app/features/ses-message-unit-tests.feature
+++ b/app/features/ses-message-unit-tests.feature
@@ -53,7 +53,7 @@ Feature: SesMessage Unit Tests
   Scenario: Testing Reply-To default (should be From address)
     Given I have a new SesMessage
     And I set the from address to "tester@example.com"
-    Then the reply-to address should be "tester@example.com"
+    Then the reply-to address should be empty
 
   Scenario: Testing CC address
     Given I have a new SesMessage


### PR DESCRIPTION
[IDP-1949](https://support.gtis.sil.org/issue/IDP-1949) Add cc option to invite email

---
### Added
- Added unit tests for the SesMessage and SesMailer classes. (Sorry for the huge commit. Behat is very wordy.)

### Fixed
- Update the SES mail driver to more correctly match the Yii2 interface.
- Don't use the From address as the Reply-To. Aside from being unnecessary, the Reply-To is a list and the From is a single address, which causes a PHP type error if not dealt with.

---

### PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [x] Run `make psr2`
