### PR TITLE
corrections suggested by feedback on PR #467

### DIFF
--- a/app/features/bootstrap/FeatureContext.php
+++ b/app/features/bootstrap/FeatureContext.php
@@ -869,7 +869,7 @@ class FeatureContext extends YiiContext
     }
 
     #[Then('the response should contain the employee_id of the user')]
-    public function theResponseShouldContainTheEmployee_IdOfTheUser(): void
+    public function theResponseShouldContainTheEmployeeIdOfTheUser(): void
     {
         $user = User::findOne(['employee_id' => $this->tempEmployeeId]);
         $respBody = $this->getResponseBody();

--- a/app/frontend/config/main.php
+++ b/app/frontend/config/main.php
@@ -86,7 +86,7 @@ return [
                  * Reset routes
                  */
                 'POST reset'               => 'reset/create',
-                'PUT /reset/<uuid>/verify' => 'reset/verify',
+                'PUT reset/<uuid>/verify' => 'reset/verify',
 
                 /*
                  * Email routes

--- a/openapi.json
+++ b/openapi.json
@@ -132,10 +132,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ResetVerifyResponse"
-                  }
+                  "$ref": "#/components/schemas/ResetVerifyResponse"
                 }
               }
             }


### PR DESCRIPTION
[IDP-1960](https://support.gtis.sil.org/issue/IDP-1960) Add password reset capability to idp-id-broker

---

### Fixed
- Corrections suggested by feedback on PR #467
  - Corrected non-standard underscore in a FeatureContext method.
  - For consistency, remove the leading slash from the new reset verify endpoint route.
  - Fixed an error in the OpenAPI spec regarding the response body of the reset verify endpoint.

---

### PR Checklist
- [x] Documentation (README, local.env.dist, openapi.json, etc.)
- [x] Tests created or updated
- [x] Run `make composershow`
- [x] Run `make psr2`
