### PR TITLE
remove email address masking (IDP-2197)

### DIFF
--- a/app/common/helpers/Utils.php
+++ b/app/common/helpers/Utils.php
@@ -3,9 +3,6 @@
 namespace common\helpers;
 
 use yii\base\Security;
-use yii\helpers\Html;
-use yii\validators\EmailValidator;
-use yii\web\BadRequestHttpException;
 
 class Utils
 {
@@ -67,73 +64,5 @@ class Utils
         }
         $dt = date_create_from_format('U', $timestamp);
         return $dt->format(self::DT_ISO8601);
-    }
-
-    /**
-     * @param string $email an email address
-     * @return string with most letters changed to asterisks
-     * @throws BadRequestHttpException
-     */
-    public static function maskEmail($email)
-    {
-        if (empty($email)) {
-            return '';
-        }
-
-        $validator = new EmailValidator();
-        if (!$validator->validate($email)) {
-            \Yii::warning([
-                'action' => 'mask email',
-                'status' => 'error',
-                'error' => 'Invalid email address provided: ' . Html::encode($email),
-            ]);
-            throw new BadRequestHttpException('Invalid email address provided.', 1461459797);
-        }
-
-        [$part1, $domain] = explode('@', $email);
-        $newEmail = '';
-        $useRealChar = true;
-
-        /*
-         * Replace all characters with '*', except the first one, the last one,
-         * underscores, and each character that follows an underscore.
-         */
-        foreach (str_split($part1) as $nextChar) {
-            if ($useRealChar) {
-                $newEmail .= $nextChar;
-                $useRealChar = false;
-            } elseif ($nextChar === '_') {
-                $newEmail .= $nextChar;
-                $useRealChar = true;
-            } else {
-                $newEmail .= '*';
-            }
-        }
-
-        // replace the last * with the last real character
-        $newEmail = substr($newEmail, 0, -1);
-        $newEmail .= substr($part1, -1);
-        $newEmail .= '@';
-
-        /*
-         * Add an '*' for each of the characters of the domain, except
-         * for the first character of each part and the '.'
-         */
-        $domainParts = explode('.', $domain);
-        $countParts = count($domainParts);
-
-        // Leave the last part for later, to avoid adding a '.' after it.
-        for ($i = 0; $i < $countParts - 1; $i++) {
-            $nextPart = $domainParts[$i];
-            $newEmail .= substr($nextPart, 0, 1);
-            $newEmail .= str_repeat('*', strlen($nextPart) - 1);
-            $newEmail .= '.';
-        }
-
-        $nextPart = $domainParts[$countParts - 1];
-        $newEmail .= substr($nextPart, 0, 1);
-        $newEmail .= str_repeat('*', strlen($nextPart) - 1);
-
-        return $newEmail;
     }
 }

--- a/app/common/models/Method.php
+++ b/app/common/models/Method.php
@@ -73,15 +73,6 @@ class Method extends MethodBase
         ];
     }
 
-    /**
-     * @return string
-     * @throws \Exception
-     */
-    public function getMaskedValue()
-    {
-        return Utils::maskEmail($this->value);
-    }
-
     public function isVerified()
     {
         return $this->verified === 1 ? true : false;

--- a/app/common/models/User.php
+++ b/app/common/models/User.php
@@ -538,14 +538,7 @@ class User extends UserBase
                 return $model->deactivated_utc === null ? null : Utils::getIso8601($model->deactivated_utc);
             },
             'manager_email',
-            'personal_email' => function (self $model) {
-                $maskParam = Yii::$app->request->queryParams['mask'] ?? 'no';
-                if ($maskParam === 'no') {
-                    return $model->personal_email;
-                } else {
-                    return Utils::maskEmail($model->personal_email);
-                }
-            },
+            'personal_email',
             'hide',
             'member' => function (self $model) {
                 return $model->getMemberList();
@@ -727,28 +720,9 @@ class User extends UserBase
      */
     public function getMethodFields()
     {
-        $maskParam = Yii::$app->request->queryParams['mask'] ?? 'no';
-
-        /*
-         * Provide method data when a profile review is requested OR
-         * if a `mask=yes` query parameter has been given.
-         */
-        $methods = [];
-        if ($maskParam === 'yes'
-            || ($this->getNagState() === NagState::NAG_PROFILE_REVIEW
-            && $this->scenario == self::SCENARIO_AUTHENTICATE)) {
-            $methods = $this->methods;
-        }
-
-        if ($maskParam === 'yes') {
-            foreach ($methods as $key => $method) {
-                $methods[$key]->value = $method->getMaskedValue();
-            }
-        }
-
         return [
             'add' => $this->getNagState() == NagState::NAG_ADD_METHOD ? 'yes' : 'no',
-            'options' => $methods,
+            'options' => $this->methods,
         ];
     }
 
@@ -931,7 +905,6 @@ class User extends UserBase
                     ]));
                     break;
                 case 'fields':
-                case 'mask':
                     break;
                 default:
                     // if no criteria names match, this will ensure an empty result is returned

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -141,15 +141,6 @@ paths:
           'username', 'email', and 'personal_email'
         schema:
           type: string
-      - name: mask
-        in: query
-        description: >-
-          Mask personal information (method options, personal_email) for privacy. Default is 'yes'.
-        schema:
-          enum:
-          - 'yes'
-          - 'no'
-          type: string
       - name: token_hash
         in: query
         description: >-
@@ -1127,9 +1118,7 @@ components:
     UserResponse:
       description: >-
         Information on user record. Password is not included if a password
-        has not been assigned to the user. Method options are included only if `method.review`
-        is 'yes' and only in response to `POST /authentication`, otherwise it will
-        be an empty list.
+        has not been assigned to the user.
       example:
         uuid: 11111111-aaaa-1111-aaaa-111111111111
         employee_id: '12345'
@@ -1778,4 +1767,3 @@ components:
       name: Authorization
   links: {}
   callbacks: {}
-


### PR DESCRIPTION
[IDP-2197](https://support.gtis.sil.org/issue/IDP-2197) Unmask recovery emails and personal emails in API responses

---

### Changed (non-breaking)
- Stop masking email addresses in API responses.

---

### PR Checklist
- [x] Documentation (README, local.env.dist, openapi.yaml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
- [x] Run `make psr2`
