### PR TITLE
add reset verification endpoint

### DIFF
--- a/app/common/config/main.php
+++ b/app/common/config/main.php
@@ -331,7 +331,7 @@ return [
         'passwordGracePeriodExtension'  => '+7 days',
         'passwordLifespan'              => Env::get('PASSWORD_LIFESPAN', '+1 year'),
         'passwordMfaLifespanExtension'  => Env::get('PASSWORD_MFA_LIFESPAN_EXTENSION', '+4 years'),
-        'passwordProfileUrl'            => $passwordProfileUrl,
+        'passwordProfileUrl'            => $passwordProfileUrl . "/#",
         'passwordReuseLimit'            => Env::get('PASSWORD_REUSE_LIMIT', 10),
         'profileReviewInterval'         => Env::get('PROFILE_REVIEW_INTERVAL', '+6 months'),
     ],

--- a/app/common/models/Reset.php
+++ b/app/common/models/Reset.php
@@ -210,7 +210,6 @@ class Reset extends ResetBase
     {
         $this->expires = MySqlDateTime::now();
         if (!$this->save()) {
-            print_r($this->getFirstErrors());
             Yii::error("failed to expire reset: " . implode(", ", $this->getFirstErrors()));
         }
     }

--- a/app/common/models/Reset.php
+++ b/app/common/models/Reset.php
@@ -206,4 +206,12 @@ class Reset extends ResetBase
         return $data;
     }
 
+    public function verify(): void
+    {
+        $this->expires = MySqlDateTime::now();
+        if (!$this->save()) {
+            print_r($this->getFirstErrors());
+            Yii::error("failed to expire reset: " . implode(", ", $this->getFirstErrors()));
+        }
+    }
 }

--- a/app/features/bootstrap/FeatureContext.php
+++ b/app/features/bootstrap/FeatureContext.php
@@ -133,7 +133,12 @@ class FeatureContext extends YiiContext
     }
 
     #[When('/^I request "(.*)" be <?(created|updated|deleted|retrieved|headed|patched)>?$/')]
-    public function iRequestTheResourceBe($resource, $action)
+    public function iRequestTheResourceBe($resource, $action): void
+    {
+        $this->sendRequestAndRecordResponse($resource, $action);
+    }
+
+    public function sendRequestAndRecordResponse($resource, $action): void
     {
         $client = $this->buildClient();
 
@@ -807,5 +812,37 @@ class FeatureContext extends YiiContext
         $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
         Reset::create($user);
         Assert::notEmpty($user->reset);
+    }
+
+    #[Given('the reset has expired')]
+    public function theResetHasExpired(): void
+    {
+        $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
+        $reset = $user->reset;
+        $reset->expires = MySqlDateTime::now();
+        Assert::true($reset->save());
+    }
+
+    #[When('I send a reset verification request using the correct uuid')]
+    public function iSendAResetVerificationRequestUsingTheCorrectUuid(): void
+    {
+        $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
+        $reset = $user->reset;
+
+        $this->sendRequestAndRecordResponse("/reset/$reset->uuid/verify", self::UPDATED);
+    }
+
+    #[When('I send a reset verification request using an incorrect uuid')]
+    public function iSendAResetVerificationRequestUsingAnIncorrectUuid(): void
+    {
+        $this->sendRequestAndRecordResponse("/reset/0000/verify", self::UPDATED);
+    }
+
+    #[Then('the response should contain the employee_id of the user')]
+    public function theResponseShouldContainTheEmployee_IdOfTheUser(): void
+    {
+        $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
+        $respBody = $this->getResponseBody();
+        Assert::eq($respBody['employee_id'], $user->employee_id, "The response did not contain the employee_id.");
     }
 }

--- a/app/features/bootstrap/ResetContext.php
+++ b/app/features/bootstrap/ResetContext.php
@@ -44,12 +44,26 @@ class ResetContext extends UnitTestsContext
         Assert::true($this->reset->save(), 'failed to save a new Reset');
     }
 
