### PR TITLE
handle null $this->email gracefully

### DIFF
--- a/app/common/models/User.php
+++ b/app/common/models/User.php
@@ -848,9 +848,11 @@ class User extends UserBase
             $ccAddresses[] = $this->personal_email;
         }
         if (\Yii::$app->params['accountMailAdminsCcOnInvite']) {
+            $mailAdminEmails = [];
             if (!empty($this->email)) {
                 $mailAdminEmails = MailAdmin::getEmailsFor($this->email);
-            } else {
+            }
+            if (empty($mailAdminEmails)) {
                 $fallback = \Yii::$app->params['accountMailAdminsCcFallback'] ?? '';
                 $mailAdminEmails = $fallback === '' ? [] : [$fallback];
             }

--- a/app/common/models/User.php
+++ b/app/common/models/User.php
@@ -848,8 +848,9 @@ class User extends UserBase
             $ccAddresses[] = $this->personal_email;
         }
         if (\Yii::$app->params['accountMailAdminsCcOnInvite']) {
-            $mailAdminEmails = MailAdmin::getEmailsFor($this->email);
-            if (empty($mailAdminEmails)) {
+            if (!empty($this->email)) {
+                $mailAdminEmails = MailAdmin::getEmailsFor($this->email);
+            } else {
                 $fallback = \Yii::$app->params['accountMailAdminsCcFallback'] ?? '';
                 $mailAdminEmails = $fallback === '' ? [] : [$fallback];
             }

--- a/app/features/bootstrap/EmailContext.php
+++ b/app/features/bootstrap/EmailContext.php
@@ -66,6 +66,8 @@ class EmailContext extends YiiContext
 
     private ?EmailLog $tempEmailLog;
 
+    private string $fallback = '';
+
     public const METHOD_EMAIL_ADDRESS = 'method@example.com';
     public const MANAGER_EMAIL = 'manager@example.com';
     public const RECOVERY_EMAIL = 'recovery@example.com';
@@ -1213,7 +1215,7 @@ class EmailContext extends YiiContext
     #[Given('we are configured to CC :address as the mail admin fallback')]
     public function weAreConfiguredToCcAsTheMailAdminFallback($address): void
     {
-        \Yii::$app->params['accountMailAdminsCcFallback'] = $address;
+        $this->fallback = $address;
     }
 
     #[When('that user whose account has no mail admins is created')]
@@ -1222,6 +1224,7 @@ class EmailContext extends YiiContext
         Assert::null($this->tempUser, 'The user should not have existed yet.');
         // Unique address that still matches the "no mail admins" rule in the API mock.
         $email = str_replace('@', '_' . uniqid() . '@', self::NO_MAIL_ADMINS_EMAIL);
+        \Yii::$app->params['accountMailAdminsCcFallback'] = $this->fallback;
         $this->tempUser = $this->createNewUser(false, $email);
     }
 

--- a/app/features/bootstrap/EmailContext.php
+++ b/app/features/bootstrap/EmailContext.php
@@ -66,8 +66,6 @@ class EmailContext extends YiiContext
 
     private ?EmailLog $tempEmailLog;
 
-    private string $fallback = '';
-
     public const METHOD_EMAIL_ADDRESS = 'method@example.com';
     public const MANAGER_EMAIL = 'manager@example.com';
     public const RECOVERY_EMAIL = 'recovery@example.com';
@@ -1215,7 +1213,7 @@ class EmailContext extends YiiContext
     #[Given('we are configured to CC :address as the mail admin fallback')]
     public function weAreConfiguredToCcAsTheMailAdminFallback($address): void
     {
-        $this->fallback = $address;
+        \Yii::$app->params['accountMailAdminsCcFallback'] = $address;
     }
 
     #[When('that user whose account has no mail admins is created')]
@@ -1224,7 +1222,6 @@ class EmailContext extends YiiContext
         Assert::null($this->tempUser, 'The user should not have existed yet.');
         // Unique address that still matches the "no mail admins" rule in the API mock.
         $email = str_replace('@', '_' . uniqid() . '@', self::NO_MAIL_ADMINS_EMAIL);
-        \Yii::$app->params['accountMailAdminsCcFallback'] = $this->fallback;
         $this->tempUser = $this->createNewUser(false, $email);
     }
 


### PR DESCRIPTION
By checking if it isn't empty before calling MailAdmin::getEmailsFor(), prevent Sentry error DP-ID-BROKER-7Y.

[IDP-2171](https://support.gtis.sil.org/issue/IDP-2171) Fix Sentry IDP-ID-BROKER-7Y

### Fixed
- User::getInviteCcAddress by checking if this->email is not empty before calling MailAdmin::getEmailsFor

### PR Checklist
- [ ] Documentation (README, local.env.dist, openapi.yaml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [ ] Run `make psr2`
