### PR TITLE
corrections suggested by feedback on PR #465

### DIFF
--- a/app/behat.yml
+++ b/app/behat.yml
@@ -75,7 +75,7 @@ default:
       paths:
         - "features/reset.feature"
       contexts: [FeatureContext]
-    reset__unit_tests_features:
+    reset_unit_tests_features:
       paths:
         - "features/reset-unit-tests.feature"
       contexts: [Sil\SilIdBroker\Behat\Context\ResetContext]

--- a/app/common/models/Reset.php
+++ b/app/common/models/Reset.php
@@ -75,7 +75,6 @@ class Reset extends ResetBase
         if ($reset !== null && $reset->isExpired()) {
             if ($reset->delete() === false) {
                 Yii::error("failed to delete reset for employee_id: " . $reset->user->employee_id);
-                throw new Exception('Failed to delete expired reset.');
             }
             $reset = null;
         }

--- a/app/common/models/Reset.php
+++ b/app/common/models/Reset.php
@@ -75,6 +75,7 @@ class Reset extends ResetBase
         if ($reset !== null && $reset->isExpired()) {
             if ($reset->delete() === false) {
                 Yii::error("failed to delete reset for employee_id: " . $reset->user->employee_id);
+                throw new Exception('Failed to delete expired reset.');
             }
             $reset = null;
         }

--- a/app/console/migrations/m260511_000000_change_email_log_type_column.php
+++ b/app/console/migrations/m260511_000000_change_email_log_type_column.php
@@ -27,7 +27,7 @@ class m260511_000000_change_email_log_type_column extends Migration
         $this->alterColumn(
             '{{email_log}}',
             'message_type',
-            "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes','refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed','mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help','method-reminder','method-purged','password-expiring','password-expired','password-pwned','ext-group-sync-errors','abandoned-users', 'mfa-recovery', 'mfa-recovery-help') null"
+            "enum('invite','welcome','mfa-rate-limit','password-changed','get-backup-codes','refresh-backup-codes','lost-security-key','mfa-option-added','mfa-option-removed','mfa-enabled','mfa-disabled','method-verify','mfa-manager','mfa-manager-help','method-reminder','method-purged','password-expiring','password-expired','password-pwned','ext-group-sync-errors','abandoned-users', 'mfa-recovery', 'mfa-recovery-help', 'reset-self', 'reset-on-behalf') null"
         );
     }
 }


### PR DESCRIPTION
[IDP-1960](https://support.gtis.sil.org/issue/IDP-1960) Add password reset capability to idp-id-broker

---

### Fixed
- Corrections suggested by feedback on #465 
  - Removed a harmless but extra underscore in behat.yml
  - Added the new email types to the down migration, just in case it might need to run after those types are added to the database.

---

### PR Checklist
- [x] Documentation (README, local.env.dist, openapi.json, etc.)
- [x] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