+    #[Given('the user has requested a password reset')]
+    public function theUserHasRequestedAPasswordReset(): void
+    {
+        $this->reset = new Reset();
+        $this->reset->user_id = $this->tempUser->id;
+        Assert::true($this->reset->save(), 'failed to save a new Reset');
+    }
+
     #[When('the user requests a password reset')]
     public function theUserRequestsAPasswordReset(): void
     {
         $this->emailCount = 0;
         $this->fakeEmailer->forgetFakeEmailsSent();
         Reset::create($this->tempUser);
+    }
+
+    #[When('the user submits the reset for verification')]
+    public function theUserSubmitsTheResetForVerification(): void
+    {
+        $this->reset->verify();
     }
 
     #[Then('a reset record exists for the user')]
@@ -105,21 +119,6 @@ class ResetContext extends UnitTestsContext
             $this->emailCount,
             "Received more emails than expected. Got $receiveCount, expected $this->emailCount.",
         );
-    }
-
-    #[Given('the user has requested a password reset')]
-    public function theUserHasRequestedAPasswordReset(): void
-    {
-        $this->reset = new Reset();
-        $this->reset->user_id = $this->tempUser->id;
-        Assert::true($this->reset->save(), 'failed to save a new Reset');
-    }
-
-
-    #[When('the user submits the reset for verification')]
-    public function theUserSubmitsTheResetForVerification(): void
-    {
-        $this->reset->verify();
     }
 
     #[Then('the reset will become expired')]

--- a/app/features/bootstrap/ResetContext.php
+++ b/app/features/bootstrap/ResetContext.php
@@ -106,4 +106,25 @@ class ResetContext extends UnitTestsContext
             "Received more emails than expected. Got $receiveCount, expected $this->emailCount.",
         );
     }
+
+    #[Given('the user has requested a password reset')]
+    public function theUserHasRequestedAPasswordReset(): void
+    {
+        $this->reset = new Reset();
+        $this->reset->user_id = $this->tempUser->id;
+        Assert::true($this->reset->save(), 'failed to save a new Reset');
+    }
+
+
+    #[When('the user submits the reset for verification')]
+    public function theUserSubmitsTheResetForVerification(): void
+    {
+        $this->reset->verify();
+    }
+
+    #[Then('the reset will become expired')]
+    public function theResetWillBecomeExpired(): void
+    {
+        Assert::true($this->reset->isExpired());
+    }
 }

--- a/app/features/reset-unit-tests.feature
+++ b/app/features/reset-unit-tests.feature
@@ -45,3 +45,9 @@ Feature: Password Reset
     Then a reset record exists for the user
     And the reset record has an expiry in the future
     And a "reset-self" email should be sent to their primary email
+
+  Scenario: Verify a password reset
+    Given there is a user in the database
+    And the user has requested a password reset
+    When the user submits the reset for verification
+    Then the reset will become expired

--- a/app/features/reset.feature
+++ b/app/features/reset.feature
@@ -48,7 +48,7 @@ Feature: Password Reset API
     Given a user that has an existing reset record
     And the reset has expired
     When I send a reset verification request using the correct uuid
-    Then the response status code should be 410
+    Then the response status code should be 404
 
   Scenario: Attempt to validate a reset using an invalid UUID
     Given a user that has an existing reset record

--- a/app/features/reset.feature
+++ b/app/features/reset.feature
@@ -32,3 +32,20 @@ Feature: Password Reset API
     Given a user that has an existing reset record
     When I request "/reset" be created
     Then the response status code should be 204
+
+  Scenario: Correctly verifying a reset
+    Given a user that has an existing reset record
+    When I send a reset verification request using the correct uuid
+    Then the response status code should be 200
+    And the response should contain the employee_id of the user
+
+  Scenario: Attempt to validate an expired reset
+    Given a user that has an existing reset record
+    And the reset has expired
+    When I send a reset verification request using the correct uuid
+    Then the response status code should be 410
+
+  Scenario: Attempt to validate a reset using an invalid UUID
+    Given a user that has an existing reset record
+    When I send a reset verification request using an incorrect uuid
+    Then the response status code should be 404

