### PR TITLE
Send reset email

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,3 +65,5 @@ testcli: appfortests tablesfortests mfaapi
 
 testdb:
 	docker compose up -d testdb
+
+.PHONY: db

--- a/app/behat.yml
+++ b/app/behat.yml
@@ -74,4 +74,8 @@ default:
     reset_features:
       paths:
         - "features/reset.feature"
+      contexts: [FeatureContext]
+    reset__unit_tests_features:
+      paths:
+        - "features/reset-unit-tests.feature"
       contexts: [Sil\SilIdBroker\Behat\Context\ResetContext]

--- a/app/common/components/Emailer.php
+++ b/app/common/components/Emailer.php
@@ -288,6 +288,8 @@ class Emailer extends Component
             EmailLog::MESSAGE_TYPE_PASSWORD_PWNED => $this->subjectForPasswordPwned,
             EmailLog::MESSAGE_TYPE_REFRESH_BACKUP_CODES => $this->subjectForRefreshBackupCodes,
             EmailLog::MESSAGE_TYPE_WELCOME => $this->subjectForWelcome,
+            EmailLog::MESSAGE_TYPE_RESET_ON_BEHALF => '{idpDisplayName} password reset request for {firstName}',
+            EmailLog::MESSAGE_TYPE_RESET_SELF => '{idpDisplayName} password reset request',
         ];
 
         $this->hrNotificationsEmail ??= '';

--- a/app/common/config/main.php
+++ b/app/common/config/main.php
@@ -331,6 +331,7 @@ return [
         'passwordGracePeriodExtension'  => '+7 days',
         'passwordLifespan'              => Env::get('PASSWORD_LIFESPAN', '+1 year'),
         'passwordMfaLifespanExtension'  => Env::get('PASSWORD_MFA_LIFESPAN_EXTENSION', '+4 years'),
+        'passwordProfileUrl'            => $passwordProfileUrl,
         'passwordReuseLimit'            => Env::get('PASSWORD_REUSE_LIMIT', 10),
         'profileReviewInterval'         => Env::get('PROFILE_REVIEW_INTERVAL', '+6 months'),
     ],

--- a/app/common/mail/reset-on-behalf.html.php
+++ b/app/common/mail/reset-on-behalf.html.php
@@ -37,7 +37,8 @@ use yii\helpers\Html as yHtml;
 <p>
     <?= yHtml::a(yHtml::encode($resetUrl), $resetUrl) ?>
 </p>
-<p>This link is valid for <?= yHtml::encode($lifetime) ?>.
+<p>
+    This link is valid for <?= yHtml::encode($lifetime) ?>.
 </p>
 <p>
     To maintain security, please don't forward this email to anyone.

--- a/app/common/mail/reset-on-behalf.html.php
+++ b/app/common/mail/reset-on-behalf.html.php
@@ -1,0 +1,59 @@
+<?php
+
+use yii\helpers\Html as yHtml;
+
+/**
+ * @var string $idpDisplayName
+ * @var string $lifetime
+ * @var string $resetUrl
+ * @var string $helpCenterUrl
+ * @var string $emailSignature
+ * @var string $displayName
+ * @var string $supportName
+ * @var string $supportEmail
+ * @var string $passwordProfileUrl
+ */
+?>
+<p>
+    Hi there,
+</p>
+<p>
+    <?= yHtml::encode($displayName) ?> recently requested a password change for their
+    <?= yHtml::encode($idpDisplayName) ?> Identity account.
+</p>
+<p>
+    If this was you, please use the link below to reset your password.
+</p>
+<p>
+    If it's not you but you do know them, you may have been sent this link because they requested
+    it sent to you - their recovery contact. You may provide the link for them to use, but <i>please
+    contact them directly</i> to ensure that you are only providing the link to them and not to
+    someone else.
+</p>
+<p>
+    If you are this person's supervisor or sponsor, please have them update their password recovery
+    address in the <?= yHtml::a('profile manager', $passwordProfileUrl) ?>.
+</p>
+<p>
+    <?= yHtml::a(yHtml::encode($resetUrl), $resetUrl) ?>
+</p>
+<p>This link is valid for <?= yHtml::encode($lifetime) ?>.
+</p>
+<p>
+    To maintain security, please don't forward this email to anyone.
+</p>
+<p>
+    <?php if (empty($helpCenterUrl)) { ?>
+        If you have any questions, please contact <?= yHtml::encode($supportName) ?> at
+        <?= yHtml::encode($supportEmail) ?>.
+    <?php } else { ?>
+        See our Help Center at <?= yHtml::a(yHtml::encode($helpCenterUrl), $helpCenterUrl) ?> for more security
+        tips.
+    <?php } ?>
+</p>
+<p>
+    Thanks,
+</p>
+<p>
+    <i><?= nl2br(yHtml::encode($emailSignature), false) ?></i>
+</p>

