### PR TITLE
do not run database migrations before scheduled tasks

### DIFF
--- a/app/run.sh
+++ b/app/run.sh
@@ -39,12 +39,12 @@ if [[ -n "$SSL_CA_BASE64" ]]; then
     fi
 fi
 
-$config "$APP_HOME"/yii migrate --interactive=0
-
 if [[ $RUN_TASK ]]; then
   $config ./yii $RUN_TASK
   exit $?
 fi
+
+$config "$APP_HOME"/yii migrate --interactive=0
 
 make-ssl-cert generate-default-snakeoil
 


### PR DESCRIPTION

[IDP-2183](https://support.gtis.sil.org/issue/IDP-2183) disable db migrations for idp-id-broker scheduled task

---

### Changed (non-breaking)
- Do not run database migrations before scheduled tasks. This is to prevent the scheduled task from running migrations before the main service has been updated to use the new migration.


---

### PR Checklist
- [ ] Documentation (README, local.env.dist, openapi.yaml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [ ] Run `make psr2`
