### PR TITLE
Confirm people cannot change their password to an old password

### DIFF
--- a/app/common/models/Password.php
+++ b/app/common/models/Password.php
@@ -76,6 +76,11 @@ class Password extends PasswordBase
     {
         $reuseLimit = Yii::$app->params['passwordReuseLimit'];
 
+        // A numeric 0 becomes LIMIT 0, which checks no rows and silently allows reuse of the current password.
+        if (is_numeric($reuseLimit) && (int) $reuseLimit === 0) {
+            $reuseLimit = 1;
+        }
+
         /** @var Password[] $passwords */
         $passwords = Password::find()->where(['user_id' => $this->user_id])
                                      ->orderBy(['id' => SORT_DESC])

--- a/app/common/models/Password.php
+++ b/app/common/models/Password.php
@@ -76,11 +76,6 @@ class Password extends PasswordBase
     {
         $reuseLimit = Yii::$app->params['passwordReuseLimit'];
 
-        // A numeric 0 becomes LIMIT 0, which checks no rows and silently allows reuse of the current password.
-        if (is_numeric($reuseLimit) && (int) $reuseLimit === 0) {
-            $reuseLimit = 1;
-        }
-
         /** @var Password[] $passwords */
         $passwords = Password::find()->where(['user_id' => $this->user_id])
                                      ->orderBy(['id' => SORT_DESC])

--- a/app/features/bootstrap/UnitTestsContext.php
+++ b/app/features/bootstrap/UnitTestsContext.php
@@ -35,8 +35,11 @@ class UnitTestsContext extends YiiContext
     /** @var User */
     protected $tempUser;
 
-    /** @var bool whether the most recent password submission was saved */
-    protected $passwordWasAccepted;
+    /** @var string */
+    protected $originalPassword;
+
+    /** @var ConflictHttpException|null */
+    protected $reuseException;
 
     /** @var bool whether the Mfa option is considered newly verified */
     protected $mfaIsNewlyVerified;
@@ -452,26 +455,67 @@ class UnitTestsContext extends YiiContext
         \Yii::$app->params['passwordReuseLimit'] = $limit;
     }
 
-    #[When('the user submits that same password again')]
-    public function theUserSubmitsThatSamePasswordAgain()
+    #[Given('the user has a password')]
+    public function theUserHasAPassword()
+    {
+        $this->originalPassword = 'k23@U$%235u25@I2$o';
+        $this->tempUser->setScenario(User::SCENARIO_UPDATE_PASSWORD);
+        $this->tempUser->password = $this->originalPassword;
+        Assert::true($this->tempUser->save(), 'Failed to set the initial password.');
+    }
+
+    #[Given('the user changes their password to a different one')]
+    public function theUserChangesTheirPasswordToADifferentOne()
     {
         $this->tempUser = User::findOne($this->tempUser->id);
         $this->tempUser->setScenario(User::SCENARIO_UPDATE_PASSWORD);
-        $this->tempUser->password = 'k23@U$%235u25@I2$o';
+        $this->tempUser->password = '8Wq@2v!zR6#tY4$mLp';
+        Assert::true($this->tempUser->save(), 'Failed to change the password.');
+    }
+
+    #[When('the user tries to change their password to that same password')]
+    #[When('the user tries to change their password back to the original one')]
+    public function theUserTriesToReuseTheirOriginalPassword()
+    {
+        $this->reuseException = null;
+        $this->tempUser = User::findOne($this->tempUser->id);
+        $this->tempUser->setScenario(User::SCENARIO_UPDATE_PASSWORD);
+        $this->tempUser->password = $this->originalPassword;
 
         try {
-            $this->passwordWasAccepted = $this->tempUser->save();
+            $this->tempUser->save();
         } catch (ConflictHttpException $e) {
-            $this->passwordWasAccepted = false;
+            $this->reuseException = $e;
         }
     }
 
-    #[Then('the password should be rejected as recently used')]
-    public function thePasswordShouldBeRejectedAsRecentlyUsed()
+    #[When("the user's current password is assessed")]
+    public function theUsersCurrentPasswordIsAssessed()
     {
-        Assert::false(
-            $this->passwordWasAccepted,
-            'The password was accepted even though it had been used recently.'
+        $this->reuseException = null;
+        $this->tempUser = User::findOne($this->tempUser->id);
+
+        try {
+            $this->tempUser->assessPassword($this->originalPassword);
+        } catch (ConflictHttpException $e) {
+            $this->reuseException = $e;
+        }
+    }
+
+    #[Then('a 409 error of :message should be returned')]
+    public function a409ErrorOfShouldBeReturned($message)
+    {
+        Assert::isInstanceOf($this->reuseException, ConflictHttpException::class);
+        Assert::same($this->reuseException->statusCode, 409);
+        Assert::same($this->reuseException->getMessage(), $message);
+    }
+
+    #[Then('the password change should succeed')]
+    public function thePasswordChangeShouldSucceed()
+    {
+        Assert::null(
+            $this->reuseException,
+            'Expected the password change to succeed, but it was rejected as reused.'
         );
     }
 

--- a/app/features/bootstrap/UnitTestsContext.php
+++ b/app/features/bootstrap/UnitTestsContext.php
@@ -502,11 +502,11 @@ class UnitTestsContext extends YiiContext
         }
     }
 