--- a/app/common/mail/reset-self.html.php
+++ b/app/common/mail/reset-self.html.php
@@ -1,0 +1,47 @@
+<?php
+
+use yii\helpers\Html as yHtml;
+
+/**
+ * @var string $idpDisplayName
+ * @var string $lifetime
+ * @var string $resetUrl
+ * @var string $helpCenterUrl
+ * @var string $displayName
+ * @var string $emailSignature
+ * @var string $supportName
+ * @var string $supportEmail
+ * @var string $passwordProfileUrl
+ */
+?>
+<p>
+    Dear <?= yHtml::encode($displayName) ?>,
+</p>
+<p>
+    Someone recently requested a password change for your <?= yHtml::encode($idpDisplayName) ?> Identity
+    account. If this was you, click the link below to set a new password.
+    This link is valid for <?= yHtml::encode($lifetime) ?>.
+</p>
+<p>
+    <?= yHtml::a(yHtml::encode($resetUrl), $resetUrl) ?>
+</p>
+<p>
+    If you don't want to change your password or didn't request this, just
+    ignore and delete this message.
+</p>
+<p>
+    To keep your account secure, please don't forward this email to anyone.
+    <?php if (empty($helpCenterUrl)) { ?>
+        If you have any questions, please contact <?= yHtml::encode($supportName) ?> at
+        <?= yHtml::encode($supportEmail) ?>.
+    <?php } else { ?>
+        See our Help Center at <?= yHtml::a(yHtml::encode($helpCenterUrl), $helpCenterUrl) ?> for more security
+        tips.
+    <?php } ?>
+</p>
+<p>
+    Thanks,
+</p>
+<p>
+    <i><?= nl2br(yHtml::encode($emailSignature), false) ?></i>
+</p>

--- a/app/common/models/EmailLog.php
+++ b/app/common/models/EmailLog.php
@@ -34,7 +34,9 @@ class EmailLog extends EmailLogBase
     public const MESSAGE_TYPE_MFA_RECOVERY_HELP = 'mfa-recovery-help';
     public const MESSAGE_TYPE_PASSWORD_EXPIRING = 'password-expiring';
     public const MESSAGE_TYPE_PASSWORD_EXPIRED = 'password-expired';
