### PR TITLE
add a custom task schedule to the root crontab

### DIFF
--- a/app/run-cron.sh
+++ b/app/run-cron.sh
@@ -27,5 +27,10 @@ fi
 echo '* * * * * root '"$APP_HOME"'/yii send/send-queued-email > /proc/1/fd/1 2>&1' > /etc/crontab
 chmod 0644 /etc/crontab
 
+if [[ -n "$CRON_TASK" ]]; then
+    echo "$TASK_SCHEDULE"' root '"$APP_HOME"'/yii '"$CRON_TASK"' > /proc/1/fd/1 2>&1' > /etc/crontab
+fi
+
+
 # run cron in foreground so output is logged
 cron -f


### PR DESCRIPTION
Alternate solution for [IDP-2183](https://support.gtis.sil.org/issue/IDP-2183) disable db migrations for idp-id-broker scheduled task

---

### Added
- Added a custom task schedule to the root crontab. This would allow for a maintenance task to run in the ["email" service](https://github.com/sil-org/terraform-aws-idp/blob/701422a0a908cbe88ca19fa5c2a30c95cbe9dd46/modules/040-id-broker/main.tf#L278), which doesn't auto-upgrade like an EventBridge [scheduled task](https://github.com/sil-org/terraform-aws-idp/blob/701422a0a908cbe88ca19fa5c2a30c95cbe9dd46/modules/040-id-broker/main.tf#L231) does. Once this "custom" cron task is configured, the EventBridge scheduled task could be dropped from the infrastructure entirely.

---

### PR Checklist
- [ ] Documentation (README, local.env.dist, openapi.yaml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [ ] Run `make psr2`