-    #[Then('a 409 error of :message should be returned')]
-    public function a409ErrorOfShouldBeReturned($message)
+    #[Then('a :statusCode error of :message should be returned')]
+    public function aErrorOfShouldBeReturned($statusCode, $message)
     {
         Assert::isInstanceOf($this->reuseException, ConflictHttpException::class);
-        Assert::same($this->reuseException->statusCode, 409);
+        Assert::same($this->reuseException->statusCode, (int) $statusCode);
         Assert::same($this->reuseException->getMessage(), $message);
     }
 

--- a/app/features/bootstrap/UnitTestsContext.php
+++ b/app/features/bootstrap/UnitTestsContext.php
@@ -17,6 +17,7 @@ use common\models\Password;
 use common\models\Reset;
 use common\models\User;
 use Webmozart\Assert\Assert;
+use yii\web\ConflictHttpException;
 
 class UnitTestsContext extends YiiContext
 {
@@ -33,6 +34,9 @@ class UnitTestsContext extends YiiContext
 
     /** @var User */
     protected $tempUser;
+
+    /** @var bool whether the most recent password submission was saved */
+    protected $passwordWasAccepted;
 
     /** @var bool whether the Mfa option is considered newly verified */
     protected $mfaIsNewlyVerified;
@@ -440,6 +444,35 @@ class UnitTestsContext extends YiiContext
     {
         $hash = $this->tempUser->currentPassword->hash;
         Assert::notEmpty($hash);
+    }
+
+    #[Given('the password reuse limit is :limit')]
+    public function thePasswordReuseLimitIs($limit)
+    {
+        \Yii::$app->params['passwordReuseLimit'] = $limit;
+    }
+
+    #[When('the user submits that same password again')]
+    public function theUserSubmitsThatSamePasswordAgain()
+    {
+        $this->tempUser = User::findOne($this->tempUser->id);
+        $this->tempUser->setScenario(User::SCENARIO_UPDATE_PASSWORD);
+        $this->tempUser->password = 'k23@U$%235u25@I2$o';
+
+        try {
+            $this->passwordWasAccepted = $this->tempUser->save();
+        } catch (ConflictHttpException $e) {
+            $this->passwordWasAccepted = false;
+        }
+    }
+
+    #[Then('the password should be rejected as recently used')]
+    public function thePasswordShouldBeRejectedAsRecentlyUsed()
+    {
+        Assert::false(
+            $this->passwordWasAccepted,
+            'The password was accepted even though it had been used recently.'
+        );
     }
 
     #[Given('that user has a password with a low hash cost')]

--- a/app/features/bootstrap/YiiContext.php
+++ b/app/features/bootstrap/YiiContext.php
@@ -52,7 +52,7 @@ class YiiContext implements Context
         // Snapshot params individual scenarios may toggle, then restore them in
         // restoreParameters(), so a change can't leak via the shared (static) application
         // instance — and config/test.env stays the single source of truth.
-        foreach (['accountMailAdminsCcOnInvite', 'accountMailAdminsCcFallback'] as $key) {
+        foreach (['accountMailAdminsCcOnInvite', 'accountMailAdminsCcFallback', 'passwordReuseLimit'] as $key) {
             $this->savedParams[$key] = Yii::$app->params[$key] ?? null;
         }
     }

--- a/app/features/password.feature
+++ b/app/features/password.feature
@@ -14,6 +14,60 @@ Feature: Password
     When the user uses their password
     Then the password hash should be updated
 
+  Scenario: Attempt to change a password to the one currently in use
+    Given the user store is empty
+      And the requester is authorized
+      And I add a user with an employee_id of "10000"
+      And I provide the following valid data:
+        | property | value              |
+        | password | k23@U$%235u25@I2$o |
+      And I request "/user/10000/password" be updated
+      And the response status code should be 200
+    When I request "/user/10000/password" be updated
+    Then the response status code should be 409
+      And the response body should contain "May not be reused yet"
+
+  Scenario: Attempt to change a password back to a previously used one
+    Given the user store is empty
+      And the requester is authorized
+      And I add a user with an employee_id of "10000"
+      And I provide the following valid data:
+        | property | value              |
+        | password | k23@U$%235u25@I2$o |
+      And I request "/user/10000/password" be updated
+      And the response status code should be 200
+      And I provide the following valid data:
+        | property | value              |
+        | password | 8Wq@2v!zR6#tY4$mLp |
+      And I request "/user/10000/password" be updated
+      And the response status code should be 200
+    When I provide the following valid data:
+        | property | value              |
+        | password | k23@U$%235u25@I2$o |
+      And I request "/user/10000/password" be updated
+    Then the response status code should be 409
+      And the response body should contain "May not be reused yet"
+
+  Scenario: Assessing a recently used password reports a conflict
+    Given the user store is empty
+      And the requester is authorized
+      And I add a user with an employee_id of "10000"
+      And I provide the following valid data:
+        | property | value              |
+        | password | k23@U$%235u25@I2$o |
+      And I request "/user/10000/password" be updated
+      And the response status code should be 200
+    When I request "/user/10000/password/assess" be updated
+    Then the response status code should be 409
+      And the response body should contain "May not be reused yet"
+
+  Scenario: A reuse limit of zero must not disable the reuse check
+    Given there is a user in the database
+      And the password reuse limit is 0
+    When the user submits a new password
+      And the user submits that same password again
+    Then the password should be rejected as recently used
+
 #  Scenario: Attempt to update a password for a nonexistent user
 #  Scenario: Attempt to update a password for an existing user without providing a password
 #  Scenario: Attempt to update a password for an existing user without providing a valid password
@@ -34,9 +88,7 @@ Feature: Password
 #  Scenario: Attempt to create a password
 #  Scenario: Attempt to retrieve a password
 #  Scenario: Attempt to delete a password
-#  Scenario: Attempt to change the password of an existing user using the same password they already have.
 #  Scenario: consider invalid employee ids that test the type conversions of Yii and/or PHP, e.g., /user/[true|false|1|0]/password
 #  Scenario: ensure password_hash and last_changed date are the only things that change even when passed all attributes available on the table.
 # TODO: need to test the expiration date calculation
-# TODO: need to test the reuse limit
 # TODO: need to test grace period and grace period extension

--- a/app/features/password.feature
+++ b/app/features/password.feature
@@ -15,58 +15,33 @@ Feature: Password
     Then the password hash should be updated
 
   Scenario: Attempt to change a password to the one currently in use
-    Given the user store is empty
-      And the requester is authorized
-      And I add a user with an employee_id of "10000"
-      And I provide the following valid data:
-        | property | value              |
-        | password | k23@U$%235u25@I2$o |
-      And I request "/user/10000/password" be updated
-      And the response status code should be 200
-    When I request "/user/10000/password" be updated
-    Then the response status code should be 409
-      And the response body should contain "May not be reused yet"
+    Given there is a user in the database
+      And the user has a password
+      And the password reuse limit is 10
+    When the user tries to change their password to that same password
+    Then a 409 error of "May not be reused yet" should be returned
 
   Scenario: Attempt to change a password back to a previously used one
-    Given the user store is empty
-      And the requester is authorized
-      And I add a user with an employee_id of "10000"
-      And I provide the following valid data:
-        | property | value              |
-        | password | k23@U$%235u25@I2$o |
-      And I request "/user/10000/password" be updated
-      And the response status code should be 200
-      And I provide the following valid data:
-        | property | value              |
-        | password | 8Wq@2v!zR6#tY4$mLp |
-      And I request "/user/10000/password" be updated
-      And the response status code should be 200
-    When I provide the following valid data:
-        | property | value              |
-        | password | k23@U$%235u25@I2$o |
-      And I request "/user/10000/password" be updated
-    Then the response status code should be 409
-      And the response body should contain "May not be reused yet"
+    Given there is a user in the database
+      And the user has a password
+      And the password reuse limit is 10
+      And the user changes their password to a different one
+    When the user tries to change their password back to the original one
+    Then a 409 error of "May not be reused yet" should be returned
 
   Scenario: Assessing a recently used password reports a conflict
-    Given the user store is empty
-      And the requester is authorized
-      And I add a user with an employee_id of "10000"
-      And I provide the following valid data:
-        | property | value              |
-        | password | k23@U$%235u25@I2$o |
-      And I request "/user/10000/password" be updated
-      And the response status code should be 200
-    When I request "/user/10000/password/assess" be updated
-    Then the response status code should be 409
-      And the response body should contain "May not be reused yet"
-
-  Scenario: A reuse limit of zero must not disable the reuse check
     Given there is a user in the database
+      And the user has a password
+      And the password reuse limit is 10
+    When the user's current password is assessed
+    Then a 409 error of "May not be reused yet" should be returned
+
+  Scenario: A reuse limit of zero disables the reuse check
+    Given there is a user in the database
+      And the user has a password
       And the password reuse limit is 0
-    When the user submits a new password
-      And the user submits that same password again
-    Then the password should be rejected as recently used
+    When the user tries to change their password to that same password
+    Then the password change should succeed
 
 #  Scenario: Attempt to update a password for a nonexistent user
 #  Scenario: Attempt to update a password for an existing user without providing a password

--- a/local.env.dist
+++ b/local.env.dist
@@ -171,7 +171,7 @@ HR_NOTIFICATIONS_EMAIL=test@test.com
 # === Password parameters ===
 
 # number of passwords to remember for "recent password" restriction
-# defaults to 10
+# defaults to 10; set to 0 to disable the check
 #PASSWORD_REUSE_LIMIT=
 
 # time span before which the user should set a new password


### PR DESCRIPTION
[IDP-1912](https://support.gtis.sil.org/issue/IDP-1912) Confirm people cannot change their password to an old password

### Added
- reuse coverage: reject change to current password, reject change to a previous password, 409 on assessing a reused password, and that a limit of 0 disables the check.

### Changed (non-breaking)
- `local.env.dist`: note that `PASSWORD_REUSE_LIMIT=0` disables the reuse check.