-    public const MESSAGE_TYPE_PASSWORD_PWNED = "password-pwned";
+    public const MESSAGE_TYPE_PASSWORD_PWNED = 'password-pwned';
+    public const MESSAGE_TYPE_RESET_ON_BEHALF = 'reset-on-behalf';
+    public const MESSAGE_TYPE_RESET_SELF = 'reset-self';
 
     /**
      * @inheritdoc

--- a/app/common/models/Reset.php
+++ b/app/common/models/Reset.php
@@ -61,6 +61,13 @@ class Reset extends ResetBase
 
         $reset = self::findOne(['user_id' => $user->id]);
 
+        if ($reset !== null && $reset->isExpired()) {
+            if ($reset->delete() === false) {
+                Yii::error("failed to delete reset for employee_id: " . $reset->user->employee_id);
+            }
+            $reset = null;
+        }
+
         if ($reset === null) {
             $reset = new Reset();
             $reset->user_id = $user->id;
@@ -105,7 +112,7 @@ class Reset extends ResetBase
      */
     public function isExpired(): bool
     {
-        return strtotime($this->expires) < time();
+        return strtotime($this->expires) <= time();
     }
 
     /**

--- a/app/common/models/Reset.php
+++ b/app/common/models/Reset.php
@@ -2,10 +2,11 @@
 
 namespace common\models;
 
+use common\components\Emailer;
 use common\helpers\MySqlDateTime;
+use Exception;
 use Ramsey\Uuid\Uuid;
 use Yii;
-use yii\db\Exception;
 use yii\helpers\ArrayHelper;
 
 /**
@@ -84,7 +85,7 @@ class Reset extends ResetBase
             ]);
         }
 
-        // TODO: send the reset email
+        $reset->send();
     }
 
     /**
@@ -106,4 +107,96 @@ class Reset extends ResetBase
     {
         return strtotime($this->expires) < time();
     }
+
+    /**
+     * Send the reset email
+     * @throws Exception
+     */
+    protected function send(): void
+    {
+        Yii::debug("sending reset to employee '{$this->user->employee_id}' primary email: " . $this->user->email);
+        $this->sendPrimary();
+
+        $methods = $this->user->getVerifiedMethodOptions();
+        if (empty($methods) && !empty($this->user->manager_email)) {
+            Yii::debug("sending reset to employee '{$this->user->employee_id}' manager: {$this->user->manager_email}");
+            $this->sendManager();
+            return;
+        }
+
+        Yii::debug("sending reset to employee '{$this->user->employee_id}' password reset emails");
+        $this->sendMethods($methods);
+    }
+
+    /**
+     * Send reset email to the user's primary email.
+     * @return void
+     */
+    protected function sendPrimary(): void
+    {
+        /* @var $emailer Emailer */
+        $emailer = Yii::$app->emailer;
+        $emailer->sendMessageTo(EmailLog::MESSAGE_TYPE_RESET_SELF, $this->user, $this->dataForEmail());
+    }
+
+    /**
+     * Send reset email to the user's manager_email.
+     * @throws Exception
+     */
+    protected function sendManager(): void
+    {
+        if (empty($this->user->manager_email)) {
+            throw new Exception('User does not have manager_email', 1461173406);
+        }
+
+        /* @var $emailer Emailer */
+        $emailer = Yii::$app->emailer;
+        $emailer->sendMessageTo(
+            EmailLog::MESSAGE_TYPE_RESET_ON_BEHALF,
+            null,
+            $this->dataForEmail($this->user->manager_email),
+        );
+    }
+
+    /**
+     * Send reset email to the user's password recovery emails.
+     * @param Method[] $methods
+     * @return void
+     */
+    protected function sendMethods(array $methods): void
+    {
+        foreach ($methods as $method) {
+            /* @var $emailer Emailer */
+            $emailer = Yii::$app->emailer;
+            $emailer->sendMessageTo(
+                EmailLog::MESSAGE_TYPE_RESET_SELF,
+                // Don't log this as a user email because the Emailer won't log the email address in that case.
+                // If non_user_address validation is changed to allow this, this should be changed to `$this->user`.
+                null,
+                $this->dataForEmail($method->value),
+            );
+        }
+    }
+
+    /**
+     * Get the data items needed to render the email template. Provide the toAddress if the email is being sent
+     * to an address other than the user's primary email.
+     * @param string|null $toAddress
+     * @return array
+     */
+    protected function dataForEmail(?string $toAddress = null): array
+    {
+        $resetUrl = sprintf('%s/password/reset/%s/verify/0', \Yii::$app->params['passwordProfileUrl'], $this->uuid);
+        $data = [
+            'resetUrl' => $resetUrl,
+            'lifetime' => self::LIFETIME,
+            'displayName' => $this->user->getDisplayName(),
+            'firstName' => $this->user->first_name,
+        ];
+        if (!empty($toAddress)) {
+            $data['toAddress'] = $toAddress;
+        }
+        return $data;
+    }
+
 }

