### PR TITLE
Document a known issue with email retry attempts count

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,16 @@ the new one here, then remove the old one from the Google Cloud Console. In
 other words, you can wait to delete the previous Key from that Service Account
 until you have deployed the new credentials, if desired, to avoid service
 interruption.
+
+## Known issues
+
+### Email retry attempts count overflow
+
+The email table `attempts_count` column is only one byte, capping the value at 128. This can cause a
+permanent failure to send due to a database failure message (SQLSTATE[22003]: Numeric value out
+of range). This bug is being left in place intentionally. In a case where a lengthy outage
+accumulates a lot of unsent messages, clearing the outage would release a flood of messages if not
+for this bug. That would likely cause Gmail to block the account for rate limiting. So if this bug
+is fixed, there should be some additional solution put in place for slowly clearing out the backlog,
+or maybe even just clearing the backlog without sending the messages. See the `Email::retry()` method
+for details. (YouTrack issue IDP-710)

--- a/app/common/models/Email.php
+++ b/app/common/models/Email.php
@@ -144,7 +144,14 @@ class Email extends EmailBase
             return $this->send();
         } catch (Exception $e) {
             /*
-             * Send failed, attempt to queue
+             * Send failed. Retain the message in the queue and increment the attempts count.
+             * Note: the `attempts_count` column is only one byte, capping the value at 128. This can cause a
+             * permanent failure to send due to a database failure message (SQLSTATE[22003]: Numeric value out
+             * of range). This bug is being left in place intentionally. In a case where a lengthy outage
+             * accumulates a lot of unsent messages, clearing the outage would release a flood of messages if not
+             * for this bug. That would likely cause Gmail to block the account for rate limiting. So if this bug
+             * is fixed, there should be some additional solution put in place for slowly clearing out the backlog,
+             * or maybe even just clearing the backlog without sending the messages.
              */
             $this->attempts_count += 1;
             $this->updated_at = time();


### PR DESCRIPTION
[IDP-710](https://support.gtis.sil.org/issue/IDP-710) email-service queue blocked after 127 attempts

---

### Added
- Added documentation to describe the attempts count overflow as a known issue.

---

### PR Checklist
- [x] Documentation (README, local.env.dist, openapi.yaml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [ ] Run `make psr2`
