### PR TITLE
Use email address for TOTP account name

### DIFF
--- a/app/common/components/MfaApiClient.php
+++ b/app/common/components/MfaApiClient.php
@@ -67,15 +67,15 @@ class MfaApiClient
 
     /**
      * Create a new TOTP configuration
-     * @param string $username
+     * @param string $email
      * @return array
      * @throws GuzzleException
      */
-    public function createTotp(string $username, string $issuer): array
+    public function createTotp(string $email, string $issuer): array
     {
         $response = $this->callApi('totp', 'POST', [
             'issuer' => $issuer,
-            'label' => $username,
+            'label' => $email,
         ]);
 
         return Json::decode($response->getBody()->getContents());

--- a/app/common/components/MfaBackendTotp.php
+++ b/app/common/components/MfaBackendTotp.php
@@ -50,7 +50,8 @@ class MfaBackendTotp extends Component implements MfaBackendInterface
             throw new NotFoundHttpException("User not found when trying to create new TOTP configuration");
         }
 
-        return $this->client->createTotp($user->username, \Yii::$app->params['idpDisplayName']);
+        $idpName = \Yii::$app->params['idpDisplayName'];
+        return $this->client->createTotp($user->email, $idpName);
     }
 
     /**


### PR DESCRIPTION
[IDP-2169](https://support.gtis.sil.org/issue/IDP-2169) Update default display text when adding TOTP application
---
### Changed (non-breaking)
- Updated TOTP configuration creation to use the user's email address instead of username.
---

### PR Checklist
- [ ] Documentation (README, local.env.dist, openapi.yaml, etc.)
- [ ] Tests created or updated
- [ ] Run `make composershow`