--- a/app/common/models/Reset.php
+++ b/app/common/models/Reset.php
@@ -114,17 +114,17 @@ class Reset extends ResetBase
      */
     protected function send(): void
     {
-        Yii::debug("sending reset to employee '{$this->user->employee_id}' primary email: " . $this->user->email);
+        Yii::info("sending reset to employee '{$this->user->employee_id}' primary email: " . $this->user->email);
         $this->sendPrimary();
 
         $methods = $this->user->getVerifiedMethodOptions();
         if (empty($methods) && !empty($this->user->manager_email)) {
-            Yii::debug("sending reset to employee '{$this->user->employee_id}' manager: {$this->user->manager_email}");
+            Yii::info("sending reset to employee '{$this->user->employee_id}' manager: {$this->user->manager_email}");
             $this->sendManager();
             return;
         }
 
-        Yii::debug("sending reset to employee '{$this->user->employee_id}' password reset emails");
+        Yii::info("sending reset to employee '{$this->user->employee_id}' password reset emails");
         $this->sendMethods($methods);
     }
 

--- a/app/console/migrations/m260427_000000_create_reset_table.php
+++ b/app/console/migrations/m260427_000000_create_reset_table.php
@@ -33,8 +33,8 @@ class m260427_000000_create_reset_table extends Migration
             'user_id',
             '{{user}}',
             'id',
-            'CASCADE',
-            'CASCADE'
+            'NO ACTION',
+            'NO ACTION'
         );
     }
 

--- a/app/console/migrations/m260427_000000_create_reset_table.php
+++ b/app/console/migrations/m260427_000000_create_reset_table.php
@@ -33,8 +33,8 @@ class m260427_000000_create_reset_table extends Migration
             'user_id',
             '{{user}}',
             'id',
-            'NO ACTION',
-            'NO ACTION'
+            'CASCADE',
+            'CASCADE'
         );
     }
 

--- a/app/console/migrations/m260511_000000_change_email_log_type_column.php
+++ b/app/console/migrations/m260511_000000_change_email_log_type_column.php
@@ -1,0 +1,33 @@
+<?php
+
+use yii\db\Migration;
+
+class m260511_000000_change_email_log_type_column extends Migration
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+
+        $this->alterColumn(
+            '{{email_log}}',
+            'message_type',
+            "varchar(32) null"
+        );
+
+
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->alterColumn(
+            '{{email_log}}',
+            'message_type',
+            "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes','refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed','mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help','method-reminder','method-purged','password-expiring','password-expired','password-pwned','ext-group-sync-errors','abandoned-users', 'mfa-recovery', 'mfa-recovery-help') null"
+        );
+    }
+}

--- a/app/features/bootstrap/FeatureContext.php
+++ b/app/features/bootstrap/FeatureContext.php
@@ -800,4 +800,12 @@ class FeatureContext extends YiiContext
     {
         $this->cleanRequestBody();
     }
+
+    #[Given('a user that has an existing reset record')]
+    public function aUserThatHasAnExistingResetRecord(): void
+    {
+        $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
+        Reset::create($user);
+        Assert::notEmpty($user->reset);
+    }
 }

--- a/app/features/bootstrap/ResetContext.php
+++ b/app/features/bootstrap/ResetContext.php
@@ -4,11 +4,11 @@ namespace Sil\SilIdBroker\Behat\Context;
 
 use Behat\Step\Given;
 use Behat\Step\Then;
+use Behat\Step\When;
 use common\models\Reset;
-use common\models\User;
 use Webmozart\Assert\Assert;
 
-class ResetContext extends \FeatureContext
+class ResetContext extends UnitTestsContext
 {
     /** @var string|null */
     protected ?string $previousResetUuid = null;
@@ -16,14 +16,17 @@ class ResetContext extends \FeatureContext
     /** @var Reset|null */
     protected ?Reset $reset = null;
 
-    #[Then('a reset record exists for employee :employeeId')]
-    public function aResetRecordExistsForEmployee(string $employeeId): void
+    #[Given('the user has a password recovery email :arg1')]
+    public function theUserHasAPasswordRecoveryEmail($arg1): void
     {
-        $user = User::findOne(['employee_id' => $employeeId]);
-        Assert::notNull($user, 'User not found for employee_id ' . $employeeId);
+        $this->createMethod($arg1, 1, $this->tempUser);
+    }
 
-        $this->reset = Reset::findOne(['user_id' => $user->id]);
-        Assert::notNull($this->reset, 'No reset record found for employee_id ' . $employeeId);
+    #[Then('a reset record exists for the user')]
+    public function aResetRecordExistsForTheUser(): void
+    {
+        $this->reset = Reset::findOne(['user_id' => $this->tempUser->id]);
+        Assert::notNull($this->reset, 'No reset record found');
     }
 
     #[Then('the reset record has a non-empty UUID')]
@@ -44,11 +47,27 @@ class ResetContext extends \FeatureContext
         );
     }
 
