### PR TITLE
IDP-697: Treat 404 on TOTP delete as success

### DIFF
--- a/app/common/components/MfaApiClient.php
+++ b/app/common/components/MfaApiClient.php
@@ -89,7 +89,15 @@ class MfaApiClient
      */
     public function deleteTotp(string $uuid): bool
     {
-        $this->callApi('totp/' . $uuid, 'DELETE');
+        try {
+            $this->callApi('totp/' . $uuid, 'DELETE');
+        } catch (ClientException $e) {
+            if ($e->getCode() === 404) {
+                // The record is already gone, so treat the delete as successful.
+                return true;
+            }
+            throw $e;
+        }
         return true;
     }
 

--- a/app/features/bootstrap/MfaUnitTestsContext.php
+++ b/app/features/bootstrap/MfaUnitTestsContext.php
@@ -2,6 +2,7 @@
 
 namespace Sil\SilIdBroker\Behat\Context;
 
+use common\helpers\MySqlDateTime;
 use common\models\Mfa;
 use common\models\MfaBackupcode;
 use Webmozart\Assert\Assert;
@@ -185,5 +186,39 @@ class MfaUnitTestsContext extends UnitTestsContext
     {
         $mfa = Mfa::findOne(['user_id' => $this->tempUser->id, 'type' => Mfa::TYPE_MANAGER]);
         Assert::null($mfa);
+    }
+
+    #[Given('that totp mfa option is old and its backend record no longer exists')]
+    public function thatTotpMfaOptionIsOldAndItsBackendRecordNoLongerExists()
+    {
+        $this->mfa->external_uuid = '11111111-2222-4333-8444-555555555555';
+        $this->mfa->created_utc = MySqlDateTime::relativeTime('-1 year');
+        Assert::true($this->mfa->save(), 'Could not set up the old totp mfa option.');
+    }
+
+    #[When('old unverified mfa records are removed')]
+    public function oldUnverifiedMfaRecordsAreRemoved()
+    {
+        Mfa::removeOldUnverifiedRecords();
+    }
+
+    #[Then('that totp mfa option should no longer exist')]
+    public function thatTotpMfaOptionShouldNoLongerExist()
+    {
+        Assert::null(
+            Mfa::findOne($this->mfaId),
+            'The old, unverified totp mfa option should have been deleted.'
+        );
+    }
+
+    #[Then('no mfa deletion error should have been logged')]
+    public function noMfaDeletionErrorShouldHaveBeenLogged()
+    {
+        \Yii::getLogger()->flush();
+        $loggedMessagesJson = $this->fakeLogTarget->getLoggedMessagesJson();
+        Assert::false(
+            str_contains($loggedMessagesJson, '404 Not Found'),
+            'A 404 error was logged while deleting old mfa records: ' . $loggedMessagesJson
+        );
     }
 }

--- a/app/features/mfa-unit-tests.feature
+++ b/app/features/mfa-unit-tests.feature
@@ -51,3 +51,10 @@ Feature: Unit Tests for the Mfa model
       And that user also has a manager rescue mfa option
     When I verify a backup code
     Then I see that the user no longer has a manager rescue mfa option
+
+  Scenario: Removing an old unverified totp option succeeds even when its backend record is already gone
+    Given I have a user with an unverified totp mfa option
+      And that totp mfa option is old and its backend record no longer exists
+    When old unverified mfa records are removed
+    Then that totp mfa option should no longer exist
+      And no mfa deletion error should have been logged


### PR DESCRIPTION
[IDP-697](https://support.gtis.sil.org/issue/IDP-697) Investigate 404's when USA IdP tries to delete old MFAs

---

### Added
- Behat scenario: cleanup of old unverified TOTP succeeds when the MFA API returns 404 on delete.

### Fixed
- `deleteTotp()` now treats 404 as success, so the cleanup cron actually deletes orphaned unverified TOTP rows instead of logging an error and re-failing every run.

---

### PR Checklist
- [X] Tests created or updated
- [X] Run `make psr2`