--- a/app/frontend/config/main.php
+++ b/app/frontend/config/main.php
@@ -85,8 +85,12 @@ return [
                 /*
                  * Reset routes
                  */
-                'POST reset' => 'reset/create',
+                'POST reset'               => 'reset/create',
+                'PUT /reset/<uuid>/verify' => 'reset/verify',
 
+                /*
+                 * Email routes
+                 */
                 'POST email' => 'email/queue',
 
                 'site/status' => 'site/status',

--- a/app/frontend/controllers/ResetController.php
+++ b/app/frontend/controllers/ResetController.php
@@ -6,8 +6,9 @@ use common\models\Reset;
 use common\models\User;
 use frontend\components\BaseRestController;
 use Yii;
-use yii\db\Exception;
 use yii\web\BadRequestHttpException;
+use yii\web\GoneHttpException;
+use yii\web\NotFoundHttpException;
 
 class ResetController extends BaseRestController
 {
@@ -18,7 +19,7 @@ class ResetController extends BaseRestController
      * the verification email.
      *
      * @throws BadRequestHttpException
-     * @throws Exception
+     * @throws \Exception
      */
     public function actionCreate()
     {
@@ -43,5 +44,31 @@ class ResetController extends BaseRestController
         }
 
         Reset::create($user);
+    }
+
+    /**
+     * PUT /reset/{uuid}/verify
+     * Verifies a reset. If found, its expiration time will be set to the current time to prevent it from being used
+     * a second time.
+     * @throws GoneHttpException
+     * @throws \Exception
+     */
+    public function actionVerify(string $uuid): array
+    {
+        /** @var Reset $reset */
+        $reset = Reset::findOne(['uuid' => $uuid]);
+        if ($reset === null) {
+            throw new NotFoundHttpException();
+        }
+
+        if ($reset->isExpired()) {
+            throw new GoneHttpException();
+        }
+
+        $reset->verify();
+
+        return [
+            'employee_id' => $reset->user->employee_id,
+        ];
     }
 }

--- a/app/frontend/controllers/ResetController.php
+++ b/app/frontend/controllers/ResetController.php
@@ -7,7 +7,6 @@ use common\models\User;
 use frontend\components\BaseRestController;
 use Yii;
 use yii\web\BadRequestHttpException;
-use yii\web\GoneHttpException;
 use yii\web\NotFoundHttpException;
 
 class ResetController extends BaseRestController
@@ -50,19 +49,15 @@ class ResetController extends BaseRestController
      * PUT /reset/{uuid}/verify
      * Verifies a reset. If found, its expiration time will be set to the current time to prevent it from being used
      * a second time.
-     * @throws GoneHttpException
+     * @throws NotFoundHttpException
      * @throws \Exception
      */
     public function actionVerify(string $uuid): array
     {
         /** @var Reset $reset */
         $reset = Reset::findOne(['uuid' => $uuid]);
-        if ($reset === null) {
+        if ($reset === null || $reset->isExpired()) {
             throw new NotFoundHttpException();
-        }
-
-        if ($reset->isExpired()) {
-            throw new GoneHttpException();
         }
 
         $reset->verify();

--- a/openapi.json
+++ b/openapi.json
@@ -140,16 +140,6 @@
               }
             }
           },
-          "410": {
-            "description": "Reset has expired",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Error"
-                }
-              }
-            }
-          },
           "500": {
             "description": "A server-side error occurred.",
             "content": {

--- a/openapi.json
+++ b/openapi.json
@@ -124,6 +124,56 @@
         }
       }
     },
+    "/reset/{uuid}/verify": {
+      "put": {
+        "responses": {
+          "200": {
+            "description": "Reset was found and is valid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResetVerifyResponse"
+                  }
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Reset has expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "A server-side error occurred.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "operationId": "PUT_reset_verify",
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      }
+    },
     "/user": {
       "get": {
         "responses": {
@@ -1682,6 +1732,21 @@
         },
         "required": [
           "username"
+        ]
+      },
+      "ResetVerifyResponse": {
+        "example": {
+          "employee_id": "12345"
+        },
+        "type": "object",
+        "properties": {
+          "employee_id": {
+            "type": "string",
+            "description": "user's employee ID"
+          }
+        },
+        "required": [
+          "employee_id"
         ]
       },
       "UserResponse": {


### PR DESCRIPTION
[IDP-1960](https://support.gtis.sil.org/issue/IDP-1960) Add password reset capability to idp-id-broker

---

### Added
- Added `PUT /reset/{uuid}/verify` endpoint.

### Fixed
- Added the missing `/#` to the URL given in the password reset email. The idp-profile-ui code ignores the path when it redirects to the hash-based path, which breaks the password recovery flow.

---

### PR Checklist
- [x] Documentation (README, local.env.dist, openapi.json, etc.)
- [x] Tests created or updated
- [ ] Run `make composershow`
- [x] Run `make psr2`