-    #[Given('a user that has an existing reset record')]
-    public function aUserThatHasAnExistingResetRecord(): void
+    #[When('the user requests a password reset')]
+    public function theUserRequestsAPasswordReset(): void
     {
-        $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
-        Reset::create($user);
-        Assert::notEmpty($user->reset);
+        Reset::create($this->tempUser);
     }
+
+    #[Then('a :template email should be sent to their primary email')]
+    public function aTemplateEmailShouldBeSentToTheirPrimaryEmail($template): void
+    {
+        $address = $this->tempUser->email;
+        $emails = $this->fakeEmailer->getFakeEmailsOfTypeSentToUser($template, $address, $this->tempUser);
+
+        Assert::greaterThan(count($emails), 0, sprintf('Did not find any %s emails sent to %s.', $template, $address));
+    }
+
+    #[Then('a :template email should be sent to :email')]
+    public function aTemplateEmailShouldBeSentToEmail($template, $email): void
+    {
+        $emails = $this->fakeEmailer->getFakeEmailsOfTypeSentToUser($template, $email, $this->tempUser);
+
+        Assert::greaterThan(count($emails), 0, sprintf('Did not find any %s emails sent to %s.', $template, $email));
+    }
+
 }

--- a/app/features/bootstrap/ResetContext.php
+++ b/app/features/bootstrap/ResetContext.php
@@ -5,6 +5,7 @@ namespace Sil\SilIdBroker\Behat\Context;
 use Behat\Step\Given;
 use Behat\Step\Then;
 use Behat\Step\When;
+use common\helpers\MySqlDateTime;
 use common\models\Reset;
 use Webmozart\Assert\Assert;
 
@@ -22,6 +23,33 @@ class ResetContext extends UnitTestsContext
     public function theUserHasAPasswordRecoveryEmail($arg1): void
     {
         $this->createMethod($arg1, 1, $this->tempUser);
+    }
+
+    #[Given('there is a user in the database with a valid password reset')]
+    public function thereIsAUserInTheDatabaseWithAValidPasswordReset(): void
+    {
+        $this->thereIsAUserInTheDatabase();
+        $this->reset = new Reset();
+        $this->reset->user_id = $this->tempUser->id;
+        Assert::true($this->reset->save(), 'failed to save a new Reset');
+    }
+
+    #[Given('there is a user in the database with an expired password reset')]
+    public function thereIsAUserInTheDatabaseWithAnExpiredPasswordReset(): void
+    {
+        $this->thereIsAUserInTheDatabase();
+        $this->reset = new Reset();
+        $this->reset->user_id = $this->tempUser->id;
+        $this->reset->expires = MySqlDateTime::now();
+        Assert::true($this->reset->save(), 'failed to save a new Reset');
+    }
+
+    #[When('the user requests a password reset')]
+    public function theUserRequestsAPasswordReset(): void
+    {
+        $this->emailCount = 0;
+        $this->fakeEmailer->forgetFakeEmailsSent();
+        Reset::create($this->tempUser);
     }
 
     #[Then('a reset record exists for the user')]
@@ -47,14 +75,6 @@ class ResetContext extends UnitTestsContext
             date('Y-m-d H:i:s'),
             'Expires should be in the future: ' . $this->reset->expires
         );
-    }
-
-    #[When('the user requests a password reset')]
-    public function theUserRequestsAPasswordReset(): void
-    {
-        $this->emailCount = 0;
-        $this->fakeEmailer->forgetFakeEmailsSent();
-        Reset::create($this->tempUser);
     }
 
     #[Then('a :template email should be sent to their primary email')]

--- a/app/features/bootstrap/ResetContext.php
+++ b/app/features/bootstrap/ResetContext.php
@@ -16,6 +16,8 @@ class ResetContext extends UnitTestsContext
     /** @var Reset|null */
     protected ?Reset $reset = null;
 
