### PR TITLE
do not include the token_hash in user data

### DIFF
--- a/app/common/models/User.php
+++ b/app/common/models/User.php
@@ -558,7 +558,6 @@ class User extends UserBase
                 return $model->getNagState() == NagState::NAG_PROFILE_REVIEW ? 'yes' : 'no';
             },
             'require_mfa',
-            'token_hash',
             'token_expiry_utc' => function (self $model) {
                 return $model->token_expiry_utc === null ? null : Utils::getIso8601($model->token_expiry_utc);
             },

--- a/app/features/user.feature
+++ b/app/features/user.feature
@@ -40,6 +40,7 @@ Feature: User
         | property                |
         | current_password_id     |
         | password_expires_at_utc |
+        | token_hash              |
       And a record exists with an employee_id of "f6bf51f2-4ccc-4d85-8f75-02132c67af27"
       And the following data should be stored:
         | property            | value                 |
@@ -722,6 +723,7 @@ Feature: User
         | property                  |
         |   current_password_id     |
         |   password_expires_at_utc |
+        |   token_hash              |
       And the response should contain a member array with only these elements:
         | element              |
         |   it                 |
@@ -790,9 +792,11 @@ Feature: User
     Then the response status code should be 200
       And the following data is returned:
         | property          | value                 |
-        | token_hash        | abc123hash            |
         | token_expiry_utc  | 2099-01-01T12:00:00Z  |
         | token_type        | login                 |
+      And the following data is not returned:
+        | property          |
+        | token_hash        |
       And a record exists with an employee_id of "123"
       And the following data should be stored:
         | property          | value                 |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1302,9 +1302,6 @@ components:
           - 'yes'
           - 'no'
           type: string
-        token_hash:
-          type: string
-          nullable: true
         token_expiry_utc:
           type: string
           nullable: true


### PR DESCRIPTION
[IDP-2267](https://support.gtis.sil.org/issue/IDP-2267) The user token_hash should not be in response data

---

### Fixed
- Remove the user `token_hash` from the API response data.

---

### PR Checklist
- [x] Documentation (README, local.env.dist, openapi.yaml, etc.)
- [x] Tests created or updated
- [ ] Run `make composershow`
- [x] Run `make psr2`
