### PR TITLE
use correct indentation for behat.yml

### DIFF
--- a/app/behat.yml
+++ b/app/behat.yml
@@ -1,73 +1,73 @@
 default:
-    suites:
-        common_features:
-            paths:
-                - "features/password.feature"
-                - "features/user.feature"
-                - "features/user-unit-tests.feature"
-                - "features/user-search.feature"
-            contexts: [ FeatureContext, Sil\SilIdBroker\Behat\Context\UnitTestsContext ]
-        authentication_features:
-            paths:
-                - "features/authentication.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\AuthenticationContext ]
-        email_features:
-            paths:
-                - "features/email.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\EmailContext ]
-        email_api_features:
-            paths:
-                - "features/email-api.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\EmailApiContext ]
-        email_client_features:
-            paths:
-                - "features/email-client.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\EmailClientContext ]
-        groups_external_features:
-            paths:
-                - "features/groups-external.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\GroupsExternalContext ]
-        groups_external_sync_features:
-            paths:
-                - "features/groups-external-sync.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\GroupsExternalSyncContext ]
-        hibp_unit_tests_features:
-            paths:
-                - "features/hibp-unit-tests.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\HibpUnitTestsContext ]
-        invite_features:
-            paths:
-                - "features/invite.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\UnitTestsContext ]
-        method_features:
-            paths:
-                - "features/method.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\MethodContext ]
-        mfa_features:
-            paths:
-                - "features/mfa.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\MfaContext ]
-        mfa_rate_limit_features:
-            paths:
-                - "features/mfa-rate-limit.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\MfaRateLimitContext ]
-        mfa_unit_tests_features:
-            paths:
-                - "features/mfa-unit-tests.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\MfaUnitTestsContext ]
-        mysql_date_time_features:
-            paths:
-                - "features/mysql-date-time.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\MySqlDateTimeContext ]
-        sheets_unit_tests_features:
-            paths:
-                - "features/sheets-unit-tests.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\SheetsUnitTestsContext ]
-        ses_message_unit_tests_features:
-            paths:
-                - "features/ses-message-unit-tests.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\SesMessageUnitTestsContext ]
-        ses_mailer_unit_tests_features:
-            paths:
-                - "features/ses-mailer-unit-tests.feature"
-            contexts: [ Sil\SilIdBroker\Behat\Context\SesMailerUnitTestsContext ]
+  suites:
+    common_features:
+      paths:
+        - "features/password.feature"
+        - "features/user.feature"
+        - "features/user-unit-tests.feature"
+        - "features/user-search.feature"
+      contexts: [FeatureContext, Sil\SilIdBroker\Behat\Context\UnitTestsContext]
+    authentication_features:
+      paths:
+        - "features/authentication.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\AuthenticationContext]
+    email_features:
+      paths:
+        - "features/email.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\EmailContext]
+    email_api_features:
+      paths:
+        - "features/email-api.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\EmailApiContext]
+    email_client_features:
+      paths:
+        - "features/email-client.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\EmailClientContext]
+    groups_external_features:
+      paths:
+        - "features/groups-external.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\GroupsExternalContext]
+    groups_external_sync_features:
+      paths:
+        - "features/groups-external-sync.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\GroupsExternalSyncContext]
+    hibp_unit_tests_features:
+      paths:
+        - "features/hibp-unit-tests.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\HibpUnitTestsContext]
+    invite_features:
+      paths:
+        - "features/invite.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\UnitTestsContext]
+    method_features:
+      paths:
+        - "features/method.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\MethodContext]
+    mfa_features:
+      paths:
+        - "features/mfa.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\MfaContext]
+    mfa_rate_limit_features:
+      paths:
+        - "features/mfa-rate-limit.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\MfaRateLimitContext]
+    mfa_unit_tests_features:
+      paths:
+        - "features/mfa-unit-tests.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\MfaUnitTestsContext]
+    mysql_date_time_features:
+      paths:
+        - "features/mysql-date-time.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\MySqlDateTimeContext]
+    sheets_unit_tests_features:
+      paths:
+        - "features/sheets-unit-tests.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\SheetsUnitTestsContext]
+    ses_message_unit_tests_features:
+      paths:
+        - "features/ses-message-unit-tests.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\SesMessageUnitTestsContext]
+    ses_mailer_unit_tests_features:
+      paths:
+        - "features/ses-mailer-unit-tests.feature"
+      contexts: [Sil\SilIdBroker\Behat\Context\SesMailerUnitTestsContext]


### PR DESCRIPTION

### Fixed
- Use the correct indentation (2 spaces) in behat.yml.

---

### PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [ ] Run `make psr2`
