### PR TITLE
deprecate the "hide" property

### DIFF
--- a/api.raml
+++ b/api.raml
@@ -13,6 +13,9 @@ securitySchemes:
             example: Bearer abc123
 securedBy: [ AuthzBearerToken ]
 
+annotationTypes:
+  deprecated: nil | string
+
 types:
   Authentication:
     type: object
@@ -70,6 +73,7 @@ types:
       personal_email?: string
       hide:
         enum: [ yes, no ]
+        (deprecated): The hide property will be removed in the next major version.
       member: string[]
       mfa:
         type: object
@@ -186,6 +190,7 @@ types:
       personal_email?: string
       hide:
         enum: [ yes, no ]
+        (deprecated): The hide property will be removed in the next major version.
       groups?: string
     example: |
       {
@@ -212,6 +217,7 @@ types:
       personal_email?: string
       hide?:
         enum: [ yes, no ]
+        (deprecated): The hide property will be removed in the next major version.
       groups?: string
     example: |
       {


### PR DESCRIPTION
[IDP-1996](https://support.gtis.sil.org/issue/IDP-1996) Remove "hide" property from idp-id-broker

---


### Deprecated
- Deprecate the "hide" property. It is intended to be always-on in the future.

---

### PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [ ] Run `make psr2`