+    protected int $emailCount = 0;
+
     #[Given('the user has a password recovery email :arg1')]
     public function theUserHasAPasswordRecoveryEmail($arg1): void
     {
@@ -50,6 +52,8 @@ class ResetContext extends UnitTestsContext
     #[When('the user requests a password reset')]
     public function theUserRequestsAPasswordReset(): void
     {
+        $this->emailCount = 0;
+        $this->fakeEmailer->forgetFakeEmailsSent();
         Reset::create($this->tempUser);
     }
 
@@ -60,6 +64,7 @@ class ResetContext extends UnitTestsContext
         $emails = $this->fakeEmailer->getFakeEmailsOfTypeSentToUser($template, $address, $this->tempUser);
 
         Assert::greaterThan(count($emails), 0, sprintf('Did not find any %s emails sent to %s.', $template, $address));
+        $this->emailCount++;
     }
 
     #[Then('a :template email should be sent to :email')]
@@ -68,6 +73,17 @@ class ResetContext extends UnitTestsContext
         $emails = $this->fakeEmailer->getFakeEmailsOfTypeSentToUser($template, $email, $this->tempUser);
 
         Assert::greaterThan(count($emails), 0, sprintf('Did not find any %s emails sent to %s.', $template, $email));
+        $this->emailCount++;
     }
 
+    #[Then('no other emails should be sent')]
+    public function noOtherEmailsShouldBeSent(): void
+    {
+        $receiveCount = count($this->fakeEmailer->getFakeEmailsSent());
+        Assert::eq(
+            $receiveCount,
+            $this->emailCount,
+            "Received more emails than expected. Got $receiveCount, expected $this->emailCount.",
+        );
+    }
 }

--- a/app/features/reset-unit-tests.feature
+++ b/app/features/reset-unit-tests.feature
@@ -17,6 +17,11 @@ Feature: Password Reset
     Then a "reset-self" email should be sent to their primary email
     And a "reset-on-behalf" email should be sent to "manager@example.com"
 
+  Scenario: Create a password reset for a user with no recovery options and no manager
+    Given there is a user in the database
+    When the user requests a password reset
+    Then a "reset-self" email should be sent to their primary email
+
   Scenario: Create a password reset for a user with a password recovery email
     Given there is a user in the database
     And the user has a password recovery email "recovery@example.com"

--- a/app/features/reset-unit-tests.feature
+++ b/app/features/reset-unit-tests.feature
@@ -16,11 +16,13 @@ Feature: Password Reset
     When the user requests a password reset
     Then a "reset-self" email should be sent to their primary email
     And a "reset-on-behalf" email should be sent to "manager@example.com"
+    And no other emails should be sent
 
   Scenario: Create a password reset for a user with no recovery options and no manager
     Given there is a user in the database
     When the user requests a password reset
     Then a "reset-self" email should be sent to their primary email
+    And no other emails should be sent
 
   Scenario: Create a password reset for a user with a password recovery email
     Given there is a user in the database
@@ -28,3 +30,4 @@ Feature: Password Reset
     When the user requests a password reset
     Then a "reset-self" email should be sent to their primary email
     And a "reset-self" email should be sent to "recovery@example.com"
+    And no other emails should be sent

--- a/app/features/reset-unit-tests.feature
+++ b/app/features/reset-unit-tests.feature
@@ -31,3 +31,17 @@ Feature: Password Reset
     Then a "reset-self" email should be sent to their primary email
     And a "reset-self" email should be sent to "recovery@example.com"
     And no other emails should be sent
+
+  Scenario: Create a password reset for a user who has one already
+    Given there is a user in the database with a valid password reset
+    When the user requests a password reset
+    Then a reset record exists for the user
+    And the reset record has an expiry in the future
+    And a "reset-self" email should be sent to their primary email
+
+  Scenario: Create a password reset for a user who has an expired reset
+    Given there is a user in the database with an expired password reset
+    When the user requests a password reset
+    Then a reset record exists for the user
+    And the reset record has an expiry in the future
+    And a "reset-self" email should be sent to their primary email

