### PR TITLE
fix regression on user search

### DIFF
--- a/app/common/models/User.php
+++ b/app/common/models/User.php
@@ -905,6 +905,8 @@ class User extends UserBase
                     ]));
                     break;
                 case 'fields':
+                // retain 'mask' for backward compatibility
+                case 'mask':
                     break;
                 default:
                     // if no criteria names match, this will ensure an empty result is returned


### PR DESCRIPTION
[IDP-2197](https://support.gtis.sil.org/issue/IDP-2197) Unmask recovery emails and personal emails in API responses

---

### Fixed
- Fixed regression from #502 which broke the user search feature.

---

### PR Checklist
- [ ] Documentation (README, local.env.dist, openapi.yaml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
