### PR TITLE
deprecate the user hide property

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1749,6 +1749,7 @@
             "type": "string"
           },
           "hide": {
+            "deprecated": true,
             "enum": [
               "yes",
               "no"
@@ -1857,7 +1858,6 @@
           }
         },
         "required": [
-          "hide",
           "member",
           "mfa",
           "method",
@@ -1870,8 +1870,7 @@
           "first_name": "John",
           "last_name": "Smith",
           "username": "john_smith",
-          "email": "john_smith@example.com",
-          "hide": "no"
+          "email": "john_smith@example.com"
         },
         "type": "object",
         "properties": {
@@ -1914,6 +1913,7 @@
             "type": "string"
           },
           "hide": {
+            "deprecated": true,
             "enum": [
               "yes",
               "no"
@@ -1929,8 +1929,7 @@
           "first_name",
           "last_name",
           "username",
-          "email",
-          "hide"
+          "email"
         ]
       },
       "UserUpdate": {
@@ -1975,6 +1974,7 @@
             "type": "string"
           },
           "hide": {
+            "deprecated": true,
             "enum": [
               "yes",
               "no"


### PR DESCRIPTION
[IDP-1996](https://support.gtis.sil.org/issue/IDP-1996) Remove "hide" property from idp-id-broker

---


### Deprecated
- Deprecate the "hide" property. It is intended to be always-on in the future.

---

### PR Checklist
- [ ] Documentation (README, local.env.dist, api.raml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [ ] Run `make psr2`