--- a/app/features/reset-unit-tests.feature
+++ b/app/features/reset-unit-tests.feature
@@ -1,0 +1,25 @@
+Feature: Password Reset
+  Users can initiate a password reset, which stores a reset record in the database and sends an email with a
+  unique URL for completing a password reset sequence.
+
+  Scenario: Create a password reset for a user
+    Given there is a user in the database
+    And that user has a "manager_email" property value of "manager@example.com"
+    When the user requests a password reset
+    Then a reset record exists for the user
+    And the reset record has a non-empty UUID
+    And the reset record has an expiry in the future
+
+  Scenario: Create a password reset for a user with no password recovery options
+    Given there is a user in the database
+    And that user has a "manager_email" property value of "manager@example.com"
+    When the user requests a password reset
+    Then a "reset-self" email should be sent to their primary email
+    And a "reset-on-behalf" email should be sent to "manager@example.com"
+
+  Scenario: Create a password reset for a user with a password recovery email
+    Given there is a user in the database
+    And the user has a password recovery email "recovery@example.com"
+    When the user requests a password reset
+    Then a "reset-self" email should be sent to their primary email
+    And a "reset-self" email should be sent to "recovery@example.com"

--- a/app/features/reset.feature
+++ b/app/features/reset.feature
@@ -12,18 +12,12 @@ Feature: Password Reset API
     When I request "/reset" be created
     Then the response status code should be 204
       And there is no response body
-      And a reset record exists for employee "123"
-      And the reset record has a non-empty UUID
-      And the reset record has an expiry in the future
 
   Scenario: Successfully create a reset record given a user's email address
     Given I prepare a request with the user's email address given as their username
     When I request "/reset" be created
     Then the response status code should be 204
       And there is no response body
-      And a reset record exists for employee "123"
-      And the reset record has a non-empty UUID
-      And the reset record has an expiry in the future
 
   Scenario: Attempt to create a reset without providing employee_id
     When I provide an empty request body

--- a/app/features/reset.feature
+++ b/app/features/reset.feature
@@ -1,6 +1,6 @@
 Feature: Password Reset API
-  Users can initiate a password reset, which stores a reset record with a
-  verification code in the database.
+  Users can initiate a password reset, which stores a reset record in the database and returns an API result that
+  is not indicative of whether the user actually exists.
 
   Background:
     Given the requester is authorized
@@ -15,9 +15,6 @@ Feature: Password Reset API
     Then the response status code should be 204
       And the following data is returned:
         | property | value |
-      And a reset record exists for employee "123"
-      And the reset record has a non-empty UUID
-      And the reset record has an expiry in the future
 
   Scenario: Attempt to create a reset without providing employee_id
     When I provide an empty request body

--- a/app/frontend/controllers/ResetController.php
+++ b/app/frontend/controllers/ResetController.php
@@ -38,6 +38,7 @@ class ResetController extends BaseRestController
         Yii::$app->response->statusCode = 204;
 
         if ($user === null) {
+            Yii::info("password reset attempted, but username '$username' not found");
             return null;
         }
 

--- a/openapi.json
+++ b/openapi.json
@@ -1671,17 +1671,17 @@
       },
       "ResetCreation": {
         "example": {
-          "employee_id": "12345"
+          "username": "john_doe"
         },
         "type": "object",
         "properties": {
-          "employee_id": {
+          "username": {
             "type": "string",
-            "description": "The employee ID of the user requesting a password reset."
+            "description": "The username or email of the user requesting a password reset."
           }
         },
         "required": [
-          "employee_id"
+          "username"
         ]
       },
       "UserResponse": {


### PR DESCRIPTION
[IDP-1960](https://support.gtis.sil.org/issue/IDP-1960) Add password reset capability to idp-id-broker

---

### Added
- Added password reset emails. The templates are copied from [idp-pw-api](http://github.com/sil-org/idp-pw-api), but the rest is new code.

### Fixed
- Added `.PHONY: db` to the Makefile because the make target and the actual directory in the repo are not directly related.

---

### PR Checklist
- [ ] Documentation (README, local.env.dist, openapi.json, etc.)
- [x] Tests created or updated
- [ ] Run `make composershow`
- [x] Run `make psr2`